### PR TITLE
CAL-6 Added a NSILI Input Transformer for all NSIL views.

### DIFF
--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliApprovalStatus.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliApprovalStatus.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.common;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum NsiliApprovalStatus {
+    APPROVED("APPROVED"),
+    REJECTED("REJECTED"),
+    NOT_APPLICABLE("NOT APPLICABLE");
+
+    private static final Map<String, NsiliApprovalStatus> specNameMap = new HashMap<>();
+    static {
+        for (NsiliApprovalStatus status: NsiliApprovalStatus.values()) {
+            specNameMap.put(status.getSpecName(), status);
+        }
+    }
+
+    private String specName;
+
+    NsiliApprovalStatus(String specName) {
+        this.specName = specName;
+    }
+
+    public String getSpecName() {
+        return specName;
+    }
+
+    public static NsiliApprovalStatus fromSpecName(String specName) {
+        return specNameMap.get(specName);
+    }
+}

--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliClassification.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliClassification.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.common;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum NsiliClassification {
+    COSMIC_TOP_SECRET("COSMIC TOP SECRET", 4),
+    SECRET("SECRET", 3),
+    CONFIDENTIAL("CONFIDENTIAL", 2),
+    RESTRICTED("RESTRICTED", 1),
+    UNCLASSIFIED("UNCLASSIFIED", 0),
+    NO_CLASSIFICATION("NO CLASSIFICATION", -1);
+
+    private static final Map<String, NsiliClassification> specNameMap = new HashMap<>();
+    static {
+        for (NsiliClassification classification: NsiliClassification.values()) {
+            specNameMap.put(classification.getSpecName(), classification);
+        }
+    }
+
+    private String specName;
+    private int classificationRank;
+
+    NsiliClassification(String specName, int classificationRank) {
+        this.specName = specName;
+        this.classificationRank = classificationRank;
+    }
+
+    public String getSpecName() {
+        return specName;
+    }
+
+    public int getClassificationRank() {
+        return classificationRank;
+    }
+
+    public static NsiliClassification fromSpecName(String specName) {
+        return specNameMap.get(specName);
+    }
+}

--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliClassificationComparator.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliClassificationComparator.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.common;
+
+import java.util.Comparator;
+
+public class NsiliClassificationComparator implements Comparator<NsiliClassification> {
+    @Override
+    public int compare(NsiliClassification o1, NsiliClassification o2) {
+        if (o1 == o2) {
+            return 0;
+        }
+
+        if (o1 != NsiliClassification.NO_CLASSIFICATION &&
+                (o2 == null || o2 == NsiliClassification.NO_CLASSIFICATION)) {
+            return -1;
+        }
+        else if ((o1 == null || o1 == NsiliClassification.NO_CLASSIFICATION) &&
+                o2 != NsiliClassification.NO_CLASSIFICATION) {
+            return 1;
+        }
+        else {
+            if (o1.getClassificationRank() < o2.getClassificationRank()) {
+                return -1;
+            }
+            else {
+                return 1;
+            }
+        }
+    }
+}

--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliCommonUtils.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliCommonUtils.java
@@ -57,7 +57,7 @@ public class NsiliCommonUtils {
     }
 
     /**
-     * Set the UCO.Node IDs in DFS order to conform to the STANAG 4459 spec.  The root of the node
+     * Set the UCO.Node IDs in DFS order to conform to the NSILI spec.  The root of the node
      * will be 0.
      *
      * @param graph - the graph representation of the DAG
@@ -75,7 +75,7 @@ public class NsiliCommonUtils {
     }
 
     /**
-     * Set the UCO.Edges of the DAG according to the STANAG 4459 Spec.  This requires the ids
+     * Set the UCO.Edges of the DAG according to the NSILI Spec.  This requires the ids
      * of the Nodes to be set in DFS order.
      *
      * @param root  - the root node of the graph (NSIL_PRODUCT)

--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliCxpMetacardType.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliCxpMetacardType.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.common;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.AttributeType;
+import ddf.catalog.data.impl.AttributeDescriptorImpl;
+
+public class NsiliCxpMetacardType extends NsiliMetacardType {
+    public static final String METACARD_TYPE_NAME = NSILI_METACARD_TYPE_PREFIX +".cxp."+ NSILI_METACARD_TYPE_POSTFIX;
+
+    /**
+     * A status field describing whether the Collection and Exploitation Plan is active, planned or expired.
+     */
+    public static final String STATUS = "status";
+
+    /**
+     * Metacard AttributeType for the NSILI CXP Status.
+     */
+    public static final AttributeType<NsiliCxpStatusType> NSILI_CXP_STATUS_TYPE;
+
+    private static final Set<AttributeDescriptor> NSILI_CXP_DESCRIPTORS = new HashSet<>();
+
+    static {
+        NSILI_CXP_STATUS_TYPE = new AttributeType<NsiliCxpStatusType>() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public AttributeFormat getAttributeFormat() {
+                return AttributeFormat.STRING;
+            }
+
+            @Override
+            public Class<NsiliCxpStatusType> getBinding() {
+                return NsiliCxpStatusType.class;
+            }
+        };
+
+        NSILI_CXP_DESCRIPTORS.add(new AttributeDescriptorImpl(STATUS,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                NSILI_CXP_STATUS_TYPE));
+
+    }
+
+    public NsiliCxpMetacardType() {
+        super();
+        attributeDescriptors.addAll(NsiliCxpMetacardType.NSILI_CXP_DESCRIPTORS);
+    }
+
+    @Override
+    public String getName() {
+        return METACARD_TYPE_NAME;
+    }
+}

--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliCxpStatusType.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliCxpStatusType.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.common;
+
+public enum NsiliCxpStatusType {
+    DRAFT,
+    COORDINATEDDRAFT,
+    CURRENT,
+    EXPIRED,
+    REJECTED;
+}

--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliExploitationSubQualCode.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliExploitationSubQualCode.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.common;
+
+public enum NsiliExploitationSubQualCode {
+    EXCELLENT,
+    FAIR,
+    GOOD,
+    POOR;
+}

--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliGmtiMetacardType.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliGmtiMetacardType.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.common;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.impl.AttributeDescriptorImpl;
+import ddf.catalog.data.impl.BasicTypes;
+
+public class NsiliGmtiMetacardType extends NsiliMetacardType {
+    public static final String METACARD_TYPE_NAME = NSILI_METACARD_TYPE_PREFIX +".gmti."+ NSILI_METACARD_TYPE_POSTFIX;
+
+    /**
+     * A platform-assigned number identifying the specific requestor task to which the packet pertains.
+     * The Job ID shall be unique within a mission.
+     */
+    public static final String JOB_ID = "jobId";
+
+    /**
+     * The total number of target reports within all the dwells in the file.
+     */
+    public static final String NUM_TARGET_REPORTS = "numTargetReports";
+
+    private static final Set<AttributeDescriptor> NSILI_GMTI_DESCRIPTORS = new HashSet<>();
+
+    static {
+        NSILI_GMTI_DESCRIPTORS.add(new AttributeDescriptorImpl(JOB_ID,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.FLOAT_TYPE));
+
+        NSILI_GMTI_DESCRIPTORS.add(new AttributeDescriptorImpl(NUM_TARGET_REPORTS,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.INTEGER_TYPE));
+    }
+
+    public NsiliGmtiMetacardType() {
+        super();
+        attributeDescriptors.addAll(NsiliGmtiMetacardType.NSILI_GMTI_DESCRIPTORS);
+    }
+
+    @Override
+    public String getName() {
+        return METACARD_TYPE_NAME;
+    }
+
+}

--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliIRMetacardType.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliIRMetacardType.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.common;
+
+public class NsiliIRMetacardType extends NsiliMetacardType {
+    public static final String METACARD_TYPE_NAME = NSILI_METACARD_TYPE_PREFIX +".ir."+ NSILI_METACARD_TYPE_POSTFIX;
+
+    /**
+     * Marker class only, as it contains no attributes of its own
+     */
+    public NsiliIRMetacardType() {
+        super();
+    }
+
+    @Override
+    public String getName() {
+        return METACARD_TYPE_NAME;
+    }
+}

--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliImageryMetacardType.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliImageryMetacardType.java
@@ -1,0 +1,197 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.common;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.AttributeType;
+import ddf.catalog.data.impl.AttributeDescriptorImpl;
+import ddf.catalog.data.impl.BasicTypes;
+
+public class NsiliImageryMetacardType extends NsiliMetacardType {
+    public static final String METACARD_TYPE_NAME = NSILI_METACARD_TYPE_PREFIX +".imagery."+ NSILI_METACARD_TYPE_POSTFIX;
+
+    /**
+     * A valid indicator of the specific category of image, raster, or grid data.
+     * The specific category of an image reveals its intended use or the nature of its collector.
+     */
+    public static final String IMAGERY_CATEGORY = "imageryCategory";
+
+    /**
+     * A code that indicates the percentage of the image obscured by cloud cover.
+     */
+    public static final String CLOUD_COVER_PCT = "cloudCoverPct";
+
+    /**
+     * Comments related to the image.
+     */
+    public static final String IMAGERY_COMMENTS = "imageryComments";
+
+    /**
+     * Specification of algorithm or process to apply to read or expand the image to which compression
+     * techniques have been applied.
+     */
+    public static final String DECOMPRESSION_TECHNIQUE = "decompressionTechnique";
+
+    /**
+     * Identification code associated with the image.
+     */
+    public static final String IMAGE_ID = "imageId";
+
+    /**
+     * National Image Interpretability Rating Scales (NIIRS) -defines and measures the quality of
+     * images and the performance of imaging systems.
+     */
+    public static final String NIIRS = "niirs";
+
+    /**
+     * The number of data bands within the specified image.
+     */
+    public static final String NUM_BANDS = "numBands";
+
+    /**
+     * Number of significant rows in Image. This field shall contain the total number of rows of significant
+     * pixels in the image. It could be that an image has been padded with fill data
+     * (to fill out the last part of the block in a blocked image). The meaning of 'significant' is
+     * then only the rows conveying image data excluding all the rows with padded fill data.
+     */
+    public static final String NUM_ROWS = "numRows";
+
+    /**
+     * Number of significant columns in Image. This field shall contain the total number of columns
+     * of significant pixels in the image. It could be that an image has been padded with fill data
+     * (to fill out the last part of the block in a blocked image). The meaning of 'significant'
+     * is then only the columns conveying image data excluding all the columns with padded fill data.
+     */
+    public static final String NUM_COLS = "numCols";
+
+    /**
+     * Metacard AttributeType for the NSILI Imagery Category.
+     */
+    public static final AttributeType<NsiliImageryType> NSILI_IMAGERY_TYPE;
+
+    /**
+     * Metacard AttributeType for the NSILI Imagery Decompression Technique.
+     */
+    public static final AttributeType<NsiliImageryDecompressionTech>
+            NSILI_IMAGERY_DECOMPRESSION_TECH_TYPE;
+
+    private static final Set<AttributeDescriptor> NSILI_IMAGERY_DESCRIPTORS = new HashSet<>();
+
+    static {
+        NSILI_IMAGERY_TYPE = new AttributeType<NsiliImageryType>() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public AttributeFormat getAttributeFormat() {
+                return AttributeFormat.STRING;
+            }
+
+            @Override
+            public Class<NsiliImageryType> getBinding() {
+                return NsiliImageryType.class;
+            }
+        };
+
+        NSILI_IMAGERY_DECOMPRESSION_TECH_TYPE = new AttributeType<NsiliImageryDecompressionTech>() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public AttributeFormat getAttributeFormat() {
+                return AttributeFormat.STRING;
+            }
+
+            @Override
+            public Class<NsiliImageryDecompressionTech> getBinding() {
+                return NsiliImageryDecompressionTech.class;
+            }
+        };
+
+        NSILI_IMAGERY_DESCRIPTORS.add(new AttributeDescriptorImpl(IMAGERY_CATEGORY,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */, NSILI_IMAGERY_TYPE));
+
+        NSILI_IMAGERY_DESCRIPTORS.add(new AttributeDescriptorImpl(CLOUD_COVER_PCT,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.INTEGER_TYPE));
+
+        NSILI_IMAGERY_DESCRIPTORS.add(new AttributeDescriptorImpl(IMAGERY_COMMENTS,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_IMAGERY_DESCRIPTORS.add(new AttributeDescriptorImpl(DECOMPRESSION_TECHNIQUE,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */, NSILI_IMAGERY_DECOMPRESSION_TECH_TYPE));
+
+        NSILI_IMAGERY_DESCRIPTORS.add(new AttributeDescriptorImpl(IMAGE_ID,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_IMAGERY_DESCRIPTORS.add(new AttributeDescriptorImpl(NIIRS,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.INTEGER_TYPE));
+
+        NSILI_IMAGERY_DESCRIPTORS.add(new AttributeDescriptorImpl(NUM_BANDS,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.INTEGER_TYPE));
+
+        NSILI_IMAGERY_DESCRIPTORS.add(new AttributeDescriptorImpl(NUM_ROWS,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.INTEGER_TYPE));
+
+        NSILI_IMAGERY_DESCRIPTORS.add(new AttributeDescriptorImpl(NUM_COLS,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.INTEGER_TYPE));
+
+    }
+
+    public NsiliImageryMetacardType() {
+        super();
+        attributeDescriptors.addAll(NSILI_IMAGERY_DESCRIPTORS);
+
+    }
+
+    @Override
+    public String getName() {
+        return METACARD_TYPE_NAME;
+    }
+
+}

--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliMessageMetacardType.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliMessageMetacardType.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.common;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.impl.AttributeDescriptorImpl;
+import ddf.catalog.data.impl.BasicTypes;
+
+public class NsiliMessageMetacardType extends NsiliMetacardType {
+    public static final String METACARD_TYPE_NAME = NSILI_METACARD_TYPE_PREFIX +".message."+ NSILI_METACARD_TYPE_POSTFIX;
+
+    /**
+     * Identify the receiving entity of the message. This will typically be an XMPP conference room
+     * identifier (including the fully qualified domain name extension), but could also be an
+     * individual/personal XMPP or e- mail account. In the case a message is sent to more than one
+     * recipient, this shall be supported by separating the recipients by BCS Comma.
+     */
+    public static final String RECIPIENT = "recipient";
+
+    /**
+     * Identification of message type (protocol).
+     */
+    public static final String MESSAGE_TYPE = "messageType";
+
+    /**
+     * Data that specifies the topic of the message.
+     */
+    public static final String MESSAGE_SUBJECT = "messageSubject";
+
+    /**
+     * The body of the message. In case the message body text exceeds the maximum length of this
+     * metadata attribute the message text will be truncated. . The complete message is available
+     * through the URL in NSIL_FILE entity, but only the characters stored in this attribute can be
+     * used for free text search.
+     */
+    public static final String MESSAGE_BODY = "messageBody";
+
+    private static final Set<AttributeDescriptor> NSILI_DESCRIPTORS = new HashSet<>();
+
+    static {
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(RECIPIENT,
+                true /* indexed */,
+                true /* stored */,
+                true /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(MESSAGE_TYPE,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(MESSAGE_SUBJECT,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(MESSAGE_BODY,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+    }
+
+    public NsiliMessageMetacardType() {
+        super();
+        attributeDescriptors.addAll(NSILI_DESCRIPTORS);
+    }
+
+    @Override
+    public String getName() {
+        return METACARD_TYPE_NAME;
+    }
+
+}

--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliMetacardType.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliMetacardType.java
@@ -1,0 +1,753 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.common;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.AttributeType;
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.impl.AttributeDescriptorImpl;
+import ddf.catalog.data.impl.BasicTypes;
+
+public abstract class NsiliMetacardType implements MetacardType {
+
+    /**
+     * Prefix used for the name of the NSILI Metacard Sub-Type
+     */
+    public static final String NSILI_METACARD_TYPE_PREFIX = "nsili";
+
+    /**
+     * Postfix used for the name of the NSILI Metacard Sub-Type
+     */
+    public static final String NSILI_METACARD_TYPE_POSTFIX = "metacard";
+
+    /**
+     * The date and time upon which information (cataloguing metadata) about the product was last stored or changed in the source IPL.
+     */
+    public static final String SOURCE_DATETIME_MODIFIED = "sourceDateTimeModified";
+
+    /**
+     * The name of the organization responsible for making the resource (product) available in an IPL.
+     * By doing so the publisher enables the discovery of that resource by a requestor entity (client).
+     * Examples of organizations are 'CJTF', 'LCC', 'ACC' etc.
+     */
+    public static final String PUBLISHER = "publisher";
+
+    /**
+     * Alphanumeric identification code of the library in which the product was initially ingested.
+     */
+    public static final String SOURCE_LIBRARY = "sourceLibrary";
+
+    /**
+     * An alphanumeric identifier that identifies the mission (e.g. a reconnaissance mission) under
+     * which the product was collected/generated.
+     * As an example, for products collected by sensors on an aircraft, the mission identifier should
+     * be the 'Mission Number' from the Air Tasking Order (ATO).
+     */
+    public static final String IDENTIFIER_MISSION = "identifierMission";
+
+    /**
+     * An additional identifier that can be used for cross-referencing into peripherally accessed JC3IEDM databases.
+     */
+    public static final String ID_JC3IEDM = "identiferJC3Idm";
+
+    /**
+     * A list of 3 character language codes according to ISO 639-2 for the intellectual content of the resource.
+     * Multiple languages are separated by BCS Comma (code 0x2C).
+     * Note: There are two codes for special situations: * mul (for multiple languages) should be
+     * applied when several languages are used and it is not practical to specify all the appropriate
+     * language codes. * und (for undetermined) is provided for those situations in which a language
+     * or languages must be indicated but the language cannot be identified.
+     */
+    public static final String LANGUAGE = "language";
+
+    /**
+     * References to assets (e.g. platform IDs) from which the tagged data asset is derived.
+     * Sources may be derived partially or wholly, and it is recommended that an identifier
+     * (such as a string or number from a formal identification system) be used as a reference.
+     * In case of multiple sources these shall be separated by BCS Comma
+     * (could happen for container files like AAF, MXF and NSIF).
+     * 'Source' is different from 'creator' in that the 'source' entity is the provider of the data
+     * content, while the 'creator' is the entity responsible for assembling the data
+     * (provided by "sources") into a file.
+     */
+    public static final String SOURCE = "NSILISource";
+
+    /**
+     * A target category from STANAG 3596 that should reflect the main subject of the resource.
+     * In case of multiple categories these shall be separated by the BCS Comma
+     */
+    public static final String SUBJECT_CATEGORY_TARGET = "subjectCategoryTarget";
+
+    /**
+     * This field shall contain the identification of the primary target in the product.
+     * In case of multiple target identifiers these shall be separated by the BCS Comma
+     */
+    public static final String TARGET_NUMBER = "targetNumber";
+
+    /**
+     * The nature or genre of the content of the resource.
+     * @see NsiliProductType
+     */
+    public static final String PRODUCT_TYPE = "productType";
+
+    /**
+     * List of standards-based abbreviation (three character codes) of a country names describing
+     * the area over which the product was collected separated by BCS Comma. The three character
+     * code shall be according to STANAG 1059.
+     */
+    public static final String COUNTRY_CODE = "countryCode";
+
+    /**
+     * Start time of a period of time for the content of the dataset (start time of content acquisition).
+     * For products capturing a single instant in time, start time and end time will be equal
+     * (or the end time could be omitted).
+     */
+    public static final String START_DATETIME = "startDateTime";
+
+    /**
+     * End time of a period of time for the content of the dataset (end time of content acquisition).
+     * For products capturing a single instant in time, start time and end time will be equal
+     * (or the end time could be omitted).
+     */
+    public static final String END_DATETIME = "endDateTime";
+
+    /**
+     * Indicates whether the file has been archived.
+     */
+    public static final String FILE_ARCHIVED = "fileArchived";
+
+    /**
+     * Additional archiving information in free text form allowing the archived data (product files)
+     * to be found and possibly be restored to the server storage.
+     * This information could contain the date when the data was archived and point of contact for
+     * retrieving the archived data.
+     */
+    public static final String FILE_ARCHIVED_INFO = "fileArchivedInfo";
+
+    /**
+     * Date and time on which the resource was declared, filed or stored.
+     */
+    public static final String PRODUCT_CREATE_TIME = "productCreateTime";
+
+    /**
+     *  textual description of the performed exploitation.
+     */
+    public static final String EXPLOITATION_DESCRIPTION = "exploitationDescription";
+
+    /**
+     * The degree of exploitation performed on the original data. A value of '0' means that the
+     * product is not exploited.
+     */
+    public static final String EXPLOITATION_LEVEL = "exploitationLevel";
+
+    /**
+     * A flag indicating if the exploitation was automatically generated.
+     */
+    public static final String EXPLOITATION_AUTO_GEN = "exploitationAutoGenerated";
+
+    /**
+     * A code that indicates a subjective rating of the quality of the image or video.
+     */
+    public static final String EXPLOITATION_SUBJ_QUAL_CODE = "exploitationSubjectiveQualityCode";
+
+    /**
+     * SDS operational status.
+     */
+    public static final String SDS_OPERATIONAL_STATUS = "sdsOperationalStatus";
+
+    /**
+     * The name of the organization responsible for Quality Assurance of the resource (product)
+     * available in an IPL.
+     */
+    public static final String APPROVAL_BY = "approvedBy";
+
+    /**
+     * The date and time upon which the approval information on the product was last stored or
+     * changed in the IPL.
+     */
+    public static final String APPROVAL_DATETIME_MODIFIED = "approvedDateTimeModified";
+
+    /**
+     * A status field reporting on whether this product has been approved by the party responsible
+     * for Quality Control of the product.
+     */
+    public static final String APPROVAL_STATUS = "approvalStatus";
+
+    /**
+     * NATO Security markings that determine the physical security given to the information in
+     * storage and transmission, its circulation, destruction and the personnel security clearance
+     * required for access as required by [C- M(2002)49].
+     *
+     * NOTE: This is a merged classification of the METADATA_SECURITY and SECURITY fields
+     */
+    public static final String SECURITY_CLASSIFICATION = "securityClassification";
+
+    /**
+     * This field shall contain valid values indicating the national or multinational security
+     * policies used to classify the Product. To indicate a national security policy Country Codes
+     * per STANAG 1059 shall be used. In cases where the country is not listed by a three character
+     * country code, but as a six character region code, the six character province code from
+     * STANAG 1059 shall be used (e.g. Kosovo is listed as a region in Yugoslavia with six character
+     * province code YUKM-). In all other cases when STANAG 1059 is not sufficient to describe the
+     * security policy, additional enumeration labels could be used (e.g. 'NATO/PFP' and 'NATO/EU').
+     * Note: Although STANAG 1059 includes the 'XXN' entry for NATO, the full 'NATO' name shall be
+     * used to indicate NATO security policy to avoid any confusion from established and common
+     * used terms.
+     *
+     * NOTE: This is a merged classification of the METADATA_SECURITY and SECURITY fields
+     */
+    public static final String SECURITY_POLICY = "securityPolicy";
+
+    /**
+     *  An additional marking to further limit the dissemination of classified information in
+     *  accordance with [C-M (2002)49]. Values include one or more three character country codes as
+     *  found in STANAG 1059 separated by a single BCS Comma (code 0x2C). Default value should be
+     *  NATO. Note: Although STANAG 1059 includes the 'XXN' entry for NATO, the full 'NATO' name
+     *  shall be used to indicate NATO releasability to avoid any confusion from established and
+     *  common used terms.
+     *
+     *  NOTE: This is a merged classification of the METADATA_SECURITY and SECURITY fields
+     */
+    public static final String SECURITY_RELEASABILITY = "securityReleasability";
+
+    /**
+     * Associated metadata records
+     */
+    public static final String ASSOCIATIONS = "associations";
+
+    /**
+     * Associated files
+     */
+    public static final String RELATED_FILES = "relatedFiles";
+
+    /**
+     * Indicates whether the stream has been archived.
+     */
+    public static final String STREAM_ARCHIVED = "archived";
+
+    /**
+     * Additional archiving information in free text form allowing the archived data (stream data)
+     * to be found and possibly be restored to the server storage. This information could contain
+     * the date when the data was archived and point of contact for retrieving the archived data.
+     */
+    public static final String STREAM_ARCHIVAL_INFO = "archivalInfo";
+
+    /**
+     * An entity responsible for providing the stream. Creator is responsible for the intellectual
+     * or creative content of the stream.
+     */
+    public static final String STREAM_CREATOR = "creator";
+
+    /**
+     * Date and time on which the stream was declared, filed or stored.
+     */
+    public static final String STREAM_DATETIME_DECLARED = "dateTimeDeclared";
+
+    /**
+     * The program ID determines the stream ID within the Transport Stream that contains the
+     * PMT (Program Mapping Table) of the stream.
+     */
+    public static final String STREAM_PROGRAM_ID = "programId";
+
+    /**
+     * The standard that the streamed data complies with.
+     */
+    public static final String STREAM_STANDARD = "streamFormat";
+
+    /**
+     * Version of product standard E.g. "1.0".
+     */
+    public static final String STREAM_STANDARD_VER = "streamFormatVer";
+
+    /**
+     * The address and access protocol in the form of an URL by which a user can directly access the
+     * data stream. For RTSP, HTTP, HTTPS and JPIP a standard URL syntax will be used (could include
+     * port number). For UDP/RTP, a URL notation using a '@-character-notaton' is used to allow a URL
+     * to define a broadcasted stream or a multicasted stream. A UDP broadcast source on port 8105
+     * would be defined as 'udp://@:8105', a RTP broadcast source would be defined as
+     * 'rtp://@:8105'; similarly multicasted UDP/RTP source would be defined as
+     * 'udp://@multicast_address:port' or 'udp://@multicast_address:port'. This UDP/RTP @-syntax is
+     * identical to what is being used by the VideoLAN VLC application. For the broadcast situation
+     * it is assumed that the network takes care about forwarding the broadcasts between the LANs
+     * (e.g. using NIRIS) so the stream consumer does not need of the LAN-location of the or
+     * origial stream source. Note 1: Contrary to the productURL this attribute is queryable.
+     * This would allow clients to only discover streams using protocols that the client can consume.
+     * Note 2: When a stream is archived and no longer online, the sourceURL attribute shall be removed.
+     */
+    public static final String STREAM_SOURCE_URL = "streamSourceURL";
+
+    /**
+     * The MIME type for the product object to which this metadata applies with the necessary
+     * extension to cater for ISR specific file types not yet MIME registered.
+     */
+    public static final String FILE_FORMAT = "fileFormat";
+
+    /**
+     * Version of product format. E.g. "1.0". In case of an XML document this attribute refers to
+     * the version of the XML schema that the document refers to (and not to the version of the
+     * XML format).
+     */
+    public static final String FILE_FORMAT_VER = "fileFormatVer";
+
+    /**
+     * The address and access protocol in the form of an URL by which a user can directly access a
+     * product without the user placing an order for delivery. Note, This attribute is not queryable.
+     */
+    public static final String FILE_URL = "fileURL";
+
+    /**
+     * AttributeType used to wrap a NsiliProductType enumeration.
+     */
+    public static final AttributeType<NsiliProductType> NSILI_PRODUCT_TYPE;
+
+    /**
+     * AttributeType used to wrap a NsiliProductType enumeration.
+     */
+    public static final AttributeType<NsiliExploitationSubQualCode>
+            NSILI_EXPLOITATION_SUBJ_QUAL_CD_TYPE;
+
+    /**
+     * AttributeType used to wrap a NsiliSdsOpStatus enumeration.
+     */
+    public static final AttributeType<NsiliSdsOpStatus> NSILI_SDS_OP_STATUS_TYPE;
+
+
+    /**
+     * AttributeType used to wrap a NsiliApprovalStatus enumeration.
+     */
+    public static final AttributeType<NsiliApprovalStatus> NSILI_APPROVAL_STATUS_TYPE;
+
+    protected Set<AttributeDescriptor> attributeDescriptors = new HashSet<>();
+
+    private static final Set<AttributeDescriptor> NSILI_DESCRIPTORS = new HashSet<>();
+
+    static {
+        NSILI_PRODUCT_TYPE = new AttributeType<NsiliProductType>() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public AttributeFormat getAttributeFormat() {
+                return AttributeFormat.STRING;
+            }
+
+            @Override
+            public Class<NsiliProductType> getBinding() {
+                return NsiliProductType.class;
+            }
+        };
+
+        NSILI_EXPLOITATION_SUBJ_QUAL_CD_TYPE = new AttributeType<NsiliExploitationSubQualCode>() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public AttributeFormat getAttributeFormat() {
+                return AttributeFormat.STRING;
+            }
+
+            @Override
+            public Class<NsiliExploitationSubQualCode> getBinding() {
+                return NsiliExploitationSubQualCode.class;
+            }
+        };
+
+        NSILI_SDS_OP_STATUS_TYPE = new AttributeType<NsiliSdsOpStatus>() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public AttributeFormat getAttributeFormat() {
+                return AttributeFormat.STRING;
+            }
+
+            @Override
+            public Class<NsiliSdsOpStatus> getBinding() {
+                return NsiliSdsOpStatus.class;
+            }
+        };
+
+        NSILI_APPROVAL_STATUS_TYPE = new AttributeType<NsiliApprovalStatus>() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public AttributeFormat getAttributeFormat() {
+                return AttributeFormat.STRING;
+            }
+
+            @Override
+            public Class<NsiliApprovalStatus> getBinding() {
+                return NsiliApprovalStatus.class;
+            }
+        };
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(SOURCE_DATETIME_MODIFIED,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.DATE_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(PUBLISHER,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(SOURCE_LIBRARY,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(IDENTIFIER_MISSION,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(ID_JC3IEDM,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(LANGUAGE,
+                true /* indexed */,
+                true /* stored */,
+                true /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(SOURCE,
+                true /* indexed */,
+                true /* stored */,
+                true /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(SUBJECT_CATEGORY_TARGET,
+                true /* indexed */,
+                true /* stored */,
+                true /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(TARGET_NUMBER,
+                true /* indexed */,
+                true /* stored */,
+                true /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(PRODUCT_TYPE,
+                true /* indexed */,
+                true /* stored */,
+                true /* tokenized */,
+                false /* multivalued */, NSILI_PRODUCT_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(COUNTRY_CODE,
+                true /* indexed */,
+                true /* stored */,
+                true /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(START_DATETIME,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.DATE_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(END_DATETIME,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.DATE_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(FILE_ARCHIVED,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.BOOLEAN_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(FILE_ARCHIVED_INFO,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(PRODUCT_CREATE_TIME,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.DATE_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(EXPLOITATION_DESCRIPTION,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(EXPLOITATION_LEVEL,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.INTEGER_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(EXPLOITATION_AUTO_GEN,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.BOOLEAN_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(EXPLOITATION_SUBJ_QUAL_CODE,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */, NSILI_EXPLOITATION_SUBJ_QUAL_CD_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(SDS_OPERATIONAL_STATUS,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */, NSILI_SDS_OP_STATUS_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(APPROVAL_BY,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(APPROVAL_DATETIME_MODIFIED,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.DATE_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(APPROVAL_STATUS,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */, NSILI_APPROVAL_STATUS_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(APPROVAL_STATUS,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */, NSILI_APPROVAL_STATUS_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(SECURITY_CLASSIFICATION,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(SECURITY_POLICY,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(SECURITY_RELEASABILITY,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(ASSOCIATIONS,
+                false /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                true /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(STREAM_ARCHIVED,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.BOOLEAN_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(STREAM_ARCHIVAL_INFO,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(STREAM_CREATOR,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(STREAM_DATETIME_DECLARED,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.DATE_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(STREAM_PROGRAM_ID,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.INTEGER_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(STREAM_STANDARD,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(STREAM_STANDARD_VER,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(STREAM_SOURCE_URL,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(FILE_FORMAT,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(FILE_FORMAT_VER,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_DESCRIPTORS.add(new AttributeDescriptorImpl(FILE_URL,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+    }
+
+    /**
+     * Basic attributes
+     *
+     * Metacard.MODIFIED,
+     * Metacard.EXPIRATION
+     * Metacard.EFFECTIVE
+     * Metacard.CREATED
+     * Metacard.ID
+     * Metacard.TITLE
+     * Metacard.POINT_OF_CONTACT
+     * Metacard.CONTENT_TYPE
+     * Metacard.CONTENT_TYPE_VERSION
+     * Metacard.TARGET_NAMESPACE
+     * Metacard.METADATA
+     * Metacard.RESOURCE_URI
+     * Metacard.RESOURCE_DOWNLOAD_URL
+     * Metacard.RESOURCE_SIZE
+     * Metacard.THUMBNAIL
+     * Metacard.GEOGRAPHY
+     * Metacard.DESCRIPTION
+     * VALIDATION_WARNINGS
+     * VALIDATION_ERRORS
+     *
+     */
+
+    /**
+     * NSIL_COMMON Attributes
+     * descriptonAbstract -> Metacard.Description
+     *
+     */
+
+    public NsiliMetacardType() {
+        attributeDescriptors.addAll(BasicTypes.BASIC_METACARD.getAttributeDescriptors());
+        attributeDescriptors.addAll(NsiliMetacardType.NSILI_DESCRIPTORS);
+    }
+
+    @Override
+    public abstract String getName();
+
+    @Override
+    public Set<AttributeDescriptor> getAttributeDescriptors() {
+        return attributeDescriptors;
+    }
+
+    @Override
+    public AttributeDescriptor getAttributeDescriptor(String attributeName) {
+        AttributeDescriptor attributeDescriptor = null;
+        for (AttributeDescriptor descriptor:attributeDescriptors) {
+            if (descriptor.getName().equals(attributeName)) {
+                attributeDescriptor = descriptor;
+                break;
+            }
+        }
+        return attributeDescriptor;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        NsiliMetacardType that = (NsiliMetacardType) o;
+
+        if (attributeDescriptors != null ?
+                !attributeDescriptors.equals(that.attributeDescriptors) :
+                that.attributeDescriptors != null) {
+            return false;
+        }
+        return getName() != null ? getName().equals(that.getName()) : that.getName() == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = attributeDescriptors != null ? attributeDescriptors.hashCode() : 0;
+        result = 31 * result + (getName() != null ? getName().hashCode() : 0);
+        return result;
+    }
+}

--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliMetadataEncodingScheme.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliMetadataEncodingScheme.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.common;
+
+public enum NsiliMetadataEncodingScheme {
+    NONE,
+    KLV;
+}

--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliReportMetacardType.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliReportMetacardType.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.common;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.AttributeType;
+import ddf.catalog.data.impl.AttributeDescriptorImpl;
+import ddf.catalog.data.impl.BasicTypes;
+
+public class NsiliReportMetacardType extends NsiliMetacardType {
+    public static final String METACARD_TYPE_NAME = NSILI_METACARD_TYPE_PREFIX +".report."+ NSILI_METACARD_TYPE_POSTFIX;
+
+    /**
+     * Based on the originators request serial number STANAG 3277.
+     */
+    public static final String ORIGINATOR_REQ_SERIAL_NUM = "originatorsRequestSerialNumber";
+
+    /**
+     * A priority marking of the report.
+     */
+    public static final String PRIORITY = "reportPriority";
+
+    /**
+     * The specific type of report.
+     */
+    public static final String TYPE = "reportType";
+
+    /**
+     * Metacard AttributeType for the NSILI Report Priority.
+     */
+    public static final AttributeType<NsiliReportPriority> NSILI_REPORT_PRIORITY_TYPE;
+
+    /**
+     * Metacard AttributeType for the NSILI Priority.
+     */
+    public static final AttributeType<NsiliReportType> NSILI_REPORT_TYPE;
+
+    private static final Set<AttributeDescriptor> NSILI_REPORT_DESCRIPTORS = new HashSet<>();
+
+    static {
+        NSILI_REPORT_PRIORITY_TYPE = new AttributeType<NsiliReportPriority>() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public AttributeFormat getAttributeFormat() {
+                return AttributeFormat.STRING;
+            }
+
+            @Override
+            public Class<NsiliReportPriority> getBinding() {
+                return NsiliReportPriority.class;
+            }
+        };
+
+        NSILI_REPORT_TYPE = new AttributeType<NsiliReportType>() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public AttributeFormat getAttributeFormat() {
+                return AttributeFormat.STRING;
+            }
+
+            @Override
+            public Class<NsiliReportType> getBinding() {
+                return NsiliReportType.class;
+            }
+        };
+
+        NSILI_REPORT_DESCRIPTORS.add(new AttributeDescriptorImpl(ORIGINATOR_REQ_SERIAL_NUM,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_REPORT_DESCRIPTORS.add(new AttributeDescriptorImpl(PRIORITY,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */, NSILI_REPORT_PRIORITY_TYPE));
+
+        NSILI_REPORT_DESCRIPTORS.add(new AttributeDescriptorImpl(TYPE,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */, NSILI_REPORT_TYPE));
+
+    }
+
+    public NsiliReportMetacardType() {
+        super();
+        attributeDescriptors.addAll(NsiliReportMetacardType.NSILI_REPORT_DESCRIPTORS);
+    }
+
+    @Override
+    public String getName() {
+        return METACARD_TYPE_NAME;
+    }
+}

--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliReportPriority.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliReportPriority.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.common;
+
+public enum NsiliReportPriority {
+    ROUTINE,
+    PRIORITY,
+    IMMEDIATE,
+    FLASH;
+}

--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliReportType.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliReportType.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.common;
+
+public enum NsiliReportType {
+    IQREP,
+    ISRSPOTREP,
+    MIEXREP,
+    MTIEXREP,
+    RECCEXREP,
+    WLEXREP;
+}

--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliRfiMetacardType.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliRfiMetacardType.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.common;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.AttributeType;
+import ddf.catalog.data.impl.AttributeDescriptorImpl;
+import ddf.catalog.data.impl.BasicTypes;
+
+public class NsiliRfiMetacardType extends NsiliMetacardType {
+    public static final String METACARD_TYPE_NAME = NSILI_METACARD_TYPE_PREFIX +".rfi."+ NSILI_METACARD_TYPE_POSTFIX;
+
+    /**
+     * A nation, command, agency, organization or unit requested to provide a response.
+     */
+    public static final String FOR_ACTION = "forAction";
+
+    /**
+     * A comma-separated list of nations, commands, agencies, organizations and units which may have an interest in the response.
+     */
+    public static final String FOR_INFORMATION = "forInformation";
+
+    /**
+     * Unique human readable string identifying the RFI instance.
+     */
+    public static final String SERIAL_NUMBER = "serialNumber";
+
+    /**
+     * Indicates the status of the RFI.s
+     */
+    public static final String STATUS = "status";
+
+    /**
+     * Indicates the workflow status of the RFI.
+     */
+    public static final String WORKFLOW_STATUS = "workflowStatus";
+
+    /**
+     * Metacard AttributeType for the NSILI RFI Status.
+     */
+    public static final AttributeType<NsiliRfiStatus> NSILI_RFI_STATUS_TYPE;
+
+    /**
+     * Metacard AttributeType for the NSILI RFI Workflow Status.
+     */
+    public static final AttributeType<NsiliRfiWorkflowStatus> NSILI_RFI_WORKFLOW_STATUS_TYPE;
+
+
+    private static final Set<AttributeDescriptor> NSILI_RFI_DESCRIPTORS = new HashSet<>();
+
+    static {
+        NSILI_RFI_STATUS_TYPE = new AttributeType<NsiliRfiStatus>() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public AttributeFormat getAttributeFormat() {
+                return AttributeFormat.STRING;
+            }
+
+            @Override
+            public Class<NsiliRfiStatus> getBinding() {
+                return NsiliRfiStatus.class;
+            }
+        };
+
+        NSILI_RFI_WORKFLOW_STATUS_TYPE = new AttributeType<NsiliRfiWorkflowStatus>() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public AttributeFormat getAttributeFormat() {
+                return AttributeFormat.STRING;
+            }
+
+            @Override
+            public Class<NsiliRfiWorkflowStatus> getBinding() {
+                return NsiliRfiWorkflowStatus.class;
+            }
+        };
+
+        NSILI_RFI_DESCRIPTORS.add(new AttributeDescriptorImpl(FOR_ACTION,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_RFI_DESCRIPTORS.add(new AttributeDescriptorImpl(FOR_INFORMATION,
+                true /* indexed */,
+                true /* stored */,
+                true /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_RFI_DESCRIPTORS.add(new AttributeDescriptorImpl(SERIAL_NUMBER,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_RFI_DESCRIPTORS.add(new AttributeDescriptorImpl(STATUS,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                NSILI_RFI_STATUS_TYPE));
+
+        NSILI_RFI_DESCRIPTORS.add(new AttributeDescriptorImpl(WORKFLOW_STATUS,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                NSILI_RFI_WORKFLOW_STATUS_TYPE));
+
+    }
+
+    public NsiliRfiMetacardType() {
+        super();
+        attributeDescriptors.addAll(NsiliRfiMetacardType.NSILI_RFI_DESCRIPTORS);
+    }
+
+    @Override
+    public String getName() {
+        return METACARD_TYPE_NAME;
+    }
+}

--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliRfiStatus.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliRfiStatus.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.common;
+
+public enum NsiliRfiStatus {
+    APPROVED,
+    INACTION,
+    STOPPED,
+    FULFILLED;
+}

--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliRfiWorkflowStatus.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliRfiWorkflowStatus.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.common;
+
+public enum NsiliRfiWorkflowStatus {
+    NEW,
+    ACCEPTED,
+    DENIED,
+    CANCELLED,
+    COMPLETED;
+}

--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliScanningMode.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliScanningMode.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.common;
+
+public enum NsiliScanningMode {
+    INTERLACED,
+    PROGRESSIVE;
+}

--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliSdsOpStatus.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliSdsOpStatus.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.common;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum NsiliSdsOpStatus {
+    UNKNOWN("UNKNOWN"),
+    LIMITED_OPERATIONAL("LIMITED OPERATIONAL"),
+    OPERATIONAL("OPERATIONAL"),
+    NOT_OPERATIONAL("NOT OPERATIONAL");
+
+    private static final Map<String, NsiliSdsOpStatus> specNameMap = new HashMap<>();
+    static {
+        for (NsiliSdsOpStatus status: NsiliSdsOpStatus.values()) {
+            specNameMap.put(status.getSpecName(), status);
+        }
+    }
+
+    private String specName;
+
+    NsiliSdsOpStatus(String specName) {
+        this.specName = specName;
+    }
+
+    public String getSpecName() {
+        return specName;
+    }
+
+    public static NsiliSdsOpStatus fromSpecName(String specName) {
+        return specNameMap.get(specName);
+    }
+}

--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliSecurity.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliSecurity.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.common;
+
+public class NsiliSecurity {
+    private String classification;
+    private String policy;
+    private String releasability;
+
+    public NsiliSecurity() {
+
+    }
+
+    public String getClassification() {
+        return classification;
+    }
+
+    public void setClassification(String classification) {
+        this.classification = classification;
+    }
+
+    public String getPolicy() {
+        return policy;
+    }
+
+    public void setPolicy(String policy) {
+        this.policy = policy;
+    }
+
+    public String getReleasability() {
+        return releasability;
+    }
+
+    public void setReleasability(String releasability) {
+        this.releasability = releasability;
+    }
+}

--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliTaskMetacardType.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliTaskMetacardType.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.common;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.AttributeType;
+import ddf.catalog.data.impl.AttributeDescriptorImpl;
+import ddf.catalog.data.impl.BasicTypes;
+
+public class NsiliTaskMetacardType extends NsiliMetacardType {
+    public static final String METACARD_TYPE_NAME = NSILI_METACARD_TYPE_PREFIX +".task."+ NSILI_METACARD_TYPE_POSTFIX;
+
+    /**
+     * Comments on the task.
+     */
+    public static final String COMMENTS = "comments";
+
+    /**
+     * A status of the task
+     */
+    public static final String STATUS = "status";
+
+    /**
+     * Metacard AttributeType for the NSILI Task Status.
+     */
+    public static final AttributeType<NsiliTaskStatus> NSILI_TASK_STATUS_TYPE;
+
+    private static final Set<AttributeDescriptor> NSILI_TASK_DESCRIPTORS = new HashSet<>();
+
+    static {
+        NSILI_TASK_STATUS_TYPE = new AttributeType<NsiliTaskStatus>() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public AttributeFormat getAttributeFormat() {
+                return AttributeFormat.STRING;
+            }
+
+            @Override
+            public Class<NsiliTaskStatus> getBinding() {
+                return NsiliTaskStatus.class;
+            }
+        };
+
+        NSILI_TASK_DESCRIPTORS.add(new AttributeDescriptorImpl(COMMENTS,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_TASK_DESCRIPTORS.add(new AttributeDescriptorImpl(STATUS,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */, NSILI_TASK_STATUS_TYPE));
+
+    }
+
+    public NsiliTaskMetacardType() {
+        super();
+        attributeDescriptors.addAll(NsiliTaskMetacardType.NSILI_TASK_DESCRIPTORS);
+    }
+
+    @Override
+    public String getName() {
+        return METACARD_TYPE_NAME;
+    }
+}

--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliTaskStatus.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliTaskStatus.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.common;
+
+public enum NsiliTaskStatus {
+    PLANNED,
+    ACKNOWLEDGED,
+    ONGOING,
+    ACCOMPLISHED,
+    INTERRUPTED,
+    INFEASIBLE,
+    CANCELLED;
+}

--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliTdlMetacardType.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliTdlMetacardType.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.common;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.impl.AttributeDescriptorImpl;
+import ddf.catalog.data.impl.BasicTypes;
+
+public class NsiliTdlMetacardType extends NsiliMetacardType {
+    public static final String METACARD_TYPE_NAME = NSILI_METACARD_TYPE_PREFIX +".tdl."+ NSILI_METACARD_TYPE_POSTFIX;
+
+    /**
+     * A number that together with the 'platform' number defines the identity of a track
+     */
+    public static final String ACTIVITY = "activity";
+
+    /**
+     * The Link 16 J Series message number.
+     */
+    public static final String MESSAGE_NUM = "messageNumber";
+
+    /**
+     * A number that together with the 'activity' number defines the identity of a track.
+     */
+    public static final String PLATFORM = "platform";
+
+    /**
+     * Link 16 J Series track number for the track found in the product.
+     * The track number shall be in the decoded 5-character format (e.g. EK627).
+     */
+    public static final String TRACK_NUM = "trackNumber";
+
+    private static final Set<AttributeDescriptor> NSILI_TDL_DESCRIPTORS = new HashSet<>();
+
+    static {
+        NSILI_TDL_DESCRIPTORS.add(new AttributeDescriptorImpl(ACTIVITY,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.INTEGER_TYPE));
+
+        NSILI_TDL_DESCRIPTORS.add(new AttributeDescriptorImpl(MESSAGE_NUM,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+
+        NSILI_TDL_DESCRIPTORS.add(new AttributeDescriptorImpl(PLATFORM,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.INTEGER_TYPE));
+
+        NSILI_TDL_DESCRIPTORS.add(new AttributeDescriptorImpl(TRACK_NUM,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.STRING_TYPE));
+    }
+
+    public NsiliTdlMetacardType() {
+        super();
+        attributeDescriptors.addAll(NsiliTdlMetacardType.NSILI_TDL_DESCRIPTORS);
+    }
+
+    @Override
+    public String getName() {
+        return METACARD_TYPE_NAME;
+    }
+}

--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliVideoCategoryType.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliVideoCategoryType.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.common;
+
+public enum NsiliVideoCategoryType {
+    VIS,
+    IR,
+    MS,
+    HS
+}

--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliVideoMetacardType.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliVideoMetacardType.java
@@ -1,0 +1,225 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.common;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.AttributeType;
+import ddf.catalog.data.impl.AttributeDescriptorImpl;
+import ddf.catalog.data.impl.BasicTypes;
+
+public class NsiliVideoMetacardType extends NsiliMetacardType {
+    public static final String METACARD_TYPE_NAME = NSILI_METACARD_TYPE_PREFIX +".video."+ NSILI_METACARD_TYPE_POSTFIX;
+
+    /**
+     * The bit rate of the motion imagery product when being streamed.
+     */
+    public static final String AVG_BIT_RATE = "averageBitRate";
+
+    /**
+     * An indicator of the specific category of motion image (information about the bands of visible
+     * or infrared region of electromagnetic continuum being used). The specific category of an image
+     * reveals its intended use or the nature of its collector.
+     */
+    public static final String CATEGORY = "category";
+
+    /**
+     * A code that indicates the manner in which the motion imagery was encoded.
+     */
+    public static final String ENCODING_SCHEME = "encodingScheme";
+
+    /**
+     * The standard rate (in frames per second (FPS)) at which the motion imagery was captured.
+     */
+    public static final String FRAME_RATE = "frameRate";
+
+    /**
+     * The frame vertical resolution.
+     */
+    public static final String NUM_ROWS = "numRows";
+
+    /**
+     * The frame horizontal resolution.
+     */
+    public static final String NUM_COLS = "numCols";
+
+    /**
+     * A code that indicates the manner in which the metadata for the motion imagery was encoded.
+     */
+    public static final String METADATA_ENCODING_SCHEME = "metadataEncodingScheme";
+
+    /**
+     * From [AEDP-8]: The "Motion Imagery Systems (Spatial and Temporal) Matrix" (MISM) defines an
+     * ENGINEERING GUIDELINE for the simple identification of broad categories of Motion Imagery Systems.
+     * The intent of the MISM is to give user communities an easy to use, common shorthand reference
+     * language to describe the fundamental technical capabilities of NATO motion imagery systems.
+     */
+    public static final String MISM_LEVEL = "mismLevel";
+
+    /**
+     * Indicate if progressive or interlaced scans are being applied.
+     */
+    public static final String SCANNING_MODE = "scanningMode";
+
+    /**
+     * Metacard AttributeType for the NSILI Video Category Type.
+     */
+    public static final AttributeType<NsiliVideoCategoryType> NSILI_VIDEO_CAT_TYPE;
+
+    /**
+     * Metacard AttributeType for the NSILI Video Encoding Type.
+     */
+    public static final AttributeType<NsiliVideoEncodingScheme> NSILI_VIDEO_ENC_TYPE;
+
+    /**
+     * Metacard AttributeType for the NSILI Metadata Encoding Scheme Type.
+     */
+    public static final AttributeType<NsiliMetadataEncodingScheme> NSILI_METADATA_ENC_TYPE;
+
+    /**
+     * Metacard AttributeType for the NSILI Scanning Mode.
+     */
+    public static final AttributeType<NsiliScanningMode> NSILI_SCANNING_MODE_TYPE;
+
+    private static final Set<AttributeDescriptor> NSILI_VIDEO_DESCRIPTORS = new HashSet<>();
+
+    static {
+        NSILI_VIDEO_CAT_TYPE = new AttributeType<NsiliVideoCategoryType>() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public AttributeFormat getAttributeFormat() {
+                return AttributeFormat.STRING;
+            }
+
+            @Override
+            public Class<NsiliVideoCategoryType> getBinding() {
+                return NsiliVideoCategoryType.class;
+            }
+        };
+
+        NSILI_VIDEO_ENC_TYPE = new AttributeType<NsiliVideoEncodingScheme>() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public AttributeFormat getAttributeFormat() {
+                return AttributeFormat.STRING;
+            }
+
+            @Override
+            public Class<NsiliVideoEncodingScheme> getBinding() {
+                return NsiliVideoEncodingScheme.class;
+            }
+        };
+
+        NSILI_METADATA_ENC_TYPE = new AttributeType<NsiliMetadataEncodingScheme>() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public AttributeFormat getAttributeFormat() {
+                return AttributeFormat.STRING;
+            }
+
+            @Override
+            public Class<NsiliMetadataEncodingScheme> getBinding() {
+                return NsiliMetadataEncodingScheme.class;
+            }
+        };
+
+        NSILI_SCANNING_MODE_TYPE = new AttributeType<NsiliScanningMode>() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public AttributeFormat getAttributeFormat() {
+                return AttributeFormat.STRING;
+            }
+
+            @Override
+            public Class<NsiliScanningMode> getBinding() {
+                return NsiliScanningMode.class;
+            }
+        };
+
+        NSILI_VIDEO_DESCRIPTORS.add(new AttributeDescriptorImpl(AVG_BIT_RATE,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.FLOAT_TYPE));
+
+        NSILI_VIDEO_DESCRIPTORS.add(new AttributeDescriptorImpl(CATEGORY,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */, NSILI_VIDEO_CAT_TYPE));
+
+        NSILI_VIDEO_DESCRIPTORS.add(new AttributeDescriptorImpl(ENCODING_SCHEME,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */, NSILI_VIDEO_ENC_TYPE));
+
+        NSILI_VIDEO_DESCRIPTORS.add(new AttributeDescriptorImpl(FRAME_RATE,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.FLOAT_TYPE));
+
+        NSILI_VIDEO_DESCRIPTORS.add(new AttributeDescriptorImpl(NUM_ROWS,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.INTEGER_TYPE));
+
+        NSILI_VIDEO_DESCRIPTORS.add(new AttributeDescriptorImpl(NUM_COLS,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.INTEGER_TYPE));
+
+        NSILI_VIDEO_DESCRIPTORS.add(new AttributeDescriptorImpl(METADATA_ENCODING_SCHEME,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */, NSILI_METADATA_ENC_TYPE));
+
+        NSILI_VIDEO_DESCRIPTORS.add(new AttributeDescriptorImpl(MISM_LEVEL,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.INTEGER_TYPE));
+
+        NSILI_VIDEO_DESCRIPTORS.add(new AttributeDescriptorImpl(SCANNING_MODE,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */, NSILI_SCANNING_MODE_TYPE));
+    }
+
+    public NsiliVideoMetacardType() {
+        super();
+        attributeDescriptors.addAll(NSILI_VIDEO_DESCRIPTORS);
+    }
+
+    @Override
+    public String getName() {
+        return METACARD_TYPE_NAME;
+    }
+}

--- a/catalog/nsili/catalog-nsili-source/pom.xml
+++ b/catalog/nsili/catalog-nsili-source/pom.xml
@@ -24,7 +24,7 @@
 
     <artifactId>catalog-nsili-source</artifactId>
     <packaging>bundle</packaging>
-    <name>DDF :: Alliance :: NSILI :: Source</name>
+    <name>Alliance :: NSILI :: Source</name>
 
     <dependencies>
         <dependency>
@@ -40,6 +40,11 @@
         <dependency>
             <groupId>org.codice.alliance.nsili</groupId>
             <artifactId>catalog-nsili-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.alliance.nsili</groupId>
+            <artifactId>catalog-nsili-transformer</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
@@ -149,6 +154,7 @@
                         <Embed-Dependency>
                             catalog-core-api-impl,
                             catalog-nsili-common,
+                            catalog-nsili-transformer,
                             platform-util,
                             commons-lang,
                             jgrapht-core,
@@ -157,7 +163,8 @@
                             ddf-security-common,
                             platform-util,
                             platform-util-unavailableurls,
-                            joda-time
+                            joda-time,
+                            jts
                         </Embed-Dependency>
                     </instructions>
                 </configuration>
@@ -185,7 +192,7 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.69</minimum>
+                                            <minimum>0.68</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>

--- a/catalog/nsili/catalog-nsili-source/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/nsili/catalog-nsili-source/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -18,17 +18,17 @@
          description="NSILI Federated Source">
 
         <AD description="The ID of the NSILI Source" name="NSILI Source ID" id="id"
-            required="true" type="String" default="STANAG4559 Federated Source"/>
+            required="true" type="String" default="NSILI Federated Source"/>
 
         <AD description="The URL of the IOR File to use for the NSILI CORBA Server"
             name="Ior File URL" id="iorUrl" required="true" type="String"/>
 
         <AD description="The Username to be used for authentication with HTTP server."
-            name="HTTP(s) Username" id="cxfUsername"
+            name="HTTP/S Username" id="cxfUsername"
             required="false" type="String"/>
 
         <AD description="The Password to be used for authentication with HTTP server."
-            name="HTTP(s) Password" id="cxfPassword" required="false" type="String"/>
+            name="HTTP/S Password" id="cxfPassword" required="false" type="String"/>
 
         <AD description="The Maximum Hit Count for Queries to the Source" name="Max Hit Count"
             id="maxHitCount" required="true" type="Integer" default="250"/>
@@ -42,17 +42,17 @@
          description="NSILI Connected Source">
 
         <AD description="The ID of the NSILI Source" name="NSILI Source ID" id="id"
-            required="true" type="String" default="STANAG4559 Federated Source"/>
+            required="true" type="String" default="NSILI Connected Source"/>
 
         <AD description="The URL of the IOR File to use for the NSILI CORBA Server"
             name="Ior File URL" id="iorUrl" required="true" type="String"/>
 
         <AD description="The Username to be used for authentication with HTTP server."
-            name="HTTP(s) Username" id="cxfUsername"
+            name="HTTP/S Username" id="cxfUsername"
             required="false" type="String"/>
 
         <AD description="The Password to be used for authentication with HTTP server."
-            name="HTTP(s) Password" id="cxfPassword" required="false" type="String"/>
+            name="HTTP/S Password" id="cxfPassword" required="false" type="String"/>
 
         <AD description="The Maximum Hit Count for Queries to the Source" name="Max Hit Count"
             id="maxHitCount" required="true" type="Integer" default="250"/>

--- a/catalog/nsili/catalog-nsili-transformer/pom.xml
+++ b/catalog/nsili/catalog-nsili-transformer/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 /**
  * Copyright (c) Codice Foundation
@@ -22,20 +22,19 @@
         <version>0.1-SNAPSHOT</version>
     </parent>
 
-    <artifactId>catalog-nsili-common</artifactId>
-    <name>Alliance :: NSILI :: Common</name>
+    <artifactId>catalog-nsili-transformer</artifactId>
     <packaging>jar</packaging>
+    <name>Alliance :: NSILI :: Input Transformer</name>
 
     <properties>
-        <findbugs.skip>true</findbugs.skip>
-        <checkstyle.skip>true</checkstyle.skip>
+        <project.report.output.directory>reports</project.report.output.directory>
     </properties>
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.cxf</groupId>
-            <artifactId>cxf-rt-rs-client</artifactId>
-            <version>${cxf.version}</version>
+            <groupId>org.codice.alliance.nsili</groupId>
+            <artifactId>catalog-nsili-common</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>ddf.catalog.core</groupId>
@@ -47,52 +46,48 @@
             <artifactId>jgrapht-core</artifactId>
             <version>0.9.1</version>
         </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>1.6.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vividsolutions</groupId>
+            <artifactId>jts</artifactId>
+            <version>1.12</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>idlj-maven-plugin</artifactId>
-                <version>1.2.1</version>
-                <executions>
-                    <execution>
-                        <id>generate-sources-from-idl</id>
-                        <configuration>
-                            <outputDirectory>${basedir}/target/generated-sources</outputDirectory>
-                            <sources>
-                                <source>
-                                    <additionalArguments>
-                                        <list>-pkgTranslate</list>
-                                        <list>GIAS</list>
-                                        <list>org.codice.alliance.nsili.common.GIAS</list>
-                                        <list>-pkgTranslate</list>
-                                        <list>UCO</list>
-                                        <list>org.codice.alliance.nsili.common.UCO</list>
-                                        <list>-pkgTranslate</list>
-                                        <list>CB</list>
-                                        <list>org.codice.alliance.nsili.common.CB</list>
-                                        <list>-pkgTranslate</list>
-                                        <list>PS</list>
-                                        <list>org.codice.alliance.nsili.common.PS</list>
-                                        <list>-pkgTranslate</list>
-                                        <list>UID</list>
-                                        <list>org.codice.alliance.nsili.common.UID</list>
-                                    </additionalArguments>
-                                    <compatible>false</compatible>
-                                </source>
-                            </sources>
-                        </configuration>
-                        <goals>
-                            <goal>generate</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <phase>prepare-package</phase>
+                        <configuration>
+                            <outputDirectory>
+                                ${project.build.directory}/site/${project.report.output.directory}/jacoco/
+                            </outputDirectory>
+                        </configuration>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+
                     <execution>
                         <id>default-check</id>
                         <goals>
@@ -112,22 +107,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.0</minimum>
+                                            <minimum>0.90</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.0</minimum>
+                                            <minimum>0.70</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.0</minimum>
+                                            <minimum>0.59</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.0</minimum>
+                                            <minimum>0.90</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/nsili/catalog-nsili-transformer/src/main/java/org/codice/alliance/nsili/transformer/DAGConverter.java
+++ b/catalog/nsili/catalog-nsili-transformer/src/main/java/org/codice/alliance/nsili/transformer/DAGConverter.java
@@ -1,0 +1,1177 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.transformer;
+
+import java.io.Serializable;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.codice.alliance.nsili.common.NsiliApprovalStatus;
+import org.codice.alliance.nsili.common.NsiliClassification;
+import org.codice.alliance.nsili.common.NsiliClassificationComparator;
+import org.codice.alliance.nsili.common.NsiliConstants;
+import org.codice.alliance.nsili.common.NsiliCxpMetacardType;
+import org.codice.alliance.nsili.common.NsiliCxpStatusType;
+import org.codice.alliance.nsili.common.NsiliExploitationSubQualCode;
+import org.codice.alliance.nsili.common.NsiliGmtiMetacardType;
+import org.codice.alliance.nsili.common.NsiliIRMetacardType;
+import org.codice.alliance.nsili.common.NsiliImageryDecompressionTech;
+import org.codice.alliance.nsili.common.NsiliImageryMetacardType;
+import org.codice.alliance.nsili.common.NsiliImageryType;
+import org.codice.alliance.nsili.common.NsiliMessageMetacardType;
+import org.codice.alliance.nsili.common.NsiliMetacardType;
+import org.codice.alliance.nsili.common.NsiliMetadataEncodingScheme;
+import org.codice.alliance.nsili.common.NsiliProductType;
+import org.codice.alliance.nsili.common.NsiliReportMetacardType;
+import org.codice.alliance.nsili.common.NsiliReportPriority;
+import org.codice.alliance.nsili.common.NsiliReportType;
+import org.codice.alliance.nsili.common.NsiliRfiMetacardType;
+import org.codice.alliance.nsili.common.NsiliRfiStatus;
+import org.codice.alliance.nsili.common.NsiliRfiWorkflowStatus;
+import org.codice.alliance.nsili.common.NsiliSdsOpStatus;
+import org.codice.alliance.nsili.common.NsiliSecurity;
+import org.codice.alliance.nsili.common.NsiliTaskMetacardType;
+import org.codice.alliance.nsili.common.NsiliTaskStatus;
+import org.codice.alliance.nsili.common.NsiliTdlMetacardType;
+import org.codice.alliance.nsili.common.NsiliVideoCategoryType;
+import org.codice.alliance.nsili.common.NsiliVideoEncodingScheme;
+import org.codice.alliance.nsili.common.NsiliVideoMetacardType;
+import org.codice.alliance.nsili.common.UCO.AbsTime;
+import org.codice.alliance.nsili.common.UCO.AbsTimeHelper;
+import org.codice.alliance.nsili.common.UCO.DAG;
+import org.codice.alliance.nsili.common.UCO.Edge;
+import org.codice.alliance.nsili.common.UCO.Node;
+import org.codice.alliance.nsili.common.UCO.NodeType;
+import org.codice.alliance.nsili.common.UCO.RectangleHelper;
+import org.jgrapht.experimental.dag.DirectedAcyclicGraph;
+import org.jgrapht.traverse.DepthFirstIterator;
+import org.joda.time.DateTime;
+import org.omg.CORBA.Any;
+import org.omg.CORBA.TCKind;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.LinearRing;
+import com.vividsolutions.jts.geom.Polygon;
+import com.vividsolutions.jts.io.WKTWriter;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.impl.MetacardImpl;
+
+public class DAGConverter {
+
+    private static final long MEGABYTE = 1024L * 1024L;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DAGConverter.class);
+
+    private static final WKTWriter WKT_WRITER = new WKTWriter();
+
+    public static MetacardImpl convertDAG(DAG dag, String sourceId) {
+        MetacardImpl metacard = null;
+
+        //Need to have at least 2 nodes and an edge for anything useful
+        if (dag.nodes != null && dag.edges != null) {
+            Map<Integer, Node> nodeMap = createNodeMap(dag.nodes);
+            DirectedAcyclicGraph<Node, Edge> graph = new DirectedAcyclicGraph<>(Edge.class);
+
+            //Build up the graph
+            for (Node node : dag.nodes) {
+                graph.addVertex(node);
+            }
+
+            for (Edge edge : dag.edges) {
+                Node node1 = nodeMap.get(edge.start_node);
+                Node node2 = nodeMap.get(edge.end_node);
+                if (node1 != null && node2 != null) {
+                    graph.addEdge(node1, node2);
+                }
+            }
+
+            metacard = parseGraph(graph);
+            metacard.setSourceId(sourceId);
+        }
+
+        return metacard;
+    }
+
+    private static Map<Integer, Node> createNodeMap(Node[] nodes) {
+        Map<Integer, Node> nodeMap = new HashMap<>();
+        for (Node node : nodes) {
+            nodeMap.put(node.id, node);
+        }
+
+        return nodeMap;
+    }
+
+    private static MetacardImpl parseGraph(DirectedAcyclicGraph<Node, Edge> graph) {
+        MetacardImpl metacard = new MetacardImpl();
+
+        NsiliSecurity security = new NsiliSecurity();
+        List<Serializable> associatedCards = new ArrayList<>();
+
+        //Traverse the graph
+        DepthFirstIterator<Node, Edge> depthFirstIterator = new DepthFirstIterator<>(graph);
+        Node parentEntity = null;
+        Node assocNode = null;
+
+        while (depthFirstIterator.hasNext()) {
+            Node node = depthFirstIterator.next();
+
+            if (node.node_type == NodeType.ROOT_NODE && node.attribute_name.equals(
+                    NsiliConstants.NSIL_PRODUCT)) {
+                //Nothing to process from root node
+            } else if (node.node_type == NodeType.ENTITY_NODE) {
+                parentEntity = node;
+                if (node.attribute_name.equals(NsiliConstants.NSIL_ASSOCIATION)) {
+                    assocNode = node;
+                } else {
+                    if (assocNode != null && !isNodeChildOfStart(graph, assocNode, node)) {
+                        assocNode = null;
+                    }
+                }
+
+                //Handle Marker nodes
+                if (node.attribute_name.equals(NsiliConstants.NSIL_IR)) {
+                    addNsilIRAttribute(metacard);
+                }
+            } else if (node.node_type == NodeType.RECORD_NODE) {
+                //Nothing to process from record node
+            } else if (parentEntity != null &&
+                    node.node_type == NodeType.ATTRIBUTE_NODE &&
+                    node.value != null) {
+                switch (parentEntity.attribute_name) {
+                case NsiliConstants.NSIL_APPROVAL:
+                    addNsilApprovalAttribute(metacard, node);
+                    break;
+                case NsiliConstants.NSIL_CARD:
+                    if (assocNode != null) {
+                        addNsilAssociation(associatedCards, node);
+                    } else {
+                        addNsilCardAttribute(metacard, node);
+                    }
+                    break;
+                case NsiliConstants.NSIL_SECURITY:
+                    addNsilSecurityAttribute(security, node);
+                    break;
+                case NsiliConstants.NSIL_METADATA_SECURITY:
+                    addNsilSecurityAttribute(security, node);
+                    break;
+                case NsiliConstants.NSIL_COMMON:
+                    addNsilCommonAttribute(metacard, node);
+                    break;
+                case NsiliConstants.NSIL_COVERAGE:
+                    addNsilCoverageAttribute(metacard, node);
+                    break;
+                case NsiliConstants.NSIL_CXP:
+                    addNsilCxpAttribute(metacard, node);
+                    break;
+                case NsiliConstants.NSIL_EXPLOITATION_INFO:
+                    addNsilExploitationInfoAttribute(metacard, node);
+                    break;
+                case NsiliConstants.NSIL_FILE:
+                    addNsilFileAttribute(metacard, node);
+                    break;
+                case NsiliConstants.NSIL_GMTI:
+                    addNsilGmtiAttribute(metacard, node);
+                    break;
+                case NsiliConstants.NSIL_IMAGERY:
+                    addNsilImageryAttribute(metacard, node);
+                    break;
+                case NsiliConstants.NSIL_MESSAGE:
+                    addNsilMessageAttribute(metacard, node);
+                    break;
+                case NsiliConstants.NSIL_REPORT:
+                    addNsilReportAttribute(metacard, node);
+                    break;
+                case NsiliConstants.NSIL_RFI:
+                    addNsilRfiAttribute(metacard, node);
+                    break;
+                case NsiliConstants.NSIL_SDS:
+                    addNsilSdsAttribute(metacard, node);
+                    break;
+                case NsiliConstants.NSIL_STREAM:
+                    addNsilStreamAttribute(metacard, node);
+                    break;
+                case NsiliConstants.NSIL_TASK:
+                    addNsilTaskAttribute(metacard, node);
+                    break;
+                case NsiliConstants.NSIL_TDL:
+                    addNsilTdlAttribute(metacard, node);
+                    break;
+                case NsiliConstants.NSIL_VIDEO:
+                    addNsilVideoAttribute(metacard, node);
+                    break;
+                default:
+                    break;
+                }
+            }
+        }
+
+        addMergedSecurityDescriptor(metacard, security);
+        setTopLevelMetacardAttributes(metacard);
+
+        //Add associated data
+        if (!associatedCards.isEmpty()) {
+            boolean firstAssoc = true;
+            AttributeImpl attribute = null;
+            for (Serializable association : associatedCards) {
+                if (firstAssoc) {
+                    attribute = new AttributeImpl(NsiliMetacardType.ASSOCIATIONS, association);
+                    metacard.setAttribute(attribute);
+                    firstAssoc = false;
+                } else {
+                    attribute.addValue(association);
+                }
+            }
+
+        }
+
+        return metacard;
+    }
+
+    /**
+     * Determines if the end node is a child of the start node.
+     *
+     * @param graph - The complete graph.
+     * @param start - Starting node.
+     * @param end   - Child node to check
+     * @return true if the end node is a child of the start node in the provided graph.
+     */
+    public static boolean isNodeChildOfStart(DirectedAcyclicGraph<Node, Edge> graph, Node start,
+            Node end) {
+        boolean endNodeInTree = false;
+        DepthFirstIterator<Node, Edge> depthFirstIterator = new DepthFirstIterator<>(graph, start);
+        while (depthFirstIterator.hasNext()) {
+            Node currNode = depthFirstIterator.next();
+            if (currNode.id == end.id) {
+                endNodeInTree = true;
+            }
+        }
+        return endNodeInTree;
+    }
+
+    public static void addNsilApprovalAttribute(MetacardImpl metacard, Node node) {
+        switch (node.attribute_name) {
+        case NsiliConstants.APPROVED_BY:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.APPROVAL_BY,
+                    getString(node.value)));
+            break;
+        case NsiliConstants.DATE_TIME_MODIFIED:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.APPROVAL_DATETIME_MODIFIED,
+                    convertDate(node.value)));
+            break;
+        case NsiliConstants.STATUS:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.APPROVAL_STATUS,
+                    convertApprovalStatus(node.value)));
+            break;
+        default:
+            break;
+        }
+    }
+
+    public static void addNsilCardAttribute(MetacardImpl metacard, Node node) {
+        switch (node.attribute_name) {
+        case NsiliConstants.IDENTIFIER:
+            metacard.setId(getString(node.value));
+            break;
+        case NsiliConstants.SOURCE_DATE_TIME_MODIFIED:
+            Date cardDate = convertDate(node.value);
+            metacard.setCreatedDate(cardDate);
+            break;
+        case NsiliConstants.DATE_TIME_MODIFIED:
+            metacard.setModifiedDate(convertDate(node.value));
+            break;
+        case NsiliConstants.PUBLISHER:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.PUBLISHER,
+                    getString(node.value)));
+            break;
+        case NsiliConstants.SOURCE_LIBRARY:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.SOURCE_LIBRARY,
+                    getString(node.value)));
+            break;
+        default:
+            break;
+        }
+    }
+
+    public static void addNsilCommonAttribute(MetacardImpl metacard, Node node) {
+        switch (node.attribute_name) {
+        case NsiliConstants.DESCRIPTION_ABSTRACT:
+            metacard.setDescription(getString(node.value));
+            break;
+        case NsiliConstants.IDENTIFIER_MISSION:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.IDENTIFIER_MISSION,
+                    getString(node.value)));
+            break;
+        case NsiliConstants.IDENTIFIER_UUID:
+            metacard.setId(getString(node.value));
+            break;
+        case NsiliConstants.IDENTIFIER_JC3IEDM:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.ID_JC3IEDM,
+                    getLong(node.value)));
+            break;
+        case NsiliConstants.LANGUAGE:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.LANGUAGE,
+                    getString(node.value)));
+            break;
+        case NsiliConstants.SOURCE:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.SOURCE,
+                    getString(node.value)));
+            break;
+        case NsiliConstants.SUBJECT_CATEGORY_TARGET:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.SUBJECT_CATEGORY_TARGET,
+                    getString(node.value)));
+            break;
+        case NsiliConstants.TARGET_NUMBER:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.TARGET_NUMBER, getString(
+                    node.value)));
+            break;
+        case NsiliConstants.TYPE:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.PRODUCT_TYPE,
+                    convertProductType(node.value)));
+            break;
+        default:
+            break;
+        }
+    }
+
+    public static void addNsilCoverageAttribute(MetacardImpl metacard, Node node) {
+        switch (node.attribute_name) {
+        case NsiliConstants.SPATIAL_COUNTRY_CODE:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.COUNTRY_CODE, getString(
+                    node.value)));
+            break;
+        case NsiliConstants.SPATIAL_GEOGRAPHIC_REF_BOX:
+            metacard.setLocation(convertShape(node.value));
+            break;
+        case NsiliConstants.TEMPORAL_START:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.START_DATETIME,
+                    convertDate(node.value)));
+            break;
+        case NsiliConstants.TEMPORAL_END:
+            Date temporalEnd = convertDate(node.value);
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.END_DATETIME,
+                    temporalEnd));
+            metacard.setEffectiveDate(temporalEnd);
+            break;
+        default:
+            break;
+        }
+    }
+
+    public static void addNsilCxpAttribute(MetacardImpl metacard, Node node) {
+        metacard.setType(new NsiliCxpMetacardType());
+        metacard.setContentTypeName(NsiliProductType.COLLECTION_EXPLOITATION_PLAN.toString());
+
+        switch (node.attribute_name) {
+        case NsiliConstants.STATUS:
+            metacard.setAttribute(new AttributeImpl(NsiliCxpMetacardType.STATUS,
+                    convertCxpStatus(node.value)));
+            break;
+        default:
+            break;
+        }
+    }
+
+    public static void addNsilIRAttribute(MetacardImpl metacard) {
+        metacard.setType(new NsiliIRMetacardType());
+    }
+
+    public static void addNsilExploitationInfoAttribute(MetacardImpl metacard, Node node) {
+        switch (node.attribute_name) {
+        case NsiliConstants.DESCRIPTION:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.EXPLOITATION_DESCRIPTION,
+                    getString(node.value)));
+            break;
+        case NsiliConstants.LEVEL:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.EXPLOITATION_LEVEL,
+                    getShort(node.value)));
+            break;
+        case NsiliConstants.AUTO_GENERATED:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.EXPLOITATION_AUTO_GEN,
+                    node.value.extract_boolean()));
+            break;
+        case NsiliConstants.SUBJ_QUALITY_CODE:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.EXPLOITATION_SUBJ_QUAL_CODE,
+                    convertExplSubQualCd(node.value)));
+            break;
+        default:
+            break;
+        }
+    }
+
+    public static void addNsilFileAttribute(MetacardImpl metacard, Node node) {
+
+        switch (node.attribute_name) {
+        case NsiliConstants.ARCHIVED:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.FILE_ARCHIVED,
+                    node.value.extract_boolean()));
+            break;
+        case NsiliConstants.ARCHIVE_INFORMATION:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.FILE_ARCHIVED_INFO,
+                    getString(node.value)));
+            break;
+        case NsiliConstants.CREATOR:
+            metacard.setPointOfContact(getString(node.value));
+            break;
+        case NsiliConstants.DATE_TIME_DECLARED:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.PRODUCT_CREATE_TIME,
+                    convertDate(node.value)));
+            break;
+        case NsiliConstants.EXTENT:
+            metacard.setResourceSize(String.valueOf(convertMegabytesToBytes(node.value.extract_double())));
+            break;
+        case NsiliConstants.FORMAT:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.FILE_FORMAT, getString(
+                    node.value)));
+            break;
+        case NsiliConstants.FORMAT_VERSION:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.FILE_FORMAT_VER,
+                    getString(node.value)));
+            break;
+        case NsiliConstants.PRODUCT_URL:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.FILE_URL,
+                    getString(node.value)));
+            break;
+        case NsiliConstants.TITLE:
+            metacard.setTitle(getString(node.value));
+            break;
+        default:
+            break;
+        }
+    }
+
+    public static void addNsilGmtiAttribute(MetacardImpl metacard, Node node) {
+        //If any GMTI node is added, then we will set the MetacardType
+        metacard.setType(new NsiliGmtiMetacardType());
+        metacard.setContentTypeName(NsiliProductType.GMTI.toString());
+
+        switch (node.attribute_name) {
+        case NsiliConstants.IDENTIFIER_JOB:
+            metacard.setAttribute(new AttributeImpl(NsiliGmtiMetacardType.JOB_ID,
+                    node.value.extract_double()));
+            break;
+        case NsiliConstants.NUMBER_OF_TARGET_REPORTS:
+            metacard.setAttribute(new AttributeImpl(NsiliGmtiMetacardType.NUM_TARGET_REPORTS,
+                    getLong(node.value)));
+            break;
+        default:
+            break;
+        }
+    }
+
+    public static void addNsilImageryAttribute(MetacardImpl metacard, Node node) {
+        //If any Imagery attribute is added, set the card type
+        metacard.setType(new NsiliImageryMetacardType());
+        metacard.setContentTypeName(NsiliProductType.IMAGERY.toString());
+
+        switch (node.attribute_name) {
+        case NsiliConstants.CATEGORY:
+            metacard.setAttribute(new AttributeImpl(NsiliImageryMetacardType.IMAGERY_CATEGORY,
+                    convertImageCategory(node.value)));
+            break;
+        case NsiliConstants.CLOUD_COVER_PCT:
+            metacard.setAttribute(new AttributeImpl(NsiliImageryMetacardType.CLOUD_COVER_PCT,
+                    getShort(node.value)));
+            break;
+        case NsiliConstants.COMMENTS:
+            metacard.setAttribute(new AttributeImpl(NsiliImageryMetacardType.IMAGERY_COMMENTS,
+                    getString(node.value)));
+            break;
+        case NsiliConstants.DECOMPRESSION_TECHNIQUE:
+            metacard.setAttribute(new AttributeImpl(NsiliImageryMetacardType.DECOMPRESSION_TECHNIQUE,
+                    convertDecompressionTechnique(node.value)));
+            break;
+        case NsiliConstants.IDENTIFIER:
+            metacard.setAttribute(new AttributeImpl(NsiliImageryMetacardType.IMAGE_ID,
+                    getString(node.value)));
+            break;
+        case NsiliConstants.NIIRS:
+            metacard.setAttribute(new AttributeImpl(NsiliImageryMetacardType.NIIRS, getShort(
+                    node.value)));
+            break;
+        case NsiliConstants.NUMBER_OF_BANDS:
+            metacard.setAttribute(new AttributeImpl(NsiliImageryMetacardType.NUM_BANDS,
+                    getLong(node.value)));
+            break;
+        case NsiliConstants.NUMBER_OF_ROWS:
+            metacard.setAttribute(new AttributeImpl(NsiliImageryMetacardType.NUM_ROWS, getLong(
+                    node.value)));
+            break;
+        case NsiliConstants.NUMBER_OF_COLS:
+            metacard.setAttribute(new AttributeImpl(NsiliImageryMetacardType.NUM_COLS, getLong(
+                    node.value)));
+            break;
+        case NsiliConstants.TITLE:
+            metacard.setTitle(getString(node.value));
+            break;
+        default:
+            break;
+        }
+    }
+
+    public static void addNsilMessageAttribute(MetacardImpl metacard, Node node) {
+        metacard.setType(new NsiliMessageMetacardType());
+        metacard.setContentTypeName(NsiliProductType.MESSAGE.toString());
+
+        switch (node.attribute_name) {
+        case NsiliConstants.RECIPIENT:
+            metacard.setAttribute(new AttributeImpl(NsiliMessageMetacardType.RECIPIENT,
+                    getString(node.value)));
+            break;
+        case NsiliConstants.SUBJECT:
+            metacard.setAttribute(new AttributeImpl(NsiliMessageMetacardType.MESSAGE_SUBJECT,
+                    getString(node.value)));
+            break;
+        case NsiliConstants.MESSAGE_BODY:
+            metacard.setAttribute(new AttributeImpl(NsiliMessageMetacardType.MESSAGE_BODY,
+                    getString(node.value)));
+            break;
+        case NsiliConstants.MESSAGE_TYPE:
+            metacard.setAttribute(new AttributeImpl(NsiliMessageMetacardType.MESSAGE_TYPE,
+                    getString(node.value)));
+            break;
+        default:
+            break;
+        }
+    }
+
+    public static void addNsilReportAttribute(MetacardImpl metacard, Node node) {
+        metacard.setType(new NsiliReportMetacardType());
+        metacard.setContentTypeName(NsiliProductType.REPORT.toString());
+        switch (node.attribute_name) {
+        case NsiliConstants.ORIGINATORS_REQ_SERIAL_NUM:
+            metacard.setAttribute(new AttributeImpl(NsiliReportMetacardType.ORIGINATOR_REQ_SERIAL_NUM,
+                    getString(node.value)));
+            break;
+        case NsiliConstants.PRIORITY:
+            metacard.setAttribute(new AttributeImpl(NsiliReportMetacardType.PRIORITY,
+                    convertReportPriority(node.value)));
+            break;
+        case NsiliConstants.TYPE:
+            metacard.setAttribute(new AttributeImpl(NsiliReportMetacardType.TYPE,
+                    convertReportType(node.value)));
+            break;
+        default:
+            break;
+        }
+    }
+
+    public static void addNsilRfiAttribute(MetacardImpl metacard, Node node) {
+        metacard.setType(new NsiliRfiMetacardType());
+        metacard.setContentTypeName(NsiliProductType.RFI.toString());
+
+        switch (node.attribute_name) {
+        case NsiliConstants.FOR_ACTION:
+            metacard.setAttribute(new AttributeImpl(NsiliRfiMetacardType.FOR_ACTION, getString(
+                    node.value)));
+            break;
+        case NsiliConstants.FOR_INFORMATION:
+            metacard.setAttribute(new AttributeImpl(NsiliRfiMetacardType.FOR_INFORMATION,
+                    getString(node.value)));
+            break;
+        case NsiliConstants.SERIAL_NUMBER:
+            metacard.setAttribute(new AttributeImpl(NsiliRfiMetacardType.SERIAL_NUMBER,
+                    getString(node.value)));
+            break;
+        case NsiliConstants.STATUS:
+            metacard.setAttribute(new AttributeImpl(NsiliRfiMetacardType.STATUS,
+                    convertRfiStatus(node.value)));
+            break;
+        case NsiliConstants.WORKFLOW_STATUS:
+            metacard.setAttribute(new AttributeImpl(NsiliRfiMetacardType.WORKFLOW_STATUS,
+                    convertRfiWorkflowStatus(node.value)));
+            break;
+        default:
+            break;
+        }
+    }
+
+    public static void addNsilSdsAttribute(MetacardImpl metacard, Node node) {
+        metacard.setContentTypeName(NsiliProductType.SYSTEM_DEPLOYMENT_STATUS.toString());
+
+        switch (node.attribute_name) {
+        case NsiliConstants.OPERATIONAL_STATUS:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.SDS_OPERATIONAL_STATUS,
+                    convertSdsOpStatus(node.value)));
+            break;
+        default:
+            break;
+        }
+    }
+
+    public static void addNsilSecurityAttribute(NsiliSecurity security, Node node) {
+        switch (node.attribute_name) {
+        case NsiliConstants.POLICY:
+            String mergedPolicy = mergeSecurityPolicyString(security.getPolicy(),
+                    getString(node.value));
+            security.setPolicy(mergedPolicy);
+            break;
+        case NsiliConstants.RELEASABILITY:
+            String mergedReleasability = mergeReleasabilityString(security.getReleasability(),
+                    getString(node.value));
+            security.setReleasability(mergedReleasability);
+            break;
+        case NsiliConstants.CLASSIFICATION:
+            String classification = mergeClassificationString(security.getClassification(),
+                    getString(node.value));
+            security.setClassification(classification);
+            break;
+        default:
+            break;
+        }
+    }
+
+    public static void addNsilStreamAttribute(MetacardImpl metacard, Node node) {
+
+        switch (node.attribute_name) {
+        case NsiliConstants.ARCHIVED:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.STREAM_ARCHIVED,
+                    node.value.extract_boolean()));
+            break;
+        case NsiliConstants.ARCHIVE_INFORMATION:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.STREAM_ARCHIVAL_INFO,
+                    getString(node.value)));
+            break;
+        case NsiliConstants.CREATOR:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.STREAM_CREATOR,
+                    getString(node.value)));
+            break;
+        case NsiliConstants.DATE_TIME_DECLARED:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.STREAM_DATETIME_DECLARED,
+                    convertDate(node.value)));
+            break;
+        case NsiliConstants.STANDARD:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.STREAM_STANDARD,
+                    getString(node.value)));
+            break;
+        case NsiliConstants.STANDARD_VERSION:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.STREAM_STANDARD_VER,
+                    getString(node.value)));
+            break;
+        case NsiliConstants.SOURCE_URL:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.STREAM_SOURCE_URL,
+                    getString(node.value)));
+            break;
+        case NsiliConstants.PROGRAM_ID:
+            metacard.setAttribute(new AttributeImpl(NsiliMetacardType.STREAM_PROGRAM_ID,
+                    getShort(node.value)));
+            break;
+        default:
+            break;
+        }
+    }
+
+    public static void addNsilTaskAttribute(MetacardImpl metacard, Node node) {
+        metacard.setType(new NsiliTaskMetacardType());
+        metacard.setContentTypeName(NsiliProductType.TASK.toString());
+        switch (node.attribute_name) {
+        case NsiliConstants.COMMENTS:
+            metacard.setAttribute(new AttributeImpl(NsiliTaskMetacardType.COMMENTS, getString(node.value)));
+            break;
+        case NsiliConstants.STATUS:
+            metacard.setAttribute(new AttributeImpl(NsiliTaskMetacardType.STATUS,
+                    convertTaskStatus(node.value)));
+            break;
+        default:
+            break;
+        }
+    }
+
+    public static void addNsilTdlAttribute(MetacardImpl metacard, Node node) {
+        metacard.setType(new NsiliTdlMetacardType());
+        metacard.setContentTypeName(NsiliProductType.TDL_DATA.toString());
+
+        switch (node.attribute_name) {
+        case NsiliConstants.ACTIVITY:
+            metacard.setAttribute(new AttributeImpl(NsiliTdlMetacardType.ACTIVITY, getShort(
+                    node.value)));
+            break;
+
+        case NsiliConstants.MESSAGE_NUM:
+            metacard.setAttribute(new AttributeImpl(NsiliTdlMetacardType.MESSAGE_NUM,
+                    getString(node.value)));
+            break;
+        case NsiliConstants.PLATFORM:
+            metacard.setAttribute(new AttributeImpl(NsiliTdlMetacardType.PLATFORM, getShort(
+                    node.value)));
+            break;
+        case NsiliConstants.TRACK_NUM:
+            metacard.setAttribute(new AttributeImpl(NsiliTdlMetacardType.TRACK_NUM, getString(
+                    node.value)));
+            break;
+        default:
+            break;
+        }
+    }
+
+    public static void addNsilVideoAttribute(MetacardImpl metacard, Node node) {
+        metacard.setType(new NsiliVideoMetacardType());
+        metacard.setContentTypeName(NsiliProductType.VIDEO.toString());
+
+        switch (node.attribute_name) {
+        case NsiliConstants.AVG_BIT_RATE:
+            metacard.setAttribute(new AttributeImpl(NsiliVideoMetacardType.AVG_BIT_RATE,
+                    node.value.extract_double()));
+            break;
+        case NsiliConstants.CATEGORY:
+            metacard.setAttribute(new AttributeImpl(NsiliVideoMetacardType.CATEGORY,
+                    convertVideoCategory(node.value)));
+            break;
+        case NsiliConstants.ENCODING_SCHEME:
+            metacard.setAttribute(new AttributeImpl(NsiliVideoMetacardType.ENCODING_SCHEME,
+                    convertVideoEncodingScheme(node.value)));
+            break;
+        case NsiliConstants.FRAME_RATE:
+            metacard.setAttribute(new AttributeImpl(NsiliVideoMetacardType.FRAME_RATE,
+                    node.value.extract_double()));
+            break;
+        case NsiliConstants.NUMBER_OF_ROWS:
+            metacard.setAttribute(new AttributeImpl(NsiliVideoMetacardType.NUM_ROWS, getLong(
+                    node.value)));
+            break;
+        case NsiliConstants.NUMBER_OF_COLS:
+            metacard.setAttribute(new AttributeImpl(NsiliVideoMetacardType.NUM_COLS, getLong(
+                    node.value)));
+            break;
+        case NsiliConstants.METADATA_ENC_SCHEME:
+            metacard.setAttribute(new AttributeImpl(NsiliVideoMetacardType.METADATA_ENCODING_SCHEME,
+                    convertMetadataEncScheme(node.value)));
+            break;
+        case NsiliConstants.MISM_LEVEL:
+            metacard.setAttribute(new AttributeImpl(NsiliVideoMetacardType.MISM_LEVEL,
+                    getShort(node.value)));
+            break;
+        case NsiliConstants.SCANNING_MODE:
+            metacard.setAttribute(new AttributeImpl(NsiliVideoMetacardType.SCANNING_MODE,
+                    getString(node.value)));
+            break;
+        default:
+            break;
+        }
+    }
+
+    public static void addNsilAssociation(List<Serializable> associations, Node node) {
+        switch (node.attribute_name) {
+        case NsiliConstants.IDENTIFIER:
+            associations.add(getString(node.value));
+            break;
+        default:
+            break;
+        }
+    }
+
+    public static void addMergedSecurityDescriptor(MetacardImpl metacard,
+            NsiliSecurity security) {
+        metacard.setAttribute(new AttributeImpl(NsiliMetacardType.SECURITY_CLASSIFICATION,
+                security.getClassification()));
+        metacard.setAttribute(new AttributeImpl(NsiliMetacardType.SECURITY_POLICY,
+                security.getPolicy()));
+        metacard.setAttribute(new AttributeImpl(NsiliMetacardType.SECURITY_RELEASABILITY,
+                security.getReleasability()));
+    }
+
+    public static void setTopLevelMetacardAttributes(MetacardImpl metacard) {
+        //If file data available use that
+        Attribute fileProductURLAttr = metacard.getAttribute(NsiliMetacardType.FILE_URL);
+        if (fileProductURLAttr != null) {
+            metacard.setResourceURI(convertURI(fileProductURLAttr.getValue()
+                    .toString()));
+
+            Attribute fileFormatVerAttr =
+                    metacard.getAttribute(NsiliMetacardType.FILE_FORMAT_VER);
+            if (fileFormatVerAttr != null) {
+                metacard.setContentTypeVersion(fileFormatVerAttr.getValue()
+                        .toString());
+            }
+        } else {
+            //Else use stream info
+            Attribute streamURLAttr =
+                    metacard.getAttribute(NsiliMetacardType.STREAM_SOURCE_URL);
+            if (streamURLAttr != null) {
+                metacard.setResourceURI(convertURI(streamURLAttr.getValue()
+                        .toString()));
+
+                Attribute streamFormatVerAttr =
+                        metacard.getAttribute(NsiliMetacardType.STREAM_STANDARD_VER);
+                if (streamFormatVerAttr != null) {
+                    metacard.setContentTypeVersion(streamFormatVerAttr.getValue()
+                            .toString());
+                }
+            }
+        }
+
+        if (NsiliMessageMetacardType.class.getCanonicalName()
+                .equals(metacard.getMetacardType()
+                        .getClass()
+                        .getCanonicalName())) {
+            Attribute subjAttr =
+                    metacard.getAttribute(NsiliMessageMetacardType.MESSAGE_SUBJECT);
+            if (subjAttr != null) {
+                metacard.setTitle(subjAttr.getValue()
+                        .toString());
+            }
+
+            Attribute bodyAttr = metacard.getAttribute(NsiliMessageMetacardType.MESSAGE_BODY);
+            if (bodyAttr != null) {
+                metacard.setDescription(bodyAttr.getValue()
+                        .toString());
+            }
+
+            Attribute typeAttr = metacard.getAttribute(NsiliMessageMetacardType.MESSAGE_TYPE);
+            if (typeAttr != null) {
+                //Unset the version when we have a message
+                metacard.setContentTypeVersion(null);
+            }
+        } else if (NsiliVideoMetacardType.class.getCanonicalName()
+                .equals(metacard.getMetacardType()
+                        .getClass()
+                        .getCanonicalName())) {
+            Attribute encodingSchemeAttr =
+                    metacard.getAttribute(NsiliVideoMetacardType.ENCODING_SCHEME);
+            if (encodingSchemeAttr != null) {
+                //Unset the version as we don't know that here
+                metacard.setContentTypeVersion(null);
+            }
+        }
+
+        /// Content Type Name Fall Back
+        if(metacard.getContentTypeName() == null) {
+            metacard.setContentTypeName(NsiliProductType.DOCUMENT.toString());
+        }
+    }
+
+    public static Date convertDate(Any any) {
+        AbsTime absTime = AbsTimeHelper.extract(any);
+        org.codice.alliance.nsili.common.UCO.Date ucoDate = absTime.aDate;
+        org.codice.alliance.nsili.common.UCO.Time ucoTime = absTime.aTime;
+
+        DateTime dateTime = new DateTime((int) ucoDate.year,
+                (int) ucoDate.month,
+                (int) ucoDate.day,
+                (int) ucoTime.hour,
+                (int) ucoTime.minute,
+                (int) ucoTime.second,
+                0);
+        return dateTime.toDate();
+    }
+
+    public static NsiliProductType convertProductType(Any any) {
+        String productTypeStr = getString(any);
+        return NsiliProductType.fromSpecName(productTypeStr);
+    }
+
+    public static String convertShape(Any any) {
+        org.codice.alliance.nsili.common.UCO.Rectangle rectangle =
+                RectangleHelper.extract(any);
+        org.codice.alliance.nsili.common.UCO.Coordinate2d upperLeft =
+                rectangle.upper_left;
+        org.codice.alliance.nsili.common.UCO.Coordinate2d lowerRight =
+                rectangle.lower_right;
+
+        //UCO Specifies Coordinate2d.x = lat, Coordinate2d.y = lon
+        //WKT Uses Coordinate.x = lon, Coordinate.y = lat
+        //Need to swap x & y
+        Coordinate[] coordinates = new Coordinate[5];
+        GeometryFactory geometryFactory = new GeometryFactory();
+
+        Coordinate lowerLeftCoord = new Coordinate(upperLeft.y, lowerRight.x);
+        Coordinate upperLeftCoord = new Coordinate(upperLeft.y, upperLeft.x);
+        Coordinate upperRightCoord = new Coordinate(lowerRight.y, upperLeft.x);
+        Coordinate lowerRightCoord = new Coordinate(lowerRight.y, lowerRight.x);
+
+        coordinates[0] = lowerLeftCoord;
+        coordinates[1] = upperLeftCoord;
+        coordinates[2] = upperRightCoord;
+        coordinates[3] = lowerRightCoord;
+        coordinates[4] = lowerLeftCoord;
+
+        LinearRing shell = geometryFactory.createLinearRing(coordinates);
+        Geometry geom = new Polygon(shell, null, geometryFactory);
+
+        return WKT_WRITER.write(geom);
+    }
+
+    public static int convertMegabytesToBytes(Double megabytes) {
+        int bytes = 0;
+
+        if (megabytes != null) {
+            bytes = (int) (megabytes * MEGABYTE);
+        }
+
+        return bytes;
+    }
+
+    public static final URI convertURI(String uriStr) {
+        URI uri = null;
+
+        try {
+            uri = new URI(uriStr);
+        } catch (URISyntaxException e) {
+            LOGGER.warn("Unable to parse URI for metacard: " + uriStr, e);
+        }
+
+        return uri;
+    }
+
+    public static NsiliImageryType convertImageCategory(Any any) {
+        String imageryTypeStr = getString(any);
+        return NsiliImageryType.valueOf(imageryTypeStr);
+    }
+
+    public static NsiliImageryDecompressionTech convertDecompressionTechnique(Any any) {
+        String decompressionTechStr = getString(any);
+        return NsiliImageryDecompressionTech.valueOf(decompressionTechStr);
+    }
+
+    public static NsiliVideoCategoryType convertVideoCategory(Any any) {
+        String videoCategoryType = getString(any);
+        return NsiliVideoCategoryType.valueOf(videoCategoryType);
+    }
+
+    public static NsiliVideoEncodingScheme convertVideoEncodingScheme(Any any) {
+        String videoEncSchemeStr = getString(any);
+        return NsiliVideoEncodingScheme.fromSpecName(videoEncSchemeStr);
+    }
+
+    public static NsiliMetadataEncodingScheme convertMetadataEncScheme(Any any) {
+        String metadataEncSchemeStr = getString(any);
+        return NsiliMetadataEncodingScheme.valueOf(metadataEncSchemeStr);
+    }
+
+    public static NsiliCxpStatusType convertCxpStatus(Any any) {
+        String cxpStatusStr = getString(any);
+        return NsiliCxpStatusType.valueOf(cxpStatusStr);
+    }
+
+    public static NsiliRfiStatus convertRfiStatus(Any any) {
+        String rfiStatusStr = getString(any);
+        return NsiliRfiStatus.valueOf(rfiStatusStr);
+    }
+
+    public static NsiliRfiWorkflowStatus convertRfiWorkflowStatus(Any any) {
+        String rfiWorkflowStatusStr = getString(any);
+        return NsiliRfiWorkflowStatus.valueOf(rfiWorkflowStatusStr);
+    }
+
+    public static NsiliTaskStatus convertTaskStatus(Any any) {
+        String taskStatusStr = getString(any);
+        return NsiliTaskStatus.valueOf(taskStatusStr);
+    }
+
+    public static NsiliExploitationSubQualCode convertExplSubQualCd(Any any) {
+        String explSubQualCodeStr = getString(any);
+        return NsiliExploitationSubQualCode.valueOf(explSubQualCodeStr);
+    }
+
+    public static NsiliSdsOpStatus convertSdsOpStatus(Any any) {
+        String sdsOpStatusStr = getString(any);
+        return NsiliSdsOpStatus.fromSpecName(sdsOpStatusStr);
+    }
+
+    public static NsiliApprovalStatus convertApprovalStatus(Any any) {
+        String approvalStr = getString(any);
+        return NsiliApprovalStatus.fromSpecName(approvalStr);
+    }
+
+    public static NsiliReportPriority convertReportPriority(Any any) {
+        String reportPriorityStr = getString(any);
+        return NsiliReportPriority.valueOf(reportPriorityStr);
+    }
+
+    public static NsiliReportType convertReportType(Any any) {
+        String reportTypeStr = getString(any);
+        return NsiliReportType.valueOf(reportTypeStr);
+    }
+
+    public static String getString(Any any) {
+        if (any.type()
+                .kind() == TCKind.tk_wstring) {
+            return any.extract_wstring();
+        } else if (any.type()
+                .kind() == TCKind.tk_string) {
+            return any.extract_string();
+        }
+        return null;
+    }
+
+    public static Integer getLong(Any any) {
+        if (any.type()
+                .kind() == TCKind.tk_long) {
+            return any.extract_long();
+        } else if (any.type()
+                .kind() == TCKind.tk_ulong) {
+            return any.extract_ulong();
+        }
+        return null;
+    }
+
+    public static Short getShort(Any any) {
+        if (any.type()
+                .kind() == TCKind.tk_short) {
+            return any.extract_short();
+        } else if (any.type()
+                .kind() == TCKind.tk_ushort) {
+            return any.extract_ushort();
+        }
+        return null;
+    }
+
+    /**
+     * Merge 2 space separated security policies into a single list. Merge is done additively.
+     *
+     * @param policy1 - Initial list of policies.
+     * @param policy2 - Additional policies to add.
+     * @return Non-duplicated policies space separated.
+     */
+    public static String mergeSecurityPolicyString(String policy1, String policy2) {
+        if (policy1 == null && policy2 == null) {
+            return null;
+        } else if (policy1 != null && policy2 == null) {
+            return policy1;
+        } else if (policy1 == null && policy2 != null) {
+            return policy2;
+        }
+
+        Set<String> policyAttrs = new HashSet<>();
+        String[] policy1Arr = policy1.split(" ");
+        String[] policy2Arr = policy2.split(" ");
+
+        for (String policy : policy1Arr) {
+            policyAttrs.add(policy);
+        }
+
+        for (String policy : policy2Arr) {
+            policyAttrs.add(policy);
+        }
+
+        return collectionToString(policyAttrs);
+    }
+
+    /**
+     * Merges releasabilities. Merge is done subtractively, so most restrictive applies.
+     *
+     * @param releasability1 - Initial list of releasabilities.
+     * @param releasability2 - Releasabilities to merge.
+     * @return - Non-duplicated releasabilities space separated.
+     */
+    public static String mergeReleasabilityString(String releasability1, String releasability2) {
+        if (releasability1 == null) {
+            return releasability2;
+        } else if (releasability2 == null) {
+            return null;
+        }
+
+        Set<String> releasability = new HashSet<>();
+        String[] releasebility1Arr = releasability1.split(" ");
+        String[] releasability2Arr = releasability2.split(" ");
+        for (String release1 : releasebility1Arr) {
+            boolean found = false;
+            for (String release2 : releasability2Arr) {
+                if (release1.equalsIgnoreCase(releasability2)) {
+                    found = true;
+                    break;
+                }
+            }
+            if (found) {
+                releasability.add(release1);
+            }
+        }
+
+        return collectionToString(releasability);
+    }
+
+    /**
+     * Determines most restrictive classification and returns that.
+     *
+     * @param classification1 - Initial classification
+     * @param classification2 - Classification to check
+     * @return Most restrictive classification
+     */
+    public static String mergeClassificationString(String classification1, String classification2) {
+        NsiliClassification class1 = NsiliClassification.fromSpecName(classification1);
+        NsiliClassification class2 = NsiliClassification.fromSpecName(classification2);
+        NsiliClassificationComparator classificationComparator =
+                new NsiliClassificationComparator();
+
+        int comparison = classificationComparator.compare(class1, class2);
+        if (comparison <= 0) {
+            return classification1;
+        } else {
+            return classification2;
+        }
+    }
+
+    private static String collectionToString(Collection<String> collection) {
+        return String.join(" ", collection);
+    }
+
+    public static void logMetacard(Metacard metacard, String id) {
+        MetacardType metacardType = metacard.getMetacardType();
+        LOGGER.debug("{} : Metacard Type : " + metacardType.getClass()
+                .getCanonicalName(), id);
+        LOGGER.debug("{} : ID : " + metacard.getId(), id);
+        LOGGER.debug("{} : Title : " + metacard.getTitle(), id);
+        if (metacard instanceof MetacardImpl) {
+            LOGGER.debug("{} : Description : " + ((MetacardImpl) metacard).getDescription(), id);
+        }
+        LOGGER.debug("{} : Content Type Name : " + metacard.getContentTypeName(), id);
+        LOGGER.debug("{} : Content Type Version : " + metacard.getContentTypeVersion(), id);
+        LOGGER.debug("{} : Created Date : " + metacard.getCreatedDate(), id);
+        LOGGER.debug("{} : Effective Date : " + metacard.getEffectiveDate(), id);
+        LOGGER.debug("{} : Location : " + metacard.getLocation(), id);
+        LOGGER.debug("{} : SourceID : " + metacard.getSourceId(), id);
+        LOGGER.debug("{} : Modified Date : " + metacard.getModifiedDate(), id);
+        LOGGER.debug("{} : Resource URI : " + metacard.getResourceURI()
+                .toString(), id);
+
+        Set<AttributeDescriptor> descriptors = metacardType.getAttributeDescriptors();
+        for (AttributeDescriptor descriptor : descriptors) {
+            Attribute attribute = metacard.getAttribute(descriptor.getName());
+            if (attribute != null) {
+                if (attribute.getValues() != null) {
+                    String valueStr = getValueString(attribute.getValues());
+                    LOGGER.debug("{} :  " + descriptor.getName() + " : " +
+                            valueStr, id);
+                } else {
+                    LOGGER.debug("{} :  " + descriptor.getName() + " : " +
+                            attribute.getValue(), id);
+                }
+            }
+        }
+    }
+
+    private static String getValueString(Collection<Serializable> collection) {
+        return collection.stream()
+                .map(Object::toString)
+                .sorted()
+                .collect(Collectors.joining(", "));
+    }
+}

--- a/catalog/nsili/catalog-nsili-transformer/src/test/java/org/codice/alliance/nsili/transformer/TestDAGConverter.java
+++ b/catalog/nsili/catalog-nsili-transformer/src/test/java/org/codice/alliance/nsili/transformer/TestDAGConverter.java
@@ -1,0 +1,2378 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.transformer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.Serializable;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.GregorianCalendar;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.codice.alliance.nsili.common.NsiliApprovalStatus;
+import org.codice.alliance.nsili.common.NsiliCommonUtils;
+import org.codice.alliance.nsili.common.NsiliConstants;
+import org.codice.alliance.nsili.common.NsiliCxpMetacardType;
+import org.codice.alliance.nsili.common.NsiliCxpStatusType;
+import org.codice.alliance.nsili.common.NsiliExploitationSubQualCode;
+import org.codice.alliance.nsili.common.NsiliGmtiMetacardType;
+import org.codice.alliance.nsili.common.NsiliIRMetacardType;
+import org.codice.alliance.nsili.common.NsiliImageryDecompressionTech;
+import org.codice.alliance.nsili.common.NsiliImageryMetacardType;
+import org.codice.alliance.nsili.common.NsiliImageryType;
+import org.codice.alliance.nsili.common.NsiliMessageMetacardType;
+import org.codice.alliance.nsili.common.NsiliMetacardType;
+import org.codice.alliance.nsili.common.NsiliMetadataEncodingScheme;
+import org.codice.alliance.nsili.common.NsiliProductType;
+import org.codice.alliance.nsili.common.NsiliReportMetacardType;
+import org.codice.alliance.nsili.common.NsiliReportPriority;
+import org.codice.alliance.nsili.common.NsiliReportType;
+import org.codice.alliance.nsili.common.NsiliRfiMetacardType;
+import org.codice.alliance.nsili.common.NsiliRfiStatus;
+import org.codice.alliance.nsili.common.NsiliRfiWorkflowStatus;
+import org.codice.alliance.nsili.common.NsiliScanningMode;
+import org.codice.alliance.nsili.common.NsiliSdsOpStatus;
+import org.codice.alliance.nsili.common.NsiliTaskMetacardType;
+import org.codice.alliance.nsili.common.NsiliTaskStatus;
+import org.codice.alliance.nsili.common.NsiliTdlMetacardType;
+import org.codice.alliance.nsili.common.NsiliVideoCategoryType;
+import org.codice.alliance.nsili.common.NsiliVideoEncodingScheme;
+import org.codice.alliance.nsili.common.NsiliVideoMetacardType;
+import org.codice.alliance.nsili.common.UCO.AbsTime;
+import org.codice.alliance.nsili.common.UCO.AbsTimeHelper;
+import org.codice.alliance.nsili.common.UCO.DAG;
+import org.codice.alliance.nsili.common.UCO.Edge;
+import org.codice.alliance.nsili.common.UCO.Node;
+import org.codice.alliance.nsili.common.UCO.NodeType;
+import org.codice.alliance.nsili.common.UCO.RectangleHelper;
+import org.codice.alliance.nsili.common.UCO.Time;
+import org.jgrapht.experimental.dag.DirectedAcyclicGraph;
+import org.junit.Before;
+import org.junit.Test;
+import org.omg.CORBA.Any;
+import org.omg.CORBA.ORB;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.impl.MetacardImpl;
+
+public class TestDAGConverter {
+
+    private static final String CARD_ID = "Card ID";
+
+    private static final String SOURCE_PUBLISHER = "Source Publisher";
+
+    private static final String SOURCE_LIBRARY = "SourceLibrary";
+
+    private static final String ARCHIVE_INFORMATION = "Archive Information";
+
+    private static final Boolean STREAM_ARCHIVED = false;
+
+    private static final String STREAM_CREATOR = "Stream Creator";
+
+    private static final String STREAM_STANDARD = "STANAG4609";
+
+    private static final String STREAM_STANDARD_VER = "1.0";
+
+    private static final String STREAM_SOURCE_URL = "http://localhost:1234/stream";
+
+    private static final Short STREAM_PROGRAM_ID = 3;
+
+    private static final String CLASS_POLICY = "NATO/EU";
+
+    private static final String CLASS_CLASSIFICATION = "UNCLASSIFIED";
+
+    private static final String CLASS_RELEASABILITY = "NATO";
+
+    private static final String COM_DESCRIPTION_ABSTRACT = "Product Description";
+
+    private static final String COM_ID_MSN = "CX100";
+
+    private static final String COM_ID_UUID = UUID.randomUUID()
+            .toString();
+
+    private static final Integer COM_JC3ID = 1234;
+
+    private static final String COM_LANGUAGE = "eng";
+
+    private static final String COM_SOURCE = "TestSourceSystem";
+
+    private static final String COM_SUBJECT_CATEGORY_TARGET = "Airfields";
+
+    private static final String COM_TARGET_NUMBER = "123-456-7890";
+
+    private static final NsiliProductType COM_TYPE =
+            NsiliProductType.COLLECTION_EXPLOITATION_PLAN;
+
+    private static final String COVERAGE_COUNTRY_CD = "USA";
+
+    private static final Double UPPER_LEFT_LAT = 5.0;
+
+    private static final Double UPPER_LEFT_LON = 1.0;
+
+    private static final Double LOWER_RIGHT_LAT = 1.0;
+
+    private static final Double LOWER_RIGHT_LON = 5.0;
+
+    private static final String EXPLOITATION_DESC = "Exploitation Info Description";
+
+    private static final Short EXPLOITATION_LEVEL = 0;
+
+    private static final Boolean EXPLOITATION_AUTO_GEN = false;
+
+    private static final String EXPLOITATION_SUBJ_QUAL_CODE =
+            NsiliExploitationSubQualCode.GOOD.toString();
+
+    private static final String IMAGERY_CATEGORY = NsiliImageryType.VIS.toString();
+
+    private static final Short IMAGERY_CLOUD_COVER_PCT = 35;
+
+    private static final String IMAGERY_COMMENTS = "Imagery Comments";
+
+    private static final String IMAGERY_DECOMPRESSION_TECH =
+            NsiliImageryDecompressionTech.C1.toString();
+
+    private static final String IMAGERY_IDENTIFIER = "1234";
+
+    private static final Short IMAGERY_NIIRS = 2;
+
+    private static final Integer IMAGERY_NUM_BANDS = 5000;
+
+    private static final Integer IMAGERY_NUM_ROWS = 500;
+
+    private static final Integer IMAGERY_NUM_COLS = 400;
+
+    private static final String IMAGERY_TITLE = "Imagery Title";
+
+    private static final String WKT_LOCATION = "POLYGON ((1 1, 1 5, 5 5, 5 1, 1 1))";
+
+    private static final Boolean FILE_ARCHIVED = false;
+
+    private static final String FILE_ARCHIVE_INFO = "File Archive Info";
+
+    private static final String FILE_CREATOR = "File Creator";
+
+    private static final Double FILE_EXTENT = 25.5;
+
+    private static final String FILE_FORMAT = "JPEG";
+
+    private static final String FILE_FORMAT_VER = "1.0";
+
+    private static final String FILE_PRODUCT_URL = "http://localhost/file.jpg";
+
+    private static final String FILE_TITLE = "File Title";
+
+    private static final Double GMTI_JOB_ID = 2.3;
+
+    private static final Integer GMTI_TARGET_REPORTS = 2;
+
+    private static final String MESSAGE_RECIPIENT = "john@doe.com";
+
+    private static final String MESSAGE_SUBJECT = "Test Subject";
+
+    private static final String MESSAGE_BODY = "Test Message Body";
+
+    private static final String MESSAGE_TYPE = "XMPP";
+
+    private static final Double VIDEO_AVG_BIT_RATE = 22.5;
+
+    private static final String VIDEO_CATEGORY = NsiliVideoCategoryType.VIS.name();
+
+    private static final NsiliVideoEncodingScheme VIDEO_ENCODING_SCHEME =
+            NsiliVideoEncodingScheme.MPEG2;
+
+    private static final Double VIDEO_FRAME_RATE = 15.4;
+
+    private static final Integer VIDEO_NUM_ROWS = 500;
+
+    private static final Integer VIDEO_NUM_COLS = 400;
+
+    private static final String VIDEO_METADATA_ENC_SCHEME =
+            NsiliMetadataEncodingScheme.KLV.name();
+
+    private static final Short VIDEO_MISM_LEVEL = 4;
+
+    private static final String VIDEO_SCANNING_MODE = NsiliScanningMode.PROGRESSIVE.name();
+
+    private static final String REPORT_REQ_SERIAL_NUM = "112233";
+
+    private static final String REPORT_PRIORITY = NsiliReportPriority.FLASH.name();
+
+    private static final String REPORT_TYPE = NsiliReportType.MTIEXREP.name();
+
+    private static final Short TDL_ACTIVITY = 99;
+
+    private static final String TDL_MESSAGE_NUM = "J3.2";
+
+    private static final Short TDL_PLATFORM_NUM = 42;
+
+    private static final String TDL_TRACK_NUM = "AK320";
+
+    private static final String CXP_STATUS = NsiliCxpStatusType.CURRENT.name();
+
+    private static final String RFI_FOR_ACTION = "USAF";
+
+    private static final String RFI_FOR_INFORMATION = "USMC";
+
+    private static final String RFI_SERIAL_NUM = "123456";
+
+    private static final String RFI_STATUS = NsiliRfiStatus.APPROVED.name();
+
+    private static final String RFI_WORKFLOW_STATUS = NsiliRfiWorkflowStatus.ACCEPTED.name();
+
+    private static final String TASK_COMMENTS = "Task Comments";
+
+    private static final String TASK_STATUS = NsiliTaskStatus.INTERRUPTED.name();
+
+    private static final String SOURCE_ID = "myNsiliSource";
+
+    private static final Integer NUM_ASSOCIATIONS = 5;
+
+    private static final NsiliApprovalStatus APPROVAL_STATUS =
+            NsiliApprovalStatus.NOT_APPLICABLE;
+
+    private static final String APPROVED_BY = "ApprovedBy";
+
+    private static final NsiliSdsOpStatus SDS_OP_STATUS =
+            NsiliSdsOpStatus.LIMITED_OPERATIONAL;
+
+    private ORB orb;
+
+    private Calendar cal;
+
+    private static final boolean SHOULD_PRINT_CARD = false;
+
+    @Before
+    public void setUp() {
+        this.orb = ORB.init();
+
+        int year = 2016;
+        int month = 01;
+        int dayOfMonth = 29;
+        int hourOfDay = 17;
+        int minute = 05;
+        int second = 10;
+        cal = new GregorianCalendar(year, month, dayOfMonth, hourOfDay, minute, second);
+    }
+
+    /**
+     * Test the Imagery View DAG to Metacard
+     * <p>
+     * NSIL_PRODUCT
+     * NSIL_APPROVAL
+     * NSIL_CARD
+     * NSIL_FILE
+     * NSIL_STREAM
+     * NSIL_METADATASECURITY
+     * NSIL_RELATED_FILE
+     * NSIL_SECURITY
+     * NSIL_PART
+     * NSIL_SECURITY
+     * NSIL_COMMON
+     * NSIL_COVERAGE
+     * NSIL_EXPLOITATION_INFO
+     * NSIL_IMAGERY
+     * NSIL_ASSOCIATION
+     * NSIL_RELATION
+     * NSIL_SOURCE
+     * NSIL_CARD
+     * NSIL_DESTINATION
+     * NSIL_CARD
+     */
+    @Test
+    public void testImageryViewConversion() {
+        DAG imageryDAG = new DAG();
+        DirectedAcyclicGraph<Node, Edge> graph = new DirectedAcyclicGraph<>(Edge.class);
+
+        Node productNode = createRootNode();
+        graph.addVertex(productNode);
+
+        addCardNode(graph, productNode);
+        addFileNode(graph, productNode);
+        addMetadataSecurity(graph, productNode);
+        addSecurityNode(graph, productNode);
+        addImageryPart(graph, productNode);
+        addAssocationNode(graph, productNode);
+        addApprovalNode(graph, productNode);
+        addSdsNode(graph, productNode);
+
+        graph.addVertex(productNode);
+
+        NsiliCommonUtils.setUCOEdgeIds(graph);
+        NsiliCommonUtils.setUCOEdges(productNode, graph);
+        imageryDAG.edges = NsiliCommonUtils.getEdgeArrayFromGraph(graph);
+        imageryDAG.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
+
+        MetacardImpl metacard = DAGConverter.convertDAG(imageryDAG, SOURCE_ID);
+
+        if (SHOULD_PRINT_CARD) {
+            File file = new File("/tmp/output-imagery.txt");
+            if (file.exists()) {
+                file.delete();
+            }
+
+            try (PrintStream outStream = new PrintStream(file)) {
+                printMetacard(metacard, outStream);
+            } catch (IOException ioe) {
+                //Ignore the error
+            }
+        }
+
+        //Check top-level meta-card attributes
+        assertTrue(NsiliImageryMetacardType.class.getCanonicalName()
+                .equals(metacard.getMetacardType()
+                        .getClass()
+                        .getCanonicalName()));
+        assertTrue(FILE_TITLE.equals(metacard.getTitle()));
+        assertTrue(CARD_ID.equals(metacard.getId()));
+        assertTrue(NsiliProductType.IMAGERY.toString().equals(metacard.getContentTypeName()));
+        assertTrue(FILE_FORMAT_VER.equals(metacard.getContentTypeVersion()));
+        assertTrue(metacard.getCreatedDate() != null);
+        assertTrue(metacard.getEffectiveDate() != null);
+        assertTrue(cal.getTime()
+                .equals(metacard.getModifiedDate()));
+        assertTrue(COM_DESCRIPTION_ABSTRACT.equals(metacard.getDescription()));
+        assertTrue(WKT_LOCATION.equals(metacard.getLocation()));
+        assertTrue(FILE_PRODUCT_URL.equals(metacard.getResourceURI()
+                .toString()));
+
+        checkCommonAttributes(metacard);
+        checkExploitationInfoAttributes(metacard);
+        checkImageryAttributes(metacard);
+        checkSecurityAttributes(metacard);
+        checkCoverageAttributes(metacard);
+        checkAssociationAttribute(metacard);
+        checkApprovalAttribute(metacard);
+        checkSdsAttribute(metacard);
+
+        DAGConverter.logMetacard(metacard, "123");
+    }
+
+    private void checkExploitationInfoAttributes(MetacardImpl metacard) {
+        Attribute exploitationDescAttr =
+                metacard.getAttribute(NsiliMetacardType.EXPLOITATION_DESCRIPTION);
+        assertNotNull(exploitationDescAttr);
+        assertTrue(EXPLOITATION_DESC.equals(exploitationDescAttr.getValue()
+                .toString()));
+
+        Attribute exploitationLevelAttr =
+                metacard.getAttribute(NsiliMetacardType.EXPLOITATION_LEVEL);
+        assertNotNull(exploitationLevelAttr);
+        assertTrue(EXPLOITATION_LEVEL == (short) exploitationLevelAttr.getValue());
+
+        Attribute exploitationAutoGenAttr =
+                metacard.getAttribute(NsiliMetacardType.EXPLOITATION_AUTO_GEN);
+        assertNotNull(exploitationAutoGenAttr);
+        assertTrue(EXPLOITATION_AUTO_GEN == (boolean) exploitationAutoGenAttr.getValue());
+
+        Attribute subjQualCodeAttr =
+                metacard.getAttribute(NsiliMetacardType.EXPLOITATION_SUBJ_QUAL_CODE);
+        assertNotNull(subjQualCodeAttr);
+        assertTrue(EXPLOITATION_SUBJ_QUAL_CODE.equals(subjQualCodeAttr.getValue()
+                .toString()));
+    }
+
+    private void checkStreamAttributes(MetacardImpl metacard) {
+        Attribute archivedAttr = metacard.getAttribute(NsiliMetacardType.STREAM_ARCHIVED);
+        assertNotNull(archivedAttr);
+        assertTrue(STREAM_ARCHIVED == (boolean) archivedAttr.getValue());
+
+        Attribute archivalInfoAttr =
+                metacard.getAttribute(NsiliMetacardType.STREAM_ARCHIVAL_INFO);
+        assertNotNull(archivalInfoAttr);
+        assertTrue(ARCHIVE_INFORMATION.equals(archivalInfoAttr.getValue()));
+
+        Attribute creatorAttr = metacard.getAttribute(NsiliMetacardType.STREAM_CREATOR);
+        assertNotNull(creatorAttr);
+        assertTrue(STREAM_CREATOR.equals(creatorAttr.getValue()
+                .toString()));
+
+        Attribute dateTimeDeclaredAttr =
+                metacard.getAttribute(NsiliMetacardType.STREAM_DATETIME_DECLARED);
+        assertNotNull(dateTimeDeclaredAttr);
+        assertTrue(cal.getTime()
+                .equals(dateTimeDeclaredAttr.getValue()));
+
+        Attribute programIdAttr = metacard.getAttribute(NsiliMetacardType.STREAM_PROGRAM_ID);
+        assertNotNull(programIdAttr);
+        assertTrue(STREAM_PROGRAM_ID == (short) programIdAttr.getValue());
+
+    }
+
+    private void checkCommonAttributes(MetacardImpl metacard) {
+        Attribute identifierMsnAttr =
+                metacard.getAttribute(NsiliMetacardType.IDENTIFIER_MISSION);
+        assertNotNull(identifierMsnAttr);
+        assertTrue(COM_ID_MSN.equals(identifierMsnAttr.getValue()
+                .toString()));
+
+        Attribute identifierJc3idmAttr = metacard.getAttribute(NsiliMetacardType.ID_JC3IEDM);
+        assertNotNull(identifierJc3idmAttr);
+        assertTrue(COM_JC3ID == (int) identifierJc3idmAttr.getValue());
+
+        Attribute languageAttr = metacard.getAttribute(NsiliMetacardType.LANGUAGE);
+        assertNotNull(languageAttr);
+        assertTrue(COM_LANGUAGE.equals(languageAttr.getValue()
+                .toString()));
+
+        Attribute stanagSourceAttr = metacard.getAttribute(NsiliMetacardType.SOURCE);
+        assertNotNull(stanagSourceAttr);
+        assertTrue(COM_SOURCE.equals(stanagSourceAttr.getValue()
+                .toString()));
+
+        Attribute subjCatTgtAttr =
+                metacard.getAttribute(NsiliMetacardType.SUBJECT_CATEGORY_TARGET);
+        assertNotNull(subjCatTgtAttr);
+        assertTrue(COM_SUBJECT_CATEGORY_TARGET.equals(subjCatTgtAttr.getValue()
+                .toString()));
+
+        Attribute tgtNumAttr = metacard.getAttribute(NsiliMetacardType.TARGET_NUMBER);
+        assertNotNull(tgtNumAttr);
+        assertTrue(COM_TARGET_NUMBER.equals(tgtNumAttr.getValue()
+                .toString()));
+
+        Attribute productTypeAttr = metacard.getAttribute(NsiliMetacardType.PRODUCT_TYPE);
+        assertNotNull(productTypeAttr);
+        assertTrue(COM_TYPE.name()
+                .equals(productTypeAttr.getValue()
+                        .toString()));
+    }
+
+    private void checkImageryAttributes(MetacardImpl metacard) {
+        Attribute cloudCoverPctAttr =
+                metacard.getAttribute(NsiliImageryMetacardType.CLOUD_COVER_PCT);
+        assertNotNull(cloudCoverPctAttr);
+        assertTrue(IMAGERY_CLOUD_COVER_PCT == (short) cloudCoverPctAttr.getValue());
+
+        Attribute imageryCommentsAttr =
+                metacard.getAttribute(NsiliImageryMetacardType.IMAGERY_COMMENTS);
+        assertNotNull(imageryCommentsAttr);
+        assertTrue(IMAGERY_COMMENTS.equals(imageryCommentsAttr.getValue()));
+
+        Attribute imageryCategoryAttr =
+                metacard.getAttribute(NsiliImageryMetacardType.IMAGERY_CATEGORY);
+        assertNotNull(imageryCategoryAttr);
+        assertTrue(IMAGERY_CATEGORY.equals(imageryCategoryAttr.getValue()
+                .toString()));
+
+        Attribute decompressionTechAttr =
+                metacard.getAttribute(NsiliImageryMetacardType.DECOMPRESSION_TECHNIQUE);
+        assertNotNull(decompressionTechAttr);
+        assertTrue(IMAGERY_DECOMPRESSION_TECH.equals(decompressionTechAttr.getValue()
+                .toString()));
+
+        Attribute imageIdAttr = metacard.getAttribute(NsiliImageryMetacardType.IMAGE_ID);
+        assertNotNull(imageIdAttr);
+        assertTrue(IMAGERY_IDENTIFIER.equals(imageIdAttr.getValue()
+                .toString()));
+
+        Attribute niirsAttr = metacard.getAttribute(NsiliImageryMetacardType.NIIRS);
+        assertNotNull(niirsAttr);
+        assertTrue(IMAGERY_NIIRS == (short) niirsAttr.getValue());
+
+        Attribute numBandsAttr = metacard.getAttribute(NsiliImageryMetacardType.NUM_BANDS);
+        assertNotNull(numBandsAttr);
+        assertTrue(IMAGERY_NUM_BANDS == (int) numBandsAttr.getValue());
+
+        Attribute numRowsAttr = metacard.getAttribute(NsiliImageryMetacardType.NUM_ROWS);
+        assertNotNull(numRowsAttr);
+        assertTrue(IMAGERY_NUM_ROWS == (int) numRowsAttr.getValue());
+
+        Attribute numColsAttr = metacard.getAttribute(NsiliImageryMetacardType.NUM_COLS);
+        assertNotNull(numColsAttr);
+        assertTrue(IMAGERY_NUM_COLS == (int) numColsAttr.getValue());
+
+        Attribute endDateTimeAttr =
+                metacard.getAttribute(NsiliImageryMetacardType.END_DATETIME);
+        assertNotNull(endDateTimeAttr);
+        assertTrue(cal.getTime()
+                .equals(endDateTimeAttr.getValue()));
+
+        assertNotNull(metacard.getResourceSize());
+        int size = Integer.parseInt(metacard.getResourceSize());
+        assertTrue(size == DAGConverter.convertMegabytesToBytes(FILE_EXTENT));
+    }
+
+    private void checkSecurityAttributes(MetacardImpl metacard) {
+        Attribute classificationAttr =
+                metacard.getAttribute(NsiliMetacardType.SECURITY_CLASSIFICATION);
+        assertNotNull(classificationAttr);
+        assertTrue(CLASS_CLASSIFICATION.equals(classificationAttr.getValue()
+                .toString()));
+
+        Attribute policyAttr = metacard.getAttribute(NsiliMetacardType.SECURITY_POLICY);
+        assertNotNull(policyAttr);
+        assertTrue(CLASS_POLICY.equals(policyAttr.getValue()
+                .toString()));
+
+        Attribute releasabilityAttr =
+                metacard.getAttribute(NsiliMetacardType.SECURITY_RELEASABILITY);
+        assertNotNull(releasabilityAttr);
+        assertTrue(CLASS_RELEASABILITY.equals(releasabilityAttr.getValue()
+                .toString()));
+    }
+
+    private void checkCoverageAttributes(MetacardImpl metacard) {
+        Attribute spatialCtryCodeAttr = metacard.getAttribute(NsiliMetacardType.COUNTRY_CODE);
+        assertNotNull(spatialCtryCodeAttr);
+        assertTrue(COVERAGE_COUNTRY_CD.equals(spatialCtryCodeAttr.getValue()
+                .toString()));
+
+        Attribute startTimeAttr = metacard.getAttribute(NsiliMetacardType.START_DATETIME);
+        assertNotNull(startTimeAttr);
+        assertTrue(cal.getTime()
+                .equals(startTimeAttr.getValue()));
+
+        Attribute endTimeAttr = metacard.getAttribute(NsiliMetacardType.END_DATETIME);
+        assertNotNull(endTimeAttr);
+        assertTrue(cal.getTime()
+                .equals(endTimeAttr.getValue()));
+    }
+
+    private void checkAssociationAttribute(MetacardImpl metacard) {
+        Attribute associationsAttr = metacard.getAttribute(NsiliMetacardType.ASSOCIATIONS);
+        assertNotNull(associationsAttr);
+        List<Serializable> associations = associationsAttr.getValues();
+        assertTrue(NUM_ASSOCIATIONS == associations.size());
+    }
+
+    private void checkApprovalAttribute(MetacardImpl metacard) {
+        Attribute approvedByAttr = metacard.getAttribute(NsiliMetacardType.APPROVAL_BY);
+        assertNotNull(approvedByAttr);
+        assertTrue(APPROVED_BY.equals(approvedByAttr.getValue()
+                .toString()));
+
+        Attribute modifiedAttr =
+                metacard.getAttribute(NsiliMetacardType.APPROVAL_DATETIME_MODIFIED);
+        assertNotNull(modifiedAttr);
+        assertTrue(cal.getTime()
+                .equals(modifiedAttr.getValue()));
+
+        Attribute statusAttr = metacard.getAttribute(NsiliMetacardType.APPROVAL_STATUS);
+        assertNotNull(statusAttr);
+        assertTrue(APPROVAL_STATUS.name()
+                .equals(statusAttr.getValue()
+                        .toString()));
+    }
+
+    private void checkSdsAttribute(MetacardImpl metacard) {
+        Attribute opStatusAttr =
+                metacard.getAttribute(NsiliMetacardType.SDS_OPERATIONAL_STATUS);
+        assertNotNull(opStatusAttr);
+        assertTrue(SDS_OP_STATUS.name()
+                .equals(opStatusAttr.getValue()
+                        .toString()));
+    }
+
+    /**
+     * Test the GMTI View DAG to Metacard
+     * <p>
+     * NSIL_PRODUCT
+     * NSIL_APPROVAL
+     * NSIL_CARD
+     * NSIL_FILE
+     * NSIL_STREAM
+     * NSIL_METADATASECURITY
+     * NSIL_RELATED_FILE
+     * NSIL_SECURITY
+     * NSIL_PART
+     * NSIL_SECURITY
+     * NSIL_COMMON
+     * NSIL_COVERAGE
+     * NSIL_EXPLOITATION_INFO
+     * NSIL_GMTI
+     * NSIL_ASSOCIATION
+     * NSIL_RELATION
+     * NSIL_SOURCE
+     * NSIL_CARD
+     * NSIL_DESTINATION
+     * NSIL_CARD
+     */
+    @Test
+    public void testGmtiViewConversion() {
+        DAG dag = new DAG();
+        DirectedAcyclicGraph<Node, Edge> graph = new DirectedAcyclicGraph<>(Edge.class);
+
+        Node productNode = createRootNode();
+        graph.addVertex(productNode);
+
+        addCardNode(graph, productNode);
+        addStreamNode(graph, productNode);
+        addMetadataSecurity(graph, productNode);
+        addSecurityNode(graph, productNode);
+        addGmtiPart(graph, productNode);
+
+        graph.addVertex(productNode);
+
+        NsiliCommonUtils.setUCOEdgeIds(graph);
+        NsiliCommonUtils.setUCOEdges(productNode, graph);
+        dag.edges = NsiliCommonUtils.getEdgeArrayFromGraph(graph);
+        dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
+
+        MetacardImpl metacard = DAGConverter.convertDAG(dag, SOURCE_ID);
+
+        if (SHOULD_PRINT_CARD) {
+            File file = new File("/tmp/output-gmti.txt");
+            if (file.exists()) {
+                file.delete();
+            }
+
+            try (PrintStream outStream = new PrintStream(file)) {
+                printMetacard(metacard, outStream);
+            } catch (IOException ioe) {
+                //Ignore the error
+            }
+        }
+
+        //Check top-level meta-card attributes
+        assertTrue(NsiliGmtiMetacardType.class.getCanonicalName()
+                .equals(metacard.getMetacardType()
+                        .getClass()
+                        .getCanonicalName()));
+        assertTrue(CARD_ID.equals(metacard.getId()));
+        assertTrue(NsiliProductType.GMTI.toString()
+                .equals(metacard.getContentTypeName()));
+        assertTrue(STREAM_STANDARD_VER.equals(metacard.getContentTypeVersion()));
+        assertTrue(metacard.getCreatedDate() != null);
+        assertTrue(metacard.getEffectiveDate() != null);
+        assertTrue(cal.getTime()
+                .equals(metacard.getModifiedDate()));
+        assertTrue(COM_DESCRIPTION_ABSTRACT.equals(metacard.getDescription()));
+        assertTrue(WKT_LOCATION.equals(metacard.getLocation()));
+        assertTrue(STREAM_SOURCE_URL.equals(metacard.getResourceURI()
+                .toString()));
+
+        checkCommonAttributes(metacard);
+        checkExploitationInfoAttributes(metacard);
+        checkStreamAttributes(metacard);
+        checkGmtiAttributes(metacard);
+        checkSecurityAttributes(metacard);
+        checkCoverageAttributes(metacard);
+    }
+
+    private void checkGmtiAttributes(MetacardImpl metacard) {
+        Attribute gmtiJobAttr = metacard.getAttribute(NsiliGmtiMetacardType.JOB_ID);
+        assertNotNull(gmtiJobAttr);
+        assertEquals(GMTI_JOB_ID, gmtiJobAttr.getValue());
+
+        Attribute numTgtAttr = metacard.getAttribute(NsiliGmtiMetacardType.NUM_TARGET_REPORTS);
+        assertNotNull(numTgtAttr);
+        assertTrue(GMTI_TARGET_REPORTS == (int) numTgtAttr.getValue());
+    }
+
+    /**
+     * Test the Message View DAG to Metacard
+     * <p>
+     * NSIL_PRODUCT
+     * NSIL_APPROVAL
+     * NSIL_CARD
+     * NSIL_FILE
+     * NSIL_STREAM
+     * NSIL_METADATASECURITY
+     * NSIL_RELATED_FILE
+     * NSIL_SECURITY
+     * NSIL_PART
+     * NSIL_SECURITY
+     * NSIL_COMMON
+     * NSIL_COVERAGE
+     * NSIL_EXPLOITATION_INFO
+     * NSIL_MESSAGE
+     * NSIL_ASSOCIATION
+     * NSIL_RELATION
+     * NSIL_SOURCE
+     * NSIL_CARD
+     * NSIL_DESTINATION
+     * NSIL_CARD
+     */
+    @Test
+    public void testMessageViewConversion() {
+        DAG dag = new DAG();
+        DirectedAcyclicGraph<Node, Edge> graph = new DirectedAcyclicGraph<>(Edge.class);
+
+        Node productNode = createRootNode();
+        graph.addVertex(productNode);
+
+        addCardNode(graph, productNode);
+        addFileNode(graph, productNode);
+        addStreamNode(graph, productNode);
+        addMetadataSecurity(graph, productNode);
+        addSecurityNode(graph, productNode);
+        addMessagePart(graph, productNode);
+
+        graph.addVertex(productNode);
+
+        NsiliCommonUtils.setUCOEdgeIds(graph);
+        NsiliCommonUtils.setUCOEdges(productNode, graph);
+        dag.edges = NsiliCommonUtils.getEdgeArrayFromGraph(graph);
+        dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
+
+        MetacardImpl metacard = DAGConverter.convertDAG(dag, SOURCE_ID);
+
+        if (SHOULD_PRINT_CARD) {
+            File file = new File("/tmp/output-message.txt");
+            if (file.exists()) {
+                file.delete();
+            }
+
+            try (PrintStream outStream = new PrintStream(file)) {
+                printMetacard(metacard, outStream);
+            } catch (IOException ioe) {
+                //Ignore the error
+            }
+        }
+
+        //Check top-level meta-card attributes
+        assertTrue(NsiliMessageMetacardType.class.getCanonicalName()
+                .equals(metacard.getMetacardType()
+                        .getClass()
+                        .getCanonicalName()));
+        assertTrue(MESSAGE_SUBJECT.equals(metacard.getTitle()));
+        assertTrue(CARD_ID.equals(metacard.getId()));
+        assertTrue(NsiliProductType.MESSAGE.toString().equals(metacard.getContentTypeName()));
+        assertNull(metacard.getContentTypeVersion());
+        assertTrue(metacard.getCreatedDate() != null);
+        assertTrue(metacard.getEffectiveDate() != null);
+        assertTrue(cal.getTime()
+                .equals(metacard.getModifiedDate()));
+        assertTrue(MESSAGE_BODY.equals(metacard.getDescription()));
+        assertTrue(WKT_LOCATION.equals(metacard.getLocation()));
+        assertTrue(FILE_PRODUCT_URL.equals(metacard.getResourceURI()
+                .toString()));
+
+        checkCommonAttributes(metacard);
+        checkExploitationInfoAttributes(metacard);
+        checkStreamAttributes(metacard);
+        checkMessageAttributes(metacard);
+        checkSecurityAttributes(metacard);
+        checkCoverageAttributes(metacard);
+    }
+
+    private void checkMessageAttributes(MetacardImpl metacard) {
+        Attribute messageRecipAttr = metacard.getAttribute(NsiliMessageMetacardType.RECIPIENT);
+        assertNotNull(messageRecipAttr);
+        assertTrue(MESSAGE_RECIPIENT.equals(messageRecipAttr.getValue()));
+
+        Attribute typeAttr = metacard.getAttribute(NsiliMessageMetacardType.MESSAGE_TYPE);
+        assertNotNull(typeAttr);
+        assertTrue(MESSAGE_TYPE.equals(typeAttr.getValue()
+                .toString()));
+    }
+
+    /**
+     * Test the Message View DAG to Metacard
+     * <p>
+     * NSIL_PRODUCT
+     * NSIL_APPROVAL
+     * NSIL_CARD
+     * NSIL_FILE
+     * NSIL_STREAM
+     * NSIL_METADATASECURITY
+     * NSIL_RELATED_FILE
+     * NSIL_SECURITY
+     * NSIL_PART
+     * NSIL_SECURITY
+     * NSIL_COMMON
+     * NSIL_COVERAGE
+     * NSIL_EXPLOITATION_INFO
+     * NSIL_VIDEO
+     * NSIL_ASSOCIATION
+     * NSIL_RELATION
+     * NSIL_SOURCE
+     * NSIL_CARD
+     * NSIL_DESTINATION
+     * NSIL_CARD
+     */
+    @Test
+    public void testVideoViewConversion() {
+        DAG dag = new DAG();
+        DirectedAcyclicGraph<Node, Edge> graph = new DirectedAcyclicGraph<>(Edge.class);
+
+        Node productNode = createRootNode();
+        graph.addVertex(productNode);
+
+        addCardNode(graph, productNode);
+        addFileNode(graph, productNode);
+        addStreamNode(graph, productNode);
+        addMetadataSecurity(graph, productNode);
+        addSecurityNode(graph, productNode);
+        addVideoPart(graph, productNode);
+
+        graph.addVertex(productNode);
+
+        NsiliCommonUtils.setUCOEdgeIds(graph);
+        NsiliCommonUtils.setUCOEdges(productNode, graph);
+        dag.edges = NsiliCommonUtils.getEdgeArrayFromGraph(graph);
+        dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
+
+        MetacardImpl metacard = DAGConverter.convertDAG(dag, SOURCE_ID);
+
+        if (SHOULD_PRINT_CARD) {
+            File file = new File("/tmp/output-video.txt");
+            if (file.exists()) {
+                file.delete();
+            }
+
+            try (PrintStream outStream = new PrintStream(file)) {
+                printMetacard(metacard, outStream);
+            } catch (IOException ioe) {
+                //Ignore the error
+            }
+        }
+
+        //Check top-level meta-card attributes
+        assertTrue(NsiliVideoMetacardType.class.getCanonicalName()
+                .equals(metacard.getMetacardType()
+                        .getClass()
+                        .getCanonicalName()));
+        assertTrue(FILE_TITLE.equals(metacard.getTitle()));
+        assertTrue(CARD_ID.equals(metacard.getId()));
+        assertTrue(NsiliProductType.VIDEO.toString().equals(metacard.getContentTypeName()));
+        assertNull(metacard.getContentTypeVersion());
+        assertTrue(metacard.getCreatedDate() != null);
+        assertTrue(metacard.getEffectiveDate() != null);
+        assertTrue(cal.getTime()
+                .equals(metacard.getModifiedDate()));
+        assertTrue(COM_DESCRIPTION_ABSTRACT.equals(metacard.getDescription()));
+        assertTrue(WKT_LOCATION.equals(metacard.getLocation()));
+        assertTrue(FILE_PRODUCT_URL.equals(metacard.getResourceURI()
+                .toString()));
+
+        checkCommonAttributes(metacard);
+        checkExploitationInfoAttributes(metacard);
+        checkStreamAttributes(metacard);
+        checkVideoAttributes(metacard);
+        checkSecurityAttributes(metacard);
+        checkCoverageAttributes(metacard);
+    }
+
+    @Test
+    public void testOnlyRootNodeDAG() {
+        DAG dag = new DAG();
+        DirectedAcyclicGraph<Node, Edge> graph = new DirectedAcyclicGraph<>(Edge.class);
+
+        //Create invalid root node
+        Node rootNode = createRootNode();
+        graph.addVertex(rootNode);
+
+        NsiliCommonUtils.setUCOEdgeIds(graph);
+        NsiliCommonUtils.setUCOEdges(rootNode, graph);
+        dag.edges = NsiliCommonUtils.getEdgeArrayFromGraph(graph);
+        dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
+
+        MetacardImpl metacard = DAGConverter.convertDAG(dag, SOURCE_ID);
+        assertNull(metacard.getTitle());
+    }
+
+    @Test
+    public void testRootNodeNotProduct() {
+        DAG dag = new DAG();
+        DirectedAcyclicGraph<Node, Edge> graph = new DirectedAcyclicGraph<>(Edge.class);
+
+        //Create invalid root node
+        Node rootNode = new Node(0,
+                NodeType.ROOT_NODE,
+                NsiliConstants.NSIL_APPROVAL,
+                orb.create_any());
+        graph.addVertex(rootNode);
+
+        Node attribNode = new Node(0, NodeType.ATTRIBUTE_NODE, NsiliConstants.NSIL_CARD, null);
+        graph.addVertex(attribNode);
+        graph.addEdge(rootNode, attribNode);
+
+        NsiliCommonUtils.setUCOEdgeIds(graph);
+        NsiliCommonUtils.setUCOEdges(rootNode, graph);
+        dag.edges = NsiliCommonUtils.getEdgeArrayFromGraph(graph);
+        dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
+
+        MetacardImpl metacard = DAGConverter.convertDAG(dag, SOURCE_ID);
+        assertNull(metacard.getTitle());
+    }
+
+    @Test
+    public void testAttributeWithNoValue() {
+        DAG dag = new DAG();
+        DirectedAcyclicGraph<Node, Edge> graph = new DirectedAcyclicGraph<>(Edge.class);
+
+        //Create invalid root node
+        Node rootNode = createRootNode();
+        graph.addVertex(rootNode);
+
+        Node entityNode = new Node(0,
+                NodeType.ENTITY_NODE,
+                NsiliConstants.NSIL_CARD,
+                orb.create_any());
+        graph.addVertex(entityNode);
+        graph.addEdge(rootNode, entityNode);
+
+        Node attrNode = new Node(0, NodeType.ATTRIBUTE_NODE, NsiliConstants.STATUS, null);
+        graph.addVertex(attrNode);
+        graph.addEdge(entityNode, attrNode);
+
+        NsiliCommonUtils.setUCOEdgeIds(graph);
+        NsiliCommonUtils.setUCOEdges(rootNode, graph);
+        dag.edges = NsiliCommonUtils.getEdgeArrayFromGraph(graph);
+        dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
+
+        MetacardImpl metacard = DAGConverter.convertDAG(dag, SOURCE_ID);
+        assertNull(metacard.getTitle());
+    }
+
+    @Test
+    public void testRecordNodePresent() {
+        DAG dag = new DAG();
+        DirectedAcyclicGraph<Node, Edge> graph = new DirectedAcyclicGraph<>(Edge.class);
+
+        //Create invalid root node
+        Node rootNode = createRootNode();
+        graph.addVertex(rootNode);
+
+        Node recordNode = new Node(0,
+                NodeType.RECORD_NODE,
+                NsiliConstants.NSIL_CARD,
+                orb.create_any());
+        graph.addVertex(recordNode);
+        graph.addEdge(rootNode, recordNode);
+
+        NsiliCommonUtils.setUCOEdgeIds(graph);
+        NsiliCommonUtils.setUCOEdges(rootNode, graph);
+        dag.edges = NsiliCommonUtils.getEdgeArrayFromGraph(graph);
+        dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
+
+        MetacardImpl metacard = DAGConverter.convertDAG(dag, SOURCE_ID);
+        assertNull(metacard.getTitle());
+    }
+
+    @Test
+    public void testEmptyDAG() {
+        DAG dag = new DAG();
+        MetacardImpl metacard = DAGConverter.convertDAG(dag, SOURCE_ID);
+        assertNull(metacard);
+    }
+
+    @Test
+    public void testDAGNoEdges() {
+        DAG dag = new DAG();
+        DirectedAcyclicGraph<Node, Edge> graph = new DirectedAcyclicGraph<>(Edge.class);
+
+        //Create invalid root node
+        Node rootNode = createRootNode();
+        graph.addVertex(rootNode);
+
+        dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
+
+        MetacardImpl metacard = DAGConverter.convertDAG(dag, SOURCE_ID);
+        assertNull(metacard);
+    }
+
+    @Test
+    public void testStartNodeOfEdgeNull() {
+        DAG dag = new DAG();
+        DirectedAcyclicGraph<Node, Edge> graph = new DirectedAcyclicGraph<>(Edge.class);
+
+        //Create invalid root node
+        Node rootNode = createRootNode();
+        graph.addVertex(rootNode);
+
+        Edge[] edges = new Edge[1];
+        Edge edge = new Edge(0, 1, "");
+        edges[0] = edge;
+        dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
+        dag.edges = edges;
+
+        MetacardImpl metacard = DAGConverter.convertDAG(dag, SOURCE_ID);
+        assertNull(metacard.getTitle());
+    }
+
+    @Test
+    public void testEndNodeOfEdgeNull() {
+        DAG dag = new DAG();
+        DirectedAcyclicGraph<Node, Edge> graph = new DirectedAcyclicGraph<>(Edge.class);
+
+        //Create invalid root node
+        Node rootNode = createRootNode();
+        graph.addVertex(rootNode);
+
+        Edge[] edges = new Edge[1];
+        Edge edge = new Edge(1, 2, "");
+        edges[0] = edge;
+        dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
+        dag.edges = edges;
+
+        MetacardImpl metacard = DAGConverter.convertDAG(dag, SOURCE_ID);
+        assertNull(metacard.getTitle());
+    }
+
+    private void checkVideoAttributes(MetacardImpl metacard) {
+        Attribute avgBitRateAttr = metacard.getAttribute(NsiliVideoMetacardType.AVG_BIT_RATE);
+        assertNotNull(avgBitRateAttr);
+        assertEquals(VIDEO_AVG_BIT_RATE, avgBitRateAttr.getValue());
+
+        Attribute categoryAttr = metacard.getAttribute(NsiliVideoMetacardType.CATEGORY);
+        assertNotNull(categoryAttr);
+        assertTrue(VIDEO_CATEGORY.equals(categoryAttr.getValue()
+                .toString()));
+
+        Attribute encodingSchemeAttr =
+                metacard.getAttribute(NsiliVideoMetacardType.ENCODING_SCHEME);
+        assertNotNull(encodingSchemeAttr);
+        assertTrue(VIDEO_ENCODING_SCHEME.name()
+                .equals(encodingSchemeAttr.getValue()
+                        .toString()));
+
+        Attribute frameRateAttr = metacard.getAttribute(NsiliVideoMetacardType.FRAME_RATE);
+        assertNotNull(frameRateAttr);
+        assertEquals(VIDEO_FRAME_RATE, frameRateAttr.getValue());
+
+        Attribute numRowsAttr = metacard.getAttribute(NsiliVideoMetacardType.NUM_ROWS);
+        assertNotNull(numRowsAttr);
+        assertTrue(VIDEO_NUM_ROWS == (int) numRowsAttr.getValue());
+
+        Attribute numColsAttr = metacard.getAttribute(NsiliVideoMetacardType.NUM_COLS);
+        assertNotNull(numColsAttr);
+        assertTrue(VIDEO_NUM_COLS == (int) numColsAttr.getValue());
+
+        Attribute metadataEncSchemeAttr =
+                metacard.getAttribute(NsiliVideoMetacardType.METADATA_ENCODING_SCHEME);
+        assertNotNull(metadataEncSchemeAttr);
+        assertTrue(VIDEO_METADATA_ENC_SCHEME.equals(metadataEncSchemeAttr.getValue()
+                .toString()));
+
+        Attribute mismLevelAttr = metacard.getAttribute(NsiliVideoMetacardType.MISM_LEVEL);
+        assertNotNull(mismLevelAttr);
+        assertTrue(VIDEO_MISM_LEVEL == (short) mismLevelAttr.getValue());
+
+        Attribute scanningModeAttr =
+                metacard.getAttribute(NsiliVideoMetacardType.SCANNING_MODE);
+        assertNotNull(scanningModeAttr);
+        assertTrue(VIDEO_SCANNING_MODE.equals(scanningModeAttr.getValue()
+                .toString()));
+    }
+
+    /**
+     * Test the Message View DAG to Metacard
+     * <p>
+     * NSIL_PRODUCT
+     * NSIL_APPROVAL
+     * NSIL_CARD
+     * NSIL_FILE
+     * NSIL_METADATASECURITY
+     * NSIL_RELATED_FILE
+     * NSIL_SECURITY
+     * NSIL_PART
+     * NSIL_SECURITY
+     * NSIL_COMMON
+     * NSIL_COVERAGE
+     * NSIL_EXPLOITATION_INFO
+     * NSIL_REPORT
+     * NSIL_ASSOCIATION
+     * NSIL_RELATION
+     * NSIL_SOURCE
+     * NSIL_CARD
+     * NSIL_DESTINATION
+     * NSIL_CARD
+     */
+    @Test
+    public void testReportViewConversion() {
+        DAG dag = new DAG();
+        DirectedAcyclicGraph<Node, Edge> graph = new DirectedAcyclicGraph<>(Edge.class);
+
+        Node productNode = createRootNode();
+        graph.addVertex(productNode);
+
+        addCardNode(graph, productNode);
+        addFileNode(graph, productNode);
+        addMetadataSecurity(graph, productNode);
+        addSecurityNode(graph, productNode);
+        addReportPart(graph, productNode);
+
+        graph.addVertex(productNode);
+
+        NsiliCommonUtils.setUCOEdgeIds(graph);
+        NsiliCommonUtils.setUCOEdges(productNode, graph);
+        dag.edges = NsiliCommonUtils.getEdgeArrayFromGraph(graph);
+        dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
+
+        MetacardImpl metacard = DAGConverter.convertDAG(dag, SOURCE_ID);
+
+        if (SHOULD_PRINT_CARD) {
+            File file = new File("/tmp/output-report.txt");
+            if (file.exists()) {
+                file.delete();
+            }
+
+            try (PrintStream outStream = new PrintStream(file)) {
+                printMetacard(metacard, outStream);
+            } catch (IOException ioe) {
+                //Ignore the error
+            }
+        }
+
+        //Check top-level meta-card attributes
+        assertTrue(NsiliReportMetacardType.class.getCanonicalName()
+                .equals(metacard.getMetacardType()
+                        .getClass()
+                        .getCanonicalName()));
+        assertTrue(FILE_TITLE.equals(metacard.getTitle()));
+        assertTrue(CARD_ID.equals(metacard.getId()));
+        assertTrue(NsiliProductType.REPORT.toString()
+                .equals(metacard.getContentTypeName()));
+        assertTrue(FILE_FORMAT_VER.equals(metacard.getContentTypeVersion()));
+        assertTrue(metacard.getCreatedDate() != null);
+        assertTrue(metacard.getEffectiveDate() != null);
+        assertTrue(cal.getTime()
+                .equals(metacard.getModifiedDate()));
+        assertTrue(COM_DESCRIPTION_ABSTRACT.equals(metacard.getDescription()));
+        assertTrue(WKT_LOCATION.equals(metacard.getLocation()));
+        assertTrue(FILE_PRODUCT_URL.equals(metacard.getResourceURI()
+                .toString()));
+
+        checkCommonAttributes(metacard);
+        checkExploitationInfoAttributes(metacard);
+        checkReportAttributes(metacard);
+        checkSecurityAttributes(metacard);
+        checkCoverageAttributes(metacard);
+    }
+
+    private void checkReportAttributes(MetacardImpl metacard) {
+        Attribute origReqSerialAttr =
+                metacard.getAttribute(NsiliReportMetacardType.ORIGINATOR_REQ_SERIAL_NUM);
+        assertNotNull(origReqSerialAttr);
+        assertTrue(REPORT_REQ_SERIAL_NUM.equals(origReqSerialAttr.getValue()
+                .toString()));
+
+        Attribute priorityAttr = metacard.getAttribute(NsiliReportMetacardType.PRIORITY);
+        assertNotNull(priorityAttr);
+        assertTrue(REPORT_PRIORITY.equals(priorityAttr.getValue()
+                .toString()));
+
+        Attribute typeAttr = metacard.getAttribute(NsiliReportMetacardType.TYPE);
+        assertNotNull(typeAttr);
+        assertTrue(REPORT_TYPE.equals(typeAttr.getValue()
+                .toString()));
+    }
+
+    /**
+     * Test the Message View DAG to Metacard
+     * <p>
+     * NSIL_PRODUCT
+     * NSIL_APPROVAL
+     * NSIL_CARD
+     * NSIL_STREAM
+     * NSIL_FILE
+     * NSIL_METADATASECURITY
+     * NSIL_RELATED_FILE
+     * NSIL_SECURITY
+     * NSIL_PART
+     * NSIL_SECURITY
+     * NSIL_COMMON
+     * NSIL_COVERAGE
+     * NSIL_EXPLOITATION_INFO
+     * NSIL_CXP
+     * NSIL_ASSOCIATION
+     * NSIL_RELATION
+     * NSIL_SOURCE
+     * NSIL_CARD
+     * NSIL_DESTINATION
+     * NSIL_CARD
+     */
+    @Test
+    public void testCCIRMCXPViewConversion() {
+        DAG dag = new DAG();
+        DirectedAcyclicGraph<Node, Edge> graph = new DirectedAcyclicGraph<>(Edge.class);
+
+        Node productNode = createRootNode();
+        graph.addVertex(productNode);
+
+        addCardNode(graph, productNode);
+        addFileNode(graph, productNode);
+        addMetadataSecurity(graph, productNode);
+        addSecurityNode(graph, productNode);
+        addCxpPart(graph, productNode);
+
+        graph.addVertex(productNode);
+
+        NsiliCommonUtils.setUCOEdgeIds(graph);
+        NsiliCommonUtils.setUCOEdges(productNode, graph);
+        dag.edges = NsiliCommonUtils.getEdgeArrayFromGraph(graph);
+        dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
+
+        MetacardImpl metacard = DAGConverter.convertDAG(dag, SOURCE_ID);
+
+        if (SHOULD_PRINT_CARD) {
+            File file = new File("/tmp/output-ccirm-cxp.txt");
+            if (file.exists()) {
+                file.delete();
+            }
+
+            try (PrintStream outStream = new PrintStream(file)) {
+                printMetacard(metacard, outStream);
+            } catch (IOException ioe) {
+                //Ignore the error
+            }
+        }
+
+        //Check top-level meta-card attributes
+        assertTrue(NsiliCxpMetacardType.class.getCanonicalName()
+                .equals(metacard.getMetacardType()
+                        .getClass()
+                        .getCanonicalName()));
+        assertTrue(FILE_TITLE.equals(metacard.getTitle()));
+        assertTrue(CARD_ID.equals(metacard.getId()));
+        assertTrue(NsiliProductType.COLLECTION_EXPLOITATION_PLAN.toString().equals(metacard.getContentTypeName()));
+        assertTrue(FILE_FORMAT_VER.equals(metacard.getContentTypeVersion()));
+        assertTrue(metacard.getCreatedDate() != null);
+        assertTrue(metacard.getEffectiveDate() != null);
+        assertTrue(cal.getTime()
+                .equals(metacard.getModifiedDate()));
+        assertTrue(COM_DESCRIPTION_ABSTRACT.equals(metacard.getDescription()));
+        assertTrue(WKT_LOCATION.equals(metacard.getLocation()));
+        assertTrue(FILE_PRODUCT_URL.equals(metacard.getResourceURI()
+                .toString()));
+
+        checkCommonAttributes(metacard);
+        checkExploitationInfoAttributes(metacard);
+        checkCxpAttributes(metacard);
+        checkSecurityAttributes(metacard);
+        checkCoverageAttributes(metacard);
+    }
+
+    private void checkCxpAttributes(MetacardImpl metacard) {
+        Attribute cxpAttr = metacard.getAttribute(NsiliCxpMetacardType.STATUS);
+        assertNotNull(cxpAttr);
+        assertTrue(CXP_STATUS.equals(cxpAttr.getValue()
+                .toString()));
+    }
+
+    /**
+     * Test the Message View DAG to Metacard
+     * <p>
+     * NSIL_PRODUCT
+     * NSIL_APPROVAL
+     * NSIL_CARD
+     * NSIL_STREAM
+     * NSIL_FILE
+     * NSIL_METADATASECURITY
+     * NSIL_RELATED_FILE
+     * NSIL_SECURITY
+     * NSIL_PART
+     * NSIL_SECURITY
+     * NSIL_COMMON
+     * NSIL_COVERAGE
+     * NSIL_EXPLOITATION_INFO
+     * NSIL_IR
+     * NSIL_ASSOCIATION
+     * NSIL_RELATION
+     * NSIL_SOURCE
+     * NSIL_CARD
+     * NSIL_DESTINATION
+     * NSIL_CARD
+     */
+    @Test
+    public void testCCIRMIRViewConversion() {
+        DAG dag = new DAG();
+        DirectedAcyclicGraph<Node, Edge> graph = new DirectedAcyclicGraph<>(Edge.class);
+
+        Node productNode = createRootNode();
+        graph.addVertex(productNode);
+
+        addCardNode(graph, productNode);
+        addFileNode(graph, productNode);
+        addMetadataSecurity(graph, productNode);
+        addSecurityNode(graph, productNode);
+        addIRPart(graph, productNode);
+
+        graph.addVertex(productNode);
+
+        NsiliCommonUtils.setUCOEdgeIds(graph);
+        NsiliCommonUtils.setUCOEdges(productNode, graph);
+        dag.edges = NsiliCommonUtils.getEdgeArrayFromGraph(graph);
+        dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
+
+        MetacardImpl metacard = DAGConverter.convertDAG(dag, SOURCE_ID);
+
+        if (SHOULD_PRINT_CARD) {
+            File file = new File("/tmp/output-ccirm-ir.txt");
+            if (file.exists()) {
+                file.delete();
+            }
+
+            try (PrintStream outStream = new PrintStream(file)) {
+                printMetacard(metacard, outStream);
+            } catch (IOException ioe) {
+                //Ignore the error
+            }
+        }
+
+        //Check top-level meta-card attributes
+        assertTrue(NsiliIRMetacardType.class.getCanonicalName()
+                .equals(metacard.getMetacardType()
+                        .getClass()
+                        .getCanonicalName()));
+        assertTrue(FILE_TITLE.equals(metacard.getTitle()));
+        assertTrue(CARD_ID.equals(metacard.getId()));
+        assertTrue(NsiliProductType.DOCUMENT.toString()
+                .equals(metacard.getContentTypeName()));
+        assertTrue(FILE_FORMAT_VER.equals(metacard.getContentTypeVersion()));
+        assertTrue(metacard.getCreatedDate() != null);
+        assertTrue(metacard.getEffectiveDate() != null);
+        assertTrue(cal.getTime()
+                .equals(metacard.getModifiedDate()));
+        assertTrue(COM_DESCRIPTION_ABSTRACT.equals(metacard.getDescription()));
+        assertTrue(WKT_LOCATION.equals(metacard.getLocation()));
+        assertTrue(FILE_PRODUCT_URL.equals(metacard.getResourceURI()
+                .toString()));
+
+        checkCommonAttributes(metacard);
+        checkExploitationInfoAttributes(metacard);
+        checkIRAttributes(metacard);
+        checkSecurityAttributes(metacard);
+        checkCoverageAttributes(metacard);
+    }
+
+    private void checkIRAttributes(MetacardImpl metacard) {
+        //NSIL_IR is a marker node type only, no attributes to check
+    }
+
+    /**
+     * Test the Message View DAG to Metacard
+     * <p>
+     * NSIL_PRODUCT
+     * NSIL_APPROVAL
+     * NSIL_CARD
+     * NSIL_STREAM
+     * NSIL_FILE
+     * NSIL_METADATASECURITY
+     * NSIL_RELATED_FILE
+     * NSIL_SECURITY
+     * NSIL_PART
+     * NSIL_SECURITY
+     * NSIL_COMMON
+     * NSIL_COVERAGE
+     * NSIL_EXPLOITATION_INFO
+     * NSIL_RFI
+     * NSIL_ASSOCIATION
+     * NSIL_RELATION
+     * NSIL_SOURCE
+     * NSIL_CARD
+     * NSIL_DESTINATION
+     * NSIL_CARD
+     */
+    @Test
+    public void testCCIRMRFIViewConversion() {
+        DAG dag = new DAG();
+        DirectedAcyclicGraph<Node, Edge> graph = new DirectedAcyclicGraph<>(Edge.class);
+
+        Node productNode = createRootNode();
+        graph.addVertex(productNode);
+
+        addCardNode(graph, productNode);
+        addFileNode(graph, productNode);
+        addMetadataSecurity(graph, productNode);
+        addSecurityNode(graph, productNode);
+        addRFIPart(graph, productNode);
+
+        graph.addVertex(productNode);
+
+        NsiliCommonUtils.setUCOEdgeIds(graph);
+        NsiliCommonUtils.setUCOEdges(productNode, graph);
+        dag.edges = NsiliCommonUtils.getEdgeArrayFromGraph(graph);
+        dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
+
+        MetacardImpl metacard = DAGConverter.convertDAG(dag, SOURCE_ID);
+
+        if (SHOULD_PRINT_CARD) {
+            File file = new File("/tmp/output-ccirm-rfi.txt");
+            if (file.exists()) {
+                file.delete();
+            }
+
+            try (PrintStream outStream = new PrintStream(file)) {
+                printMetacard(metacard, outStream);
+            } catch (IOException ioe) {
+                //Ignore the error
+            }
+        }
+
+        //Check top-level meta-card attributes
+        assertTrue(NsiliRfiMetacardType.class.getCanonicalName()
+                .equals(metacard.getMetacardType()
+                        .getClass()
+                        .getCanonicalName()));
+        assertTrue(FILE_TITLE.equals(metacard.getTitle()));
+        assertTrue(CARD_ID.equals(metacard.getId()));
+        assertTrue(NsiliProductType.RFI.toString().equals(metacard.getContentTypeName()));
+        assertTrue(FILE_FORMAT_VER.equals(metacard.getContentTypeVersion()));
+        assertTrue(metacard.getCreatedDate() != null);
+        assertTrue(metacard.getEffectiveDate() != null);
+        assertTrue(cal.getTime()
+                .equals(metacard.getModifiedDate()));
+        assertTrue(COM_DESCRIPTION_ABSTRACT.equals(metacard.getDescription()));
+        assertTrue(WKT_LOCATION.equals(metacard.getLocation()));
+        assertTrue(FILE_PRODUCT_URL.equals(metacard.getResourceURI()
+                .toString()));
+
+        checkCommonAttributes(metacard);
+        checkExploitationInfoAttributes(metacard);
+        checkRFIAttributes(metacard);
+        checkSecurityAttributes(metacard);
+        checkCoverageAttributes(metacard);
+    }
+
+    private void checkRFIAttributes(MetacardImpl metacard) {
+        Attribute forActionAttr = metacard.getAttribute(NsiliRfiMetacardType.FOR_ACTION);
+        assertNotNull(forActionAttr);
+        assertTrue(RFI_FOR_ACTION.equals(forActionAttr.getValue()
+                .toString()));
+
+        Attribute forInfoAttr = metacard.getAttribute(NsiliRfiMetacardType.FOR_INFORMATION);
+        assertNotNull(forInfoAttr);
+        assertTrue(RFI_FOR_INFORMATION.equals(forInfoAttr.getValue()
+                .toString()));
+
+        Attribute serialNumAttr = metacard.getAttribute(NsiliRfiMetacardType.SERIAL_NUMBER);
+        assertNotNull(serialNumAttr);
+        assertTrue(RFI_SERIAL_NUM.equals(serialNumAttr.getValue()
+                .toString()));
+
+        Attribute statusAttr = metacard.getAttribute(NsiliRfiMetacardType.STATUS);
+        assertNotNull(statusAttr);
+        assertTrue(RFI_STATUS.equals(statusAttr.getValue()
+                .toString()));
+
+        Attribute workflowStatusAttr =
+                metacard.getAttribute(NsiliRfiMetacardType.WORKFLOW_STATUS);
+        assertNotNull(workflowStatusAttr);
+        assertTrue(RFI_WORKFLOW_STATUS.equals(workflowStatusAttr.getValue()
+                .toString()));
+    }
+
+    /**
+     * Test the Message View DAG to Metacard
+     * <p>
+     * NSIL_PRODUCT
+     * NSIL_APPROVAL
+     * NSIL_CARD
+     * NSIL_STREAM
+     * NSIL_FILE
+     * NSIL_METADATASECURITY
+     * NSIL_RELATED_FILE
+     * NSIL_SECURITY
+     * NSIL_PART
+     * NSIL_SECURITY
+     * NSIL_COMMON
+     * NSIL_COVERAGE
+     * NSIL_EXPLOITATION_INFO
+     * NSIL_TASK
+     * NSIL_ASSOCIATION
+     * NSIL_RELATION
+     * NSIL_SOURCE
+     * NSIL_CARD
+     * NSIL_DESTINATION
+     * NSIL_CARD
+     */
+    @Test
+    public void testCCIRMTaskViewConversion() {
+        DAG dag = new DAG();
+        DirectedAcyclicGraph<Node, Edge> graph = new DirectedAcyclicGraph<>(Edge.class);
+
+        Node productNode = createRootNode();
+        graph.addVertex(productNode);
+
+        addCardNode(graph, productNode);
+        addFileNode(graph, productNode);
+        addMetadataSecurity(graph, productNode);
+        addSecurityNode(graph, productNode);
+        addTaskPart(graph, productNode);
+
+        graph.addVertex(productNode);
+
+        NsiliCommonUtils.setUCOEdgeIds(graph);
+        NsiliCommonUtils.setUCOEdges(productNode, graph);
+        dag.edges = NsiliCommonUtils.getEdgeArrayFromGraph(graph);
+        dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
+
+        MetacardImpl metacard = DAGConverter.convertDAG(dag, SOURCE_ID);
+
+        if (SHOULD_PRINT_CARD) {
+            File file = new File("/tmp/output-ccirm-task.txt");
+            if (file.exists()) {
+                file.delete();
+            }
+
+            try (PrintStream outStream = new PrintStream(file)) {
+                printMetacard(metacard, outStream);
+            } catch (IOException ioe) {
+                //Ignore the error
+            }
+        }
+
+        //Check top-level meta-card attributes
+        assertTrue(NsiliTaskMetacardType.class.getCanonicalName()
+                .equals(metacard.getMetacardType()
+                        .getClass()
+                        .getCanonicalName()));
+        assertTrue(FILE_TITLE.equals(metacard.getTitle()));
+        assertTrue(CARD_ID.equals(metacard.getId()));
+        assertTrue(NsiliProductType.TASK.toString().equals(metacard.getContentTypeName()));
+        assertTrue(FILE_FORMAT_VER.equals(metacard.getContentTypeVersion()));
+        assertTrue(metacard.getCreatedDate() != null);
+        assertTrue(metacard.getEffectiveDate() != null);
+        assertTrue(cal.getTime()
+                .equals(metacard.getModifiedDate()));
+        assertTrue(COM_DESCRIPTION_ABSTRACT.equals(metacard.getDescription()));
+        assertTrue(WKT_LOCATION.equals(metacard.getLocation()));
+        assertTrue(FILE_PRODUCT_URL.equals(metacard.getResourceURI()
+                .toString()));
+
+        checkCommonAttributes(metacard);
+        checkExploitationInfoAttributes(metacard);
+        checkTaskAttributes(metacard);
+        checkSecurityAttributes(metacard);
+        checkCoverageAttributes(metacard);
+    }
+
+    private void checkTaskAttributes(MetacardImpl metacard) {
+        Attribute commentAttr = metacard.getAttribute(NsiliTaskMetacardType.COMMENTS);
+        assertNotNull(commentAttr);
+        assertTrue(TASK_COMMENTS.equals(commentAttr.getValue()
+                .toString()));
+
+        Attribute statusAttr = metacard.getAttribute(NsiliTaskMetacardType.STATUS);
+        assertNotNull(statusAttr);
+        assertTrue(TASK_STATUS.equals(statusAttr.getValue()
+                .toString()));
+    }
+
+    /**
+     * Test the Message View DAG to Metacard
+     * <p>
+     * NSIL_PRODUCT
+     * NSIL_APPROVAL
+     * NSIL_CARD
+     * NSIL_STREAM
+     * NSIL_FILE
+     * NSIL_METADATASECURITY
+     * NSIL_RELATED_FILE
+     * NSIL_SECURITY
+     * NSIL_PART
+     * NSIL_SECURITY
+     * NSIL_COMMON
+     * NSIL_COVERAGE
+     * NSIL_EXPLOITATION_INFO
+     * NSIL_TDL
+     * NSIL_ASSOCIATION
+     * NSIL_RELATION
+     * NSIL_SOURCE
+     * NSIL_CARD
+     * NSIL_DESTINATION
+     * NSIL_CARD
+     */
+    @Test
+    public void testTdlViewConversion() {
+        DAG dag = new DAG();
+        DirectedAcyclicGraph<Node, Edge> graph = new DirectedAcyclicGraph<>(Edge.class);
+
+        Node productNode = createRootNode();
+        graph.addVertex(productNode);
+
+        addCardNode(graph, productNode);
+        addFileNode(graph, productNode);
+        addStreamNode(graph, productNode);
+        addMetadataSecurity(graph, productNode);
+        addSecurityNode(graph, productNode);
+        addTdlPart(graph, productNode);
+
+        graph.addVertex(productNode);
+
+        NsiliCommonUtils.setUCOEdgeIds(graph);
+        NsiliCommonUtils.setUCOEdges(productNode, graph);
+        dag.edges = NsiliCommonUtils.getEdgeArrayFromGraph(graph);
+        dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
+
+        MetacardImpl metacard = DAGConverter.convertDAG(dag, SOURCE_ID);
+
+        if (SHOULD_PRINT_CARD) {
+            File file = new File("/tmp/output-tdl.txt");
+            if (file.exists()) {
+                file.delete();
+            }
+
+            try (PrintStream outStream = new PrintStream(file)) {
+                printMetacard(metacard, outStream);
+            } catch (IOException ioe) {
+                //Ignore the error
+            }
+        }
+
+        //Check top-level meta-card attributes
+        assertTrue(NsiliTdlMetacardType.class.getCanonicalName()
+                .equals(metacard.getMetacardType()
+                        .getClass()
+                        .getCanonicalName()));
+        assertTrue(FILE_TITLE.equals(metacard.getTitle()));
+        assertTrue(CARD_ID.equals(metacard.getId()));
+        assertTrue(NsiliProductType.TDL_DATA.toString()
+                .equals(metacard.getContentTypeName()));
+        assertTrue(FILE_FORMAT_VER.equals(metacard.getContentTypeVersion()));
+        assertTrue(metacard.getCreatedDate() != null);
+        assertTrue(metacard.getEffectiveDate() != null);
+        assertTrue(cal.getTime()
+                .equals(metacard.getModifiedDate()));
+        assertTrue(COM_DESCRIPTION_ABSTRACT.equals(metacard.getDescription()));
+        assertTrue(WKT_LOCATION.equals(metacard.getLocation()));
+        assertTrue(FILE_PRODUCT_URL.equals(metacard.getResourceURI()
+                .toString()));
+
+        checkCommonAttributes(metacard);
+        checkExploitationInfoAttributes(metacard);
+        checkStreamAttributes(metacard);
+        checkTdlAttributes(metacard);
+        checkSecurityAttributes(metacard);
+        checkCoverageAttributes(metacard);
+    }
+
+    private void checkTdlAttributes(MetacardImpl metacard) {
+        Attribute activityAttr = metacard.getAttribute(NsiliTdlMetacardType.ACTIVITY);
+        assertNotNull(activityAttr);
+        assertTrue(TDL_ACTIVITY == (short) activityAttr.getValue());
+
+        Attribute msgNumAttr = metacard.getAttribute(NsiliTdlMetacardType.MESSAGE_NUM);
+        assertNotNull(msgNumAttr);
+        assertTrue(TDL_MESSAGE_NUM.equals(msgNumAttr.getValue()
+                .toString()));
+
+        Attribute platformNumAttr = metacard.getAttribute(NsiliTdlMetacardType.PLATFORM);
+        assertNotNull(platformNumAttr);
+        assertTrue(TDL_PLATFORM_NUM == (short) platformNumAttr.getValue());
+
+        Attribute trackNumAttr = metacard.getAttribute(NsiliTdlMetacardType.TRACK_NUM);
+        assertNotNull(trackNumAttr);
+        assertTrue(TDL_TRACK_NUM.equals(trackNumAttr.getValue()
+                .toString()));
+    }
+
+    private Node createRootNode() {
+        return new Node(0, NodeType.ROOT_NODE, NsiliConstants.NSIL_PRODUCT, orb.create_any());
+    }
+
+    private void addCardNode(DirectedAcyclicGraph<Node, Edge> graph, Node productNode) {
+        Any any = orb.create_any();
+        Node cardNode = new Node(0, NodeType.ENTITY_NODE, NsiliConstants.NSIL_CARD, any);
+        graph.addVertex(cardNode);
+        graph.addEdge(productNode, cardNode);
+
+        addStringAttribute(graph, cardNode, NsiliConstants.IDENTIFIER, CARD_ID);
+        addDateAttribute(graph, cardNode, NsiliConstants.SOURCE_DATE_TIME_MODIFIED);
+        addDateAttribute(graph, cardNode, NsiliConstants.DATE_TIME_MODIFIED);
+        addStringAttribute(graph, cardNode, NsiliConstants.PUBLISHER, SOURCE_PUBLISHER);
+        addStringAttribute(graph, cardNode, NsiliConstants.SOURCE_LIBRARY, SOURCE_LIBRARY);
+    }
+
+    private void addFileNode(DirectedAcyclicGraph<Node, Edge> graph, Node productNode) {
+        Any any = orb.create_any();
+        Node fileNode = new Node(0, NodeType.ENTITY_NODE, NsiliConstants.NSIL_FILE, any);
+        graph.addVertex(fileNode);
+        graph.addEdge(productNode, fileNode);
+
+        addBooleanAttribute(graph, fileNode, NsiliConstants.ARCHIVED, FILE_ARCHIVED);
+        addStringAttribute(graph,
+                fileNode,
+                NsiliConstants.ARCHIVE_INFORMATION,
+                FILE_ARCHIVE_INFO);
+        addStringAttribute(graph, fileNode, NsiliConstants.CREATOR, FILE_CREATOR);
+        addDateAttribute(graph, fileNode, NsiliConstants.DATE_TIME_DECLARED);
+        addDoubleAttribute(graph, fileNode, NsiliConstants.EXTENT, FILE_EXTENT);
+        addStringAttribute(graph, fileNode, NsiliConstants.FORMAT, FILE_FORMAT);
+        addStringAttribute(graph, fileNode, NsiliConstants.FORMAT_VERSION, FILE_FORMAT_VER);
+        addStringAttribute(graph, fileNode, NsiliConstants.PRODUCT_URL, FILE_PRODUCT_URL);
+        addStringAttribute(graph, fileNode, NsiliConstants.TITLE, FILE_TITLE);
+    }
+
+    private void addStreamNode(DirectedAcyclicGraph<Node, Edge> graph, Node productNode) {
+        Any any = orb.create_any();
+        Node streamNode = new Node(0, NodeType.ENTITY_NODE, NsiliConstants.NSIL_STREAM, any);
+        graph.addVertex(streamNode);
+        graph.addEdge(productNode, streamNode);
+
+        addBooleanAttribute(graph, streamNode, NsiliConstants.ARCHIVED, STREAM_ARCHIVED);
+        addStringAttribute(graph,
+                streamNode,
+                NsiliConstants.ARCHIVE_INFORMATION,
+                ARCHIVE_INFORMATION);
+        addStringAttribute(graph, streamNode, NsiliConstants.CREATOR, STREAM_CREATOR);
+        addDateAttribute(graph, streamNode, NsiliConstants.DATE_TIME_DECLARED);
+        addStringAttribute(graph, streamNode, NsiliConstants.STANDARD, STREAM_STANDARD);
+        addStringAttribute(graph,
+                streamNode,
+                NsiliConstants.STANDARD_VERSION,
+                STREAM_STANDARD_VER);
+        addStringAttribute(graph, streamNode, NsiliConstants.SOURCE_URL, STREAM_SOURCE_URL);
+        addShortAttribute(graph, streamNode, NsiliConstants.PROGRAM_ID, STREAM_PROGRAM_ID);
+    }
+
+    private void addMetadataSecurity(DirectedAcyclicGraph<Node, Edge> graph, Node productNode) {
+        Any any = orb.create_any();
+        Node metadataSecurityNode = new Node(0,
+                NodeType.ENTITY_NODE,
+                NsiliConstants.NSIL_METADATA_SECURITY,
+                any);
+        graph.addVertex(metadataSecurityNode);
+        graph.addEdge(productNode, metadataSecurityNode);
+
+        addStringAttribute(graph, metadataSecurityNode, NsiliConstants.POLICY, CLASS_POLICY);
+        addStringAttribute(graph,
+                metadataSecurityNode,
+                NsiliConstants.RELEASABILITY,
+                CLASS_RELEASABILITY);
+        addStringAttribute(graph,
+                metadataSecurityNode,
+                NsiliConstants.CLASSIFICATION,
+                CLASS_CLASSIFICATION);
+    }
+
+    private void addSecurityNode(DirectedAcyclicGraph<Node, Edge> graph, Node productNode) {
+        Any any = orb.create_any();
+        Node securityNode = new Node(0,
+                NodeType.ENTITY_NODE,
+                NsiliConstants.NSIL_SECURITY,
+                any);
+        graph.addVertex(securityNode);
+        graph.addEdge(productNode, securityNode);
+
+        addStringAttribute(graph, securityNode, NsiliConstants.POLICY, CLASS_POLICY);
+        addStringAttribute(graph,
+                securityNode,
+                NsiliConstants.RELEASABILITY,
+                CLASS_RELEASABILITY);
+        addStringAttribute(graph,
+                securityNode,
+                NsiliConstants.CLASSIFICATION,
+                CLASS_CLASSIFICATION);
+    }
+
+    private void addAssocationNode(DirectedAcyclicGraph<Node, Edge> graph, Node productNode) {
+        //First we create the NSIL_ASSOCATION
+        Any assocAny = orb.create_any();
+        Node associationNode = new Node(0,
+                NodeType.ENTITY_NODE,
+                NsiliConstants.NSIL_ASSOCIATION,
+                assocAny);
+        graph.addVertex(associationNode);
+        graph.addEdge(productNode, associationNode);
+
+        //Next create the NSIL_DESTINATION -- 1 per associated card
+        for (int i = 0; i < NUM_ASSOCIATIONS; i++) {
+            Any destAny = orb.create_any();
+            Node destinationNode = new Node(0,
+                    NodeType.ENTITY_NODE,
+                    NsiliConstants.NSIL_DESTINATION,
+                    destAny);
+            graph.addVertex(destinationNode);
+            graph.addEdge(associationNode, destinationNode);
+
+            Any cardAny = orb.create_any();
+            Node cardNode = new Node(0,
+                    NodeType.ENTITY_NODE,
+                    NsiliConstants.NSIL_CARD,
+                    cardAny);
+            graph.addVertex(cardNode);
+            graph.addEdge(destinationNode, cardNode);
+
+            addStringAttribute(graph,
+                    cardNode,
+                    NsiliConstants.IDENTIFIER,
+                    UUID.randomUUID()
+                            .toString());
+            addDateAttribute(graph, cardNode, NsiliConstants.SOURCE_DATE_TIME_MODIFIED);
+            addDateAttribute(graph, cardNode, NsiliConstants.DATE_TIME_MODIFIED);
+            addStringAttribute(graph, cardNode, NsiliConstants.PUBLISHER, SOURCE_PUBLISHER);
+            addStringAttribute(graph, cardNode, NsiliConstants.SOURCE_LIBRARY, SOURCE_LIBRARY);
+        }
+    }
+
+    private void addApprovalNode(DirectedAcyclicGraph<Node, Edge> graph, Node productNode) {
+        Any approvalAny = orb.create_any();
+        Node approvalNode = new Node(0,
+                NodeType.ENTITY_NODE,
+                NsiliConstants.NSIL_APPROVAL,
+                approvalAny);
+        graph.addVertex(approvalNode);
+        graph.addEdge(productNode, approvalNode);
+
+        addStringAttribute(graph, approvalNode, NsiliConstants.APPROVED_BY, APPROVED_BY);
+        addDateAttribute(graph, approvalNode, NsiliConstants.DATE_TIME_MODIFIED);
+        addStringAttribute(graph,
+                approvalNode,
+                NsiliConstants.STATUS,
+                APPROVAL_STATUS.getSpecName());
+    }
+
+    private void addSdsNode(DirectedAcyclicGraph<Node, Edge> graph, Node productNode) {
+        Any sdsAny = orb.create_any();
+        Node sdsNode = new Node(0, NodeType.ENTITY_NODE, NsiliConstants.NSIL_SDS, sdsAny);
+        graph.addVertex(sdsNode);
+        graph.addEdge(productNode, sdsNode);
+
+        addStringAttribute(graph,
+                sdsNode,
+                NsiliConstants.OPERATIONAL_STATUS,
+                SDS_OP_STATUS.getSpecName());
+    }
+
+    private Node addPartNode(DirectedAcyclicGraph<Node, Edge> graph, Node productNode) {
+        Any any = orb.create_any();
+        Node partNode = new Node(0, NodeType.ENTITY_NODE, NsiliConstants.NSIL_PART, any);
+        graph.addVertex(partNode);
+        graph.addEdge(productNode, partNode);
+        return partNode;
+    }
+
+    private void addImageryPart(DirectedAcyclicGraph<Node, Edge> graph, Node productNode) {
+        Node partNode1 = addPartNode(graph, productNode);
+        addSecurityNode(graph, partNode1);
+        addCommonNode(graph, partNode1);
+        addCoverageNode(graph, partNode1);
+
+        Node partNode2 = addPartNode(graph, productNode);
+        addSecurityNode(graph, partNode2);
+        addCommonNode(graph, partNode2);
+        addExpoloitationInfoNode(graph, partNode2);
+
+        Node partNode3 = addPartNode(graph, productNode);
+        addSecurityNode(graph, partNode3);
+        addCommonNode(graph, partNode3);
+        addImageryNode(graph, partNode3);
+    }
+
+    private void addGmtiPart(DirectedAcyclicGraph<Node, Edge> graph, Node productNode) {
+        Node partNode1 = addPartNode(graph, productNode);
+        addSecurityNode(graph, partNode1);
+        addCommonNode(graph, partNode1);
+        addCoverageNode(graph, partNode1);
+
+        Node partNode2 = addPartNode(graph, productNode);
+        addSecurityNode(graph, partNode2);
+        addCommonNode(graph, partNode2);
+        addExpoloitationInfoNode(graph, partNode2);
+
+        Node partNode3 = addPartNode(graph, productNode);
+        addSecurityNode(graph, partNode3);
+        addCommonNode(graph, partNode3);
+        addGmtiNode(graph, partNode3);
+    }
+
+    private void addMessagePart(DirectedAcyclicGraph<Node, Edge> graph, Node productNode) {
+        Node partNode1 = addPartNode(graph, productNode);
+        addSecurityNode(graph, partNode1);
+        addCommonNode(graph, partNode1);
+        addCoverageNode(graph, partNode1);
+
+        Node partNode2 = addPartNode(graph, productNode);
+        addSecurityNode(graph, partNode2);
+        addCommonNode(graph, partNode2);
+        addExpoloitationInfoNode(graph, partNode2);
+
+        Node partNode3 = addPartNode(graph, productNode);
+        addSecurityNode(graph, partNode3);
+        addCommonNode(graph, partNode3);
+        addMessageNode(graph, partNode3);
+    }
+
+    private void addVideoPart(DirectedAcyclicGraph<Node, Edge> graph, Node productNode) {
+        Node partNode1 = addPartNode(graph, productNode);
+        addSecurityNode(graph, partNode1);
+        addCommonNode(graph, partNode1);
+        addCoverageNode(graph, partNode1);
+
+        Node partNode2 = addPartNode(graph, productNode);
+        addSecurityNode(graph, partNode2);
+        addCommonNode(graph, partNode2);
+        addExpoloitationInfoNode(graph, partNode2);
+
+        Node partNode3 = addPartNode(graph, productNode);
+        addSecurityNode(graph, partNode3);
+        addCommonNode(graph, partNode3);
+        addVideoNode(graph, partNode3);
+    }
+
+    private void addReportPart(DirectedAcyclicGraph<Node, Edge> graph, Node productNode) {
+        Node partNode1 = addPartNode(graph, productNode);
+        addSecurityNode(graph, partNode1);
+        addCommonNode(graph, partNode1);
+        addCoverageNode(graph, partNode1);
+
+        Node partNode2 = addPartNode(graph, productNode);
+        addSecurityNode(graph, partNode2);
+        addCommonNode(graph, partNode2);
+        addExpoloitationInfoNode(graph, partNode2);
+
+        Node partNode3 = addPartNode(graph, productNode);
+        addSecurityNode(graph, partNode3);
+        addCommonNode(graph, partNode3);
+        addReportNode(graph, partNode3);
+    }
+
+    private void addTdlPart(DirectedAcyclicGraph<Node, Edge> graph, Node productNode) {
+        Node partNode1 = addPartNode(graph, productNode);
+        addSecurityNode(graph, partNode1);
+        addCommonNode(graph, partNode1);
+        addCoverageNode(graph, partNode1);
+
+        Node partNode2 = addPartNode(graph, productNode);
+        addSecurityNode(graph, partNode2);
+        addCommonNode(graph, partNode2);
+        addExpoloitationInfoNode(graph, partNode2);
+
+        Node partNode3 = addPartNode(graph, productNode);
+        addSecurityNode(graph, partNode3);
+        addCommonNode(graph, partNode3);
+        addTdlNode(graph, partNode3);
+    }
+
+    private void addCxpPart(DirectedAcyclicGraph<Node, Edge> graph, Node productNode) {
+        Node partNode1 = addPartNode(graph, productNode);
+        addSecurityNode(graph, partNode1);
+        addCommonNode(graph, partNode1);
+        addCoverageNode(graph, partNode1);
+
+        Node partNode2 = addPartNode(graph, productNode);
+        addSecurityNode(graph, partNode2);
+        addCommonNode(graph, partNode2);
+        addExpoloitationInfoNode(graph, partNode2);
+
+        Node partNode3 = addPartNode(graph, productNode);
+        addSecurityNode(graph, partNode3);
+        addCommonNode(graph, partNode3);
+        addCxpNode(graph, partNode3);
+    }
+
+    private void addIRPart(DirectedAcyclicGraph<Node, Edge> graph, Node productNode) {
+        Node partNode1 = addPartNode(graph, productNode);
+        addSecurityNode(graph, partNode1);
+        addCommonNode(graph, partNode1);
+        addCoverageNode(graph, partNode1);
+
+        Node partNode2 = addPartNode(graph, productNode);
+        addSecurityNode(graph, partNode2);
+        addCommonNode(graph, partNode2);
+        addExpoloitationInfoNode(graph, partNode2);
+
+        Node partNode3 = addPartNode(graph, productNode);
+        addSecurityNode(graph, partNode3);
+        addCommonNode(graph, partNode3);
+        addIRNode(graph, partNode3);
+    }
+
+    private void addRFIPart(DirectedAcyclicGraph<Node, Edge> graph, Node productNode) {
+        Node partNode1 = addPartNode(graph, productNode);
+        addSecurityNode(graph, partNode1);
+        addCommonNode(graph, partNode1);
+        addCoverageNode(graph, partNode1);
+
+        Node partNode2 = addPartNode(graph, productNode);
+        addSecurityNode(graph, partNode2);
+        addCommonNode(graph, partNode2);
+        addExpoloitationInfoNode(graph, partNode2);
+
+        Node partNode3 = addPartNode(graph, productNode);
+        addSecurityNode(graph, partNode3);
+        addCommonNode(graph, partNode3);
+        addRFINode(graph, partNode3);
+    }
+
+    private void addTaskPart(DirectedAcyclicGraph<Node, Edge> graph, Node productNode) {
+        Node partNode1 = addPartNode(graph, productNode);
+        addSecurityNode(graph, partNode1);
+        addCommonNode(graph, partNode1);
+        addCoverageNode(graph, partNode1);
+
+        Node partNode2 = addPartNode(graph, productNode);
+        addSecurityNode(graph, partNode2);
+        addCommonNode(graph, partNode2);
+        addExpoloitationInfoNode(graph, partNode2);
+
+        Node partNode3 = addPartNode(graph, productNode);
+        addSecurityNode(graph, partNode3);
+        addCommonNode(graph, partNode3);
+        addTaskNode(graph, partNode3);
+    }
+
+    private void addCommonNode(DirectedAcyclicGraph<Node, Edge> graph, Node parentNode) {
+        Any commonAny = orb.create_any();
+        Node commonNode = new Node(0,
+                NodeType.ENTITY_NODE,
+                NsiliConstants.NSIL_COMMON,
+                commonAny);
+        graph.addVertex(commonNode);
+        graph.addEdge(parentNode, commonNode);
+
+        addStringAttribute(graph,
+                commonNode,
+                NsiliConstants.DESCRIPTION_ABSTRACT,
+                COM_DESCRIPTION_ABSTRACT);
+        addStringAttribute(graph, commonNode, NsiliConstants.IDENTIFIER_MISSION, COM_ID_MSN);
+        addStringAttribute(graph, commonNode, NsiliConstants.IDENTIFIER_UUID, COM_ID_UUID);
+        addIntegerAttribute(graph, commonNode, NsiliConstants.IDENTIFIER_JC3IEDM, COM_JC3ID);
+        addStringAttribute(graph, commonNode, NsiliConstants.LANGUAGE, COM_LANGUAGE);
+        addStringAttribute(graph, commonNode, NsiliConstants.SOURCE, COM_SOURCE);
+        addStringAttribute(graph,
+                commonNode,
+                NsiliConstants.SUBJECT_CATEGORY_TARGET,
+                COM_SUBJECT_CATEGORY_TARGET);
+        addStringAttribute(graph, commonNode, NsiliConstants.TARGET_NUMBER, COM_TARGET_NUMBER);
+        addStringAttribute(graph, commonNode, NsiliConstants.TYPE, COM_TYPE.getSpecName());
+    }
+
+    private void addImageryNode(DirectedAcyclicGraph<Node, Edge> graph, Node parentNode) {
+        Any imageryAny = orb.create_any();
+        Node imageryNode = new Node(0,
+                NodeType.ENTITY_NODE,
+                NsiliConstants.NSIL_IMAGERY,
+                imageryAny);
+        graph.addVertex(imageryNode);
+        graph.addEdge(parentNode, imageryNode);
+
+        addStringAttribute(graph, imageryNode, NsiliConstants.CATEGORY, IMAGERY_CATEGORY);
+        addShortAttribute(graph,
+                imageryNode,
+                NsiliConstants.CLOUD_COVER_PCT,
+                IMAGERY_CLOUD_COVER_PCT);
+        addStringAttribute(graph, imageryNode, NsiliConstants.COMMENTS, IMAGERY_COMMENTS);
+        addStringAttribute(graph,
+                imageryNode,
+                NsiliConstants.DECOMPRESSION_TECHNIQUE,
+                IMAGERY_DECOMPRESSION_TECH);
+        addStringAttribute(graph, imageryNode, NsiliConstants.IDENTIFIER, IMAGERY_IDENTIFIER);
+        addShortAttribute(graph, imageryNode, NsiliConstants.NIIRS, IMAGERY_NIIRS);
+        addIntegerAttribute(graph,
+                imageryNode,
+                NsiliConstants.NUMBER_OF_BANDS,
+                IMAGERY_NUM_BANDS);
+        addIntegerAttribute(graph,
+                imageryNode,
+                NsiliConstants.NUMBER_OF_ROWS,
+                IMAGERY_NUM_ROWS);
+        addIntegerAttribute(graph,
+                imageryNode,
+                NsiliConstants.NUMBER_OF_COLS,
+                IMAGERY_NUM_COLS);
+        addStringAttribute(graph, imageryNode, NsiliConstants.TITLE, IMAGERY_TITLE);
+    }
+
+    private void addGmtiNode(DirectedAcyclicGraph<Node, Edge> graph, Node parentNode) {
+        Any gmtiAny = orb.create_any();
+        Node gmtiNode = new Node(0, NodeType.ENTITY_NODE, NsiliConstants.NSIL_GMTI, gmtiAny);
+        graph.addVertex(gmtiNode);
+        graph.addEdge(parentNode, gmtiNode);
+
+        addDoubleAttribute(graph, gmtiNode, NsiliConstants.IDENTIFIER_JOB, GMTI_JOB_ID);
+        addIntegerAttribute(graph,
+                gmtiNode,
+                NsiliConstants.NUMBER_OF_TARGET_REPORTS,
+                GMTI_TARGET_REPORTS);
+    }
+
+    private void addMessageNode(DirectedAcyclicGraph<Node, Edge> graph, Node parentNode) {
+        Any messageAny = orb.create_any();
+        Node messageNode = new Node(0,
+                NodeType.ENTITY_NODE,
+                NsiliConstants.NSIL_MESSAGE,
+                messageAny);
+        graph.addVertex(messageNode);
+        graph.addEdge(parentNode, messageNode);
+
+        addStringAttribute(graph, messageNode, NsiliConstants.RECIPIENT, MESSAGE_RECIPIENT);
+        addStringAttribute(graph, messageNode, NsiliConstants.SUBJECT, MESSAGE_SUBJECT);
+        addStringAttribute(graph, messageNode, NsiliConstants.MESSAGE_BODY, MESSAGE_BODY);
+        addStringAttribute(graph, messageNode, NsiliConstants.MESSAGE_TYPE, MESSAGE_TYPE);
+    }
+
+    private void addVideoNode(DirectedAcyclicGraph<Node, Edge> graph, Node parentNode) {
+        Any videoAny = orb.create_any();
+        Node videoNode = new Node(0,
+                NodeType.ENTITY_NODE,
+                NsiliConstants.NSIL_VIDEO,
+                videoAny);
+        graph.addVertex(videoNode);
+        graph.addEdge(parentNode, videoNode);
+
+        addDoubleAttribute(graph, videoNode, NsiliConstants.AVG_BIT_RATE, VIDEO_AVG_BIT_RATE);
+        addStringAttribute(graph, videoNode, NsiliConstants.CATEGORY, VIDEO_CATEGORY);
+        addStringAttribute(graph,
+                videoNode,
+                NsiliConstants.ENCODING_SCHEME,
+                VIDEO_ENCODING_SCHEME.getSpecName());
+        addDoubleAttribute(graph, videoNode, NsiliConstants.FRAME_RATE, VIDEO_FRAME_RATE);
+        addIntegerAttribute(graph, videoNode, NsiliConstants.NUMBER_OF_ROWS, VIDEO_NUM_ROWS);
+        addIntegerAttribute(graph, videoNode, NsiliConstants.NUMBER_OF_COLS, VIDEO_NUM_COLS);
+        addStringAttribute(graph,
+                videoNode,
+                NsiliConstants.METADATA_ENC_SCHEME,
+                VIDEO_METADATA_ENC_SCHEME);
+        addShortAttribute(graph, videoNode, NsiliConstants.MISM_LEVEL, VIDEO_MISM_LEVEL);
+        addStringAttribute(graph,
+                videoNode,
+                NsiliConstants.SCANNING_MODE,
+                VIDEO_SCANNING_MODE);
+    }
+
+    private void addReportNode(DirectedAcyclicGraph<Node, Edge> graph, Node parentNode) {
+        Any reportAny = orb.create_any();
+        Node reportNode = new Node(0,
+                NodeType.ENTITY_NODE,
+                NsiliConstants.NSIL_REPORT,
+                reportAny);
+        graph.addVertex(reportNode);
+        graph.addEdge(parentNode, reportNode);
+
+        addStringAttribute(graph,
+                reportNode,
+                NsiliConstants.ORIGINATORS_REQ_SERIAL_NUM,
+                REPORT_REQ_SERIAL_NUM);
+        addStringAttribute(graph, reportNode, NsiliConstants.PRIORITY, REPORT_PRIORITY);
+        addStringAttribute(graph, reportNode, NsiliConstants.TYPE, REPORT_TYPE);
+    }
+
+    private void addTdlNode(DirectedAcyclicGraph<Node, Edge> graph, Node parentNode) {
+        Any tdlAny = orb.create_any();
+        Node tdlNode = new Node(0, NodeType.ENTITY_NODE, NsiliConstants.NSIL_TDL, tdlAny);
+        graph.addVertex(tdlNode);
+        graph.addEdge(parentNode, tdlNode);
+
+        addShortAttribute(graph, tdlNode, NsiliConstants.ACTIVITY, TDL_ACTIVITY);
+        addStringAttribute(graph, tdlNode, NsiliConstants.MESSAGE_NUM, TDL_MESSAGE_NUM);
+        addShortAttribute(graph, tdlNode, NsiliConstants.PLATFORM, TDL_PLATFORM_NUM);
+        addStringAttribute(graph, tdlNode, NsiliConstants.TRACK_NUM, TDL_TRACK_NUM);
+    }
+
+    private void addCxpNode(DirectedAcyclicGraph<Node, Edge> graph, Node parentNode) {
+        Any cxpAny = orb.create_any();
+        Node cxpNode = new Node(0, NodeType.ENTITY_NODE, NsiliConstants.NSIL_CXP, cxpAny);
+        graph.addVertex(cxpNode);
+        graph.addEdge(parentNode, cxpNode);
+
+        addStringAttribute(graph, cxpNode, NsiliConstants.STATUS, CXP_STATUS);
+    }
+
+    private void addIRNode(DirectedAcyclicGraph<Node, Edge> graph, Node parentNode) {
+        Any irAny = orb.create_any();
+        Node irNode = new Node(0, NodeType.ENTITY_NODE, NsiliConstants.NSIL_IR, irAny);
+        graph.addVertex(irNode);
+        graph.addEdge(parentNode, irNode);
+    }
+
+    private void addRFINode(DirectedAcyclicGraph<Node, Edge> graph, Node parentNode) {
+        Any rfiAny = orb.create_any();
+        Node rfiNode = new Node(0, NodeType.ENTITY_NODE, NsiliConstants.NSIL_RFI, rfiAny);
+        graph.addVertex(rfiNode);
+        graph.addEdge(parentNode, rfiNode);
+
+        addStringAttribute(graph, rfiNode, NsiliConstants.FOR_ACTION, RFI_FOR_ACTION);
+        addStringAttribute(graph,
+                rfiNode,
+                NsiliConstants.FOR_INFORMATION,
+                RFI_FOR_INFORMATION);
+        addStringAttribute(graph, rfiNode, NsiliConstants.SERIAL_NUMBER, RFI_SERIAL_NUM);
+        addStringAttribute(graph, rfiNode, NsiliConstants.STATUS, RFI_STATUS);
+        addStringAttribute(graph,
+                rfiNode,
+                NsiliConstants.WORKFLOW_STATUS,
+                RFI_WORKFLOW_STATUS);
+    }
+
+    private void addTaskNode(DirectedAcyclicGraph<Node, Edge> graph, Node parentNode) {
+        Any taskAny = orb.create_any();
+        Node taskNode = new Node(0, NodeType.ENTITY_NODE, NsiliConstants.NSIL_TASK, taskAny);
+        graph.addVertex(taskNode);
+        graph.addEdge(parentNode, taskNode);
+
+        addStringAttribute(graph, taskNode, NsiliConstants.COMMENTS, TASK_COMMENTS);
+        addStringAttribute(graph, taskNode, NsiliConstants.STATUS, TASK_STATUS);
+    }
+
+    private void addCoverageNode(DirectedAcyclicGraph<Node, Edge> graph, Node parentNode) {
+        Any coverageAny = orb.create_any();
+        Node coverageNode = new Node(0,
+                NodeType.ENTITY_NODE,
+                NsiliConstants.NSIL_COVERAGE,
+                coverageAny);
+        graph.addVertex(coverageNode);
+        graph.addEdge(parentNode, coverageNode);
+
+        addStringAttribute(graph,
+                coverageNode,
+                NsiliConstants.SPATIAL_COUNTRY_CODE,
+                COVERAGE_COUNTRY_CD);
+        addDateAttribute(graph, coverageNode, NsiliConstants.TEMPORAL_START);
+        addDateAttribute(graph, coverageNode, NsiliConstants.TEMPORAL_END);
+
+        org.codice.alliance.nsili.common.UCO.Coordinate2d upperLeft =
+                new org.codice.alliance.nsili.common.UCO.Coordinate2d(UPPER_LEFT_LAT,
+                        UPPER_LEFT_LON);
+        org.codice.alliance.nsili.common.UCO.Coordinate2d lowerRight =
+                new org.codice.alliance.nsili.common.UCO.Coordinate2d(LOWER_RIGHT_LAT,
+                        LOWER_RIGHT_LON);
+        org.codice.alliance.nsili.common.UCO.Rectangle rectangle =
+                new org.codice.alliance.nsili.common.UCO.Rectangle(upperLeft, lowerRight);
+        Any spatialCoverage = orb.create_any();
+        RectangleHelper.insert(spatialCoverage, rectangle);
+        addAnyAttribute(graph,
+                coverageNode,
+                NsiliConstants.SPATIAL_GEOGRAPHIC_REF_BOX,
+                spatialCoverage);
+    }
+
+    private void addExpoloitationInfoNode(DirectedAcyclicGraph<Node, Edge> graph, Node parentNode) {
+        Any exploitationAny = orb.create_any();
+        Node exploitationNode = new Node(0,
+                NodeType.ENTITY_NODE,
+                NsiliConstants.NSIL_EXPLOITATION_INFO,
+                exploitationAny);
+        graph.addVertex(exploitationNode);
+        graph.addEdge(parentNode, exploitationNode);
+
+        addStringAttribute(graph,
+                exploitationNode,
+                NsiliConstants.DESCRIPTION,
+                EXPLOITATION_DESC);
+        addShortAttribute(graph, exploitationNode, NsiliConstants.LEVEL, EXPLOITATION_LEVEL);
+        addBooleanAttribute(graph,
+                exploitationNode,
+                NsiliConstants.AUTO_GENERATED,
+                EXPLOITATION_AUTO_GEN);
+        addStringAttribute(graph,
+                exploitationNode,
+                NsiliConstants.SUBJ_QUALITY_CODE,
+                EXPLOITATION_SUBJ_QUAL_CODE);
+    }
+
+    private void addStringAttribute(DirectedAcyclicGraph<Node, Edge> graph, Node parentNode,
+            String key, String value) {
+        Any any = orb.create_any();
+        any.insert_wstring(value);
+        Node node = new Node(0, NodeType.ATTRIBUTE_NODE, key, any);
+        graph.addVertex(node);
+        graph.addEdge(parentNode, node);
+    }
+
+    private void addIntegerAttribute(DirectedAcyclicGraph<Node, Edge> graph, Node parentNode,
+            String key, Integer integer) {
+        Any any = orb.create_any();
+        any.insert_ulong(integer);
+        Node node = new Node(0, NodeType.ATTRIBUTE_NODE, key, any);
+        graph.addVertex(node);
+        graph.addEdge(parentNode, node);
+    }
+
+    private void addShortAttribute(DirectedAcyclicGraph<Node, Edge> graph, Node parentNode,
+            String key, Short shortVal) {
+        Any any = orb.create_any();
+        any.insert_short(shortVal);
+        Node node = new Node(0, NodeType.ATTRIBUTE_NODE, key, any);
+        graph.addVertex(node);
+        graph.addEdge(parentNode, node);
+    }
+
+    private void addDoubleAttribute(DirectedAcyclicGraph<Node, Edge> graph, Node parentNode,
+            String key, Double doubleVal) {
+        Any any = orb.create_any();
+        any.insert_double(doubleVal);
+        Node node = new Node(0, NodeType.ATTRIBUTE_NODE, key, any);
+        graph.addVertex(node);
+        graph.addEdge(parentNode, node);
+    }
+
+    private void addBooleanAttribute(DirectedAcyclicGraph<Node, Edge> graph, Node parentNode,
+            String key, Boolean boolVal) {
+        Any any = orb.create_any();
+        any.insert_boolean(boolVal);
+        Node node = new Node(0, NodeType.ATTRIBUTE_NODE, key, any);
+        graph.addVertex(node);
+        graph.addEdge(parentNode, node);
+    }
+
+    private void addAnyAttribute(DirectedAcyclicGraph<Node, Edge> graph, Node parentNode,
+            String key, Any any) {
+        Node node = new Node(0, NodeType.ATTRIBUTE_NODE, key, any);
+        graph.addVertex(node);
+        graph.addEdge(parentNode, node);
+    }
+
+    private void addDateAttribute(DirectedAcyclicGraph<Node, Edge> graph, Node parentNode,
+            String key) {
+        Any any = orb.create_any();
+
+        AbsTime absTime =
+                new AbsTime(new org.codice.alliance.nsili.common.UCO.Date((short) cal.get(
+                        Calendar.YEAR), (short) (cal.get(Calendar.MONTH) + 1), (short) cal.get(
+                        Calendar.DAY_OF_MONTH)), new Time((short) cal.get(Calendar.HOUR_OF_DAY),
+                        (short) cal.get(Calendar.MINUTE),
+                        (short) cal.get(Calendar.SECOND)));
+        AbsTimeHelper.insert(any, absTime);
+        Node node = new Node(0, NodeType.ATTRIBUTE_NODE, key, any);
+        graph.addVertex(node);
+        graph.addEdge(parentNode, node);
+    }
+
+    private void printMetacard(MetacardImpl metacard, PrintStream outStream) {
+        MetacardType metacardType = metacard.getMetacardType();
+        outStream.println("Metacard Type : " + metacardType.getClass()
+                .getCanonicalName());
+        outStream.println("ID : " + metacard.getId());
+        outStream.println("Title : " + metacard.getTitle());
+        outStream.println("Description : " + metacard.getDescription());
+        outStream.println("Content Type Name : " + metacard.getContentTypeName());
+        outStream.println("Content Type Version : " + metacard.getContentTypeVersion());
+        outStream.println("Created Date : " + metacard.getCreatedDate());
+        outStream.println("Effective Date : " + metacard.getEffectiveDate());
+        outStream.println("Location : " + metacard.getLocation());
+        outStream.println("SourceID : " + metacard.getSourceId());
+        outStream.println("Modified Date : " + metacard.getModifiedDate());
+        outStream.println("Resource URI : " + metacard.getResourceURI()
+                .toString());
+
+        Set<AttributeDescriptor> descriptors = metacardType.getAttributeDescriptors();
+        for (AttributeDescriptor descriptor : descriptors) {
+            Attribute attribute = metacard.getAttribute(descriptor.getName());
+            if (attribute != null) {
+                if (attribute.getValues() != null) {
+                    String valueStr = getValueString(attribute.getValues());
+                    outStream.println("  " + descriptor.getName() + " : " +
+                            valueStr);
+                } else {
+                    outStream.println("  " + descriptor.getName() + " : " +
+                            attribute.getValue());
+                }
+            }
+        }
+    }
+
+    private static String getValueString(Collection<Serializable> collection) {
+        return collection.stream()
+                .map(Object::toString)
+                .sorted()
+                .collect(Collectors.joining(", "));
+    }
+}

--- a/catalog/nsili/nsili-app/pom.xml
+++ b/catalog/nsili/nsili-app/pom.xml
@@ -24,7 +24,7 @@
 
     <artifactId>nsili-app</artifactId>
     <packaging>pom</packaging>
-    <name>DDF :: Alliance :: NSILI :: App</name>
+    <name>Alliance :: NSILI :: App</name>
 
     <dependencies>
         <dependency>

--- a/catalog/nsili/nsili-app/src/main/resources/features.xml
+++ b/catalog/nsili/nsili-app/src/main/resources/features.xml
@@ -22,7 +22,7 @@
     </feature>
 
     <feature name="nsili-app" install="auto" version="${project.version}"
-             description="The DDF NSILI App is used to connect a NSILI (STANAG 4559) complaint federated sources to DDF and expose their data in the UI.  This includes spatial, temporal and textual searches. ::DDF NSILI">
+             description="The Alliance NSILI App is used to connect a NSILI (STANAG 4559) complaint federated sources to DDF and expose their data in the UI.  This includes spatial, temporal and textual searches. ::Alliance NSILI">
         <feature prerequisite="true">catalog-app</feature>
         <feature>catalog-nsili-source</feature>
     </feature>

--- a/catalog/nsili/pom.xml
+++ b/catalog/nsili/pom.xml
@@ -22,10 +22,11 @@
     <artifactId>nsili</artifactId>
     <groupId>org.codice.alliance.nsili</groupId>
     <packaging>pom</packaging>
-    <name>DDF :: Alliance :: NSILI</name>
+    <name>Alliance :: NSILI</name>
     <modules>
         <module>catalog-nsili-common</module>
         <module>catalog-nsili-source</module>
+        <module>catalog-nsili-transformer</module>
         <module>nsili-app</module>
     </modules>
 </project>

--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -24,7 +24,7 @@
     <groupId>org.codice.alliance</groupId>
     <artifactId>catalog</artifactId>
     <packaging>pom</packaging>
-    <name>DDF :: Alliance :: Catalog</name>
+    <name>Alliance :: Catalog</name>
 
     <modules>
         <module>nsili</module>

--- a/distribution/sdk/pom.xml
+++ b/distribution/sdk/pom.xml
@@ -24,7 +24,7 @@
     <groupId>org.codice.alliance.distribution</groupId>
     <artifactId>sdk</artifactId>
     <packaging>pom</packaging>
-    <name>DDF :: Alliance :: Distribution :: SDK</name>
+    <name>Alliance :: Distribution :: SDK</name>
     <properties>
 
     </properties>

--- a/distribution/sdk/sample-nsili-server/pom.xml
+++ b/distribution/sdk/sample-nsili-server/pom.xml
@@ -21,7 +21,7 @@
         <version>0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <name>DDF :: Alliance :: Distribution :: SDK :: NSILI Server</name>
+    <name>Alliance :: Distribution :: SDK :: NSILI Server</name>
     <artifactId>sample-nsili-server</artifactId>
     <packaging>bundle</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
     <artifactId>alliance</artifactId>
     <version>0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
-    <name>DDF :: Alliance</name>
-    <description>Distributed Data Framework (DDF) Alliance</description>
+    <name>Alliance</name>
+    <description>Codice Alliance</description>
     <inceptionYear>2016</inceptionYear>
     <organization>
         <name>Codice Foundation</name>


### PR DESCRIPTION
#### What does this PR do?
This PR adds an Input Transformer and Metacard Types for STANAG 4559 (NSILI) Federated Source responses.
#### Who is reviewing it?
@kcwire 
@jrnorth 
@dcruver 
@jaymcnallie 
@shane-voisard
@jlcsmith 
@beyelerb
#### How should this be tested?
This PR can be tested by building Alliance, installing the nsili-app in DDF, and federating to the mock nsili server.
#### Any background context you want to provide?
This PR is built on top of CAL-2 and CAL-1
#### What are the relevant tickets?
https://codice.atlassian.net/browse/CAL-6
https://codice.atlassian.net/browse/CAL-7
#### Screenshots (if appropriate)
#### Checklist:
- [n/a ] Documentation Updated
- [x] Update / Add Unit Tests
- [n/a] Update / Add Integration Tests (integration tests will be added in a separate ticket)
