### PR TITLE
CAL-46 remove subsample count from metatype admin page 

### DIFF
--- a/catalog/video/catalog-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/netty/UdpStreamProcessor.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/netty/UdpStreamProcessor.java
@@ -84,6 +84,8 @@ public class UdpStreamProcessor implements StreamProcessor {
      */
     private static final long DEFAULT_METACARD_UPDATE_INITIAL_DELAY = 2;
 
+    private static final Integer DEFAULT_KLV_LOCATION_SUBSAMPLE_COUNT = 50;
+    
     private PacketBuffer packetBuffer = new PacketBuffer();
 
     private Stanag4609Processor stanag4609Processor;
@@ -108,7 +110,7 @@ public class UdpStreamProcessor implements StreamProcessor {
 
     private RolloverAction rolloverAction;
 
-    private Integer klvLocationSubsampleCount;
+    private Integer klvLocationSubsampleCount = DEFAULT_KLV_LOCATION_SUBSAMPLE_COUNT;
 
     private CatalogFramework catalogFramework;
 

--- a/catalog/video/catalog-mpegts-stream/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/video/catalog-mpegts-stream/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -48,11 +48,6 @@
                 type="String" default="mpegts-stream-%{date=yyyy-MM-dd_hh:mm:ss}"/>
 
         <AD
-                description="KLV Metadata Location Subsample Count"
-                name="Location Subsample Count" id="klvLocationSubsampleCount" required="true"
-                type="Integer" default="50"/>
-
-        <AD
                 description="Delay updates when creating metacards to avoid retries. Slower systems require a longer delay. The minimum value is 0 seconds and the maximum value is 60 seconds. (seconds)"
                 name="Metacard Update Initial Delay" id="metacardUpdateInitialDelay" required="false"
                 type="Long" default="2" />


### PR DESCRIPTION
#### What does this PR do?
Remove subsample count from metatype. It isn't needed because subsampling is happening in the input transformer after the video chunk is uploaded to ddf.
#### Who is reviewing it?
@jaymcnallie @jrnorth @kcwire @rzwiefel 
#### How should this be tested?
Install alliance experimental and confirm that the 'subsample count' field does not appear in the metatype page.
#### Any background context you want to provide?
I only removed the metatype field. I didn't strip the subsample count out of the code in case we decide to go back to computing the complete metacard in alliance-mpegts-stream instead of the input transformer.
#### What are the relevant tickets?
CAL-46
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

