### PR TITLE
CAL-48 Refactor alliance-imaging to use imaging-nitf 0.3

### DIFF
--- a/catalog/imaging/catalog-imaging-transformer/pom.xml
+++ b/catalog/imaging/catalog-imaging-transformer/pom.xml
@@ -65,6 +65,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.codice.imaging.nitf</groupId>
+            <artifactId>codice-imaging-nitf-fluent-api</artifactId>
+            <version>${nitf-imaging.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>net.coobird</groupId>
             <artifactId>thumbnailator</artifactId>
             <version>0.4.8</version>
@@ -91,7 +97,8 @@
                             catalog-core-api-impl,
                             platform-util,
                             codice-imaging-nitf-core,
-                            codice-imaging-nitf-render
+                            codice-imaging-nitf-render,
+                            codice-imaging-nitf-fluent-api
                         </Embed-Dependency>
                         <Export-Package/>
                     </instructions>

--- a/catalog/imaging/catalog-imaging-transformer/src/main/java/org/codice/alliance/transformer/nitf/GraphicAttribute.java
+++ b/catalog/imaging/catalog-imaging-transformer/src/main/java/org/codice/alliance/transformer/nitf/GraphicAttribute.java
@@ -16,7 +16,7 @@ package org.codice.alliance.transformer.nitf;
 import java.io.Serializable;
 import java.util.function.Function;
 
-import org.codice.imaging.nitf.core.graphic.NitfGraphicSegmentHeader;
+import org.codice.imaging.nitf.core.graphic.GraphicSegment;
 
 import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.AttributeType;
@@ -24,12 +24,12 @@ import ddf.catalog.data.impl.AttributeDescriptorImpl;
 import ddf.catalog.data.impl.BasicTypes;
 
 /**
- * NitfAttributes to represent the properties of a NitfGraphicSegmentHeader.
+ * NitfAttributes to represent the properties of a GraphicSegment.
  */
-enum GraphicAttribute implements NitfAttribute<NitfGraphicSegmentHeader> {
+enum GraphicAttribute implements NitfAttribute<GraphicSegment> {
     FILE_PART_TYPE("filePartType", "SY", segment -> "SY"),
-    GRAPHIC_IDENTIFIER("graphicIdentifier", "SID", NitfGraphicSegmentHeader::getIdentifier),
-    GRAPHIC_NAME("graphicName", "SNAME", NitfGraphicSegmentHeader::getGraphicName),
+    GRAPHIC_IDENTIFIER("graphicIdentifier", "SID", GraphicSegment::getIdentifier),
+    GRAPHIC_NAME("graphicName", "SNAME", GraphicSegment::getGraphicName),
     GRAPHIC_SECURITY_CLASSIFICATION("graphicSecurityClassification", "SSCLAS",
             segment -> segment.getSecurityMetadata().getSecurityClassification().name()),
     GRAPHIC_CLASSIFICATION_SECURITY_SYSTEM("graphicClassificationSecuritySystem", "SSCLSY",
@@ -63,14 +63,14 @@ enum GraphicAttribute implements NitfAttribute<NitfGraphicSegmentHeader> {
     GRAPHIC_SECURITY_CONTROL_NUMBER("graphicSecurityControlNumber", "SSCTLN",
             segment -> segment.getSecurityMetadata().getSecurityControlNumber()),
     GRAPHIC_DISPLAY_LEVEL("graphicDisplayLevel", "SDLVL",
-            NitfGraphicSegmentHeader::getGraphicDisplayLevel, BasicTypes.INTEGER_TYPE),
+            GraphicSegment::getGraphicDisplayLevel, BasicTypes.INTEGER_TYPE),
     GRAPHIC_ATTACHMENT_LEVEL("graphicAttachmentLevel", "SALVL",
-            NitfGraphicSegmentHeader::getAttachmentLevel, BasicTypes.INTEGER_TYPE),
+            GraphicSegment::getAttachmentLevel, BasicTypes.INTEGER_TYPE),
     GRAPHIC_LOCATION("graphicLocation", "SLOC",
             segment -> segment.getGraphicLocationRow() + "," + segment.getGraphicLocationColumn()),
     GRAPHIC_COLOR("graphicColor", "SCOLOR", segment -> segment.getGraphicColour().toString()),
     GRAPHIC_EXTENDED_SUBHEADER_DATA_LENGTH("graphicExtendedSubheaderDataLength", "SXSHDL",
-            NitfGraphicSegmentHeader::getExtendedHeaderDataOverflow, BasicTypes.INTEGER_TYPE);
+            GraphicSegment::getExtendedHeaderDataOverflow, BasicTypes.INTEGER_TYPE);
 
     public static final String ATTRIBUTE_NAME_PREFIX = "nitf.graphic.";
 
@@ -78,17 +78,17 @@ enum GraphicAttribute implements NitfAttribute<NitfGraphicSegmentHeader> {
 
     private String longName;
 
-    private Function<NitfGraphicSegmentHeader, Serializable> accessorFunction;
+    private Function<GraphicSegment, Serializable> accessorFunction;
 
     private AttributeDescriptor attributeDescriptor;
 
     private GraphicAttribute(final String lName, final String sName,
-            final Function<NitfGraphicSegmentHeader, Serializable> accessor) {
+            final Function<GraphicSegment, Serializable> accessor) {
         this(lName, sName, accessor, BasicTypes.STRING_TYPE);
     }
 
     private GraphicAttribute(final String lName, final String sName,
-            final Function<NitfGraphicSegmentHeader, Serializable> accessor,
+            final Function<GraphicSegment, Serializable> accessor,
             final AttributeType attributeType) {
         this.accessorFunction = accessor;
         this.shortName = sName;
@@ -117,7 +117,7 @@ enum GraphicAttribute implements NitfAttribute<NitfGraphicSegmentHeader> {
      * {@inheritDoc}
      */
     @Override
-    public Function<NitfGraphicSegmentHeader, Serializable> getAccessorFunction() {
+    public Function<GraphicSegment, Serializable> getAccessorFunction() {
         return this.accessorFunction;
     }
 

--- a/catalog/imaging/catalog-imaging-transformer/src/main/java/org/codice/alliance/transformer/nitf/LabelAttribute.java
+++ b/catalog/imaging/catalog-imaging-transformer/src/main/java/org/codice/alliance/transformer/nitf/LabelAttribute.java
@@ -16,7 +16,7 @@ package org.codice.alliance.transformer.nitf;
 import java.io.Serializable;
 import java.util.function.Function;
 
-import org.codice.imaging.nitf.core.label.LabelSegmentHeader;
+import org.codice.imaging.nitf.core.label.LabelSegment;
 
 import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.AttributeType;
@@ -26,9 +26,9 @@ import ddf.catalog.data.impl.BasicTypes;
 /**
  * NitfAttributes to represent the properties of a LabelSegmentHeader.
  */
-enum LabelAttribute implements NitfAttribute<LabelSegmentHeader> {
+enum LabelAttribute implements NitfAttribute<LabelSegment> {
     FILE_PART_TYPE("filePartType", "LA", segment -> "LA"),
-    LABEL_ID("labelID", "LID", LabelSegmentHeader::getIdentifier),
+    LABEL_ID("labelID", "LID", LabelSegment::getIdentifier),
     LABEL_SECURITY_CLASSIFICATION("labelSecurityClassification", "LSCLAS",
             segment -> segment.getSecurityMetadata().getSecurityClassification().name()),
     LABEL_CODEWORDS("labelCodewords", "LSCODE",
@@ -45,13 +45,13 @@ enum LabelAttribute implements NitfAttribute<LabelSegmentHeader> {
             segment -> segment.getSecurityMetadata().getDowngrade()),
     LABEL_DOWNGRADING_EVENT("labelDowngradingEvent", "LSDEVT",
             segment -> segment.getSecurityMetadata().getDowngradeEvent()),
-    LABEL_CELL_WIDTH("labelCellWidth", "LCW", LabelSegmentHeader::getLabelCellWidth,
+    LABEL_CELL_WIDTH("labelCellWidth", "LCW", LabelSegment::getLabelCellWidth,
             BasicTypes.INTEGER_TYPE),
-    LABEL_CELL_HEIGHT("labelCellHeight", "LCH", LabelSegmentHeader::getLabelCellHeight,
+    LABEL_CELL_HEIGHT("labelCellHeight", "LCH", LabelSegment::getLabelCellHeight,
             BasicTypes.INTEGER_TYPE),
-    LABEL_DISPLAY_LEVEL("labelDisplayLevel", "LDLVL", LabelSegmentHeader::getLabelDisplayLevel,
+    LABEL_DISPLAY_LEVEL("labelDisplayLevel", "LDLVL", LabelSegment::getLabelDisplayLevel,
             BasicTypes.INTEGER_TYPE),
-    ATTACHMENT_LEVEL("attachmentLevel", "LALVL", LabelSegmentHeader::getAttachmentLevel,
+    ATTACHMENT_LEVEL("attachmentLevel", "LALVL", LabelSegment::getAttachmentLevel,
             BasicTypes.INTEGER_TYPE),
     LABEL_LOCATION("labelLocation", "LLOC", segment -> String
             .format("%s,%s", segment.getLabelLocationRow(), segment.getLabelLocationColumn())),
@@ -59,7 +59,7 @@ enum LabelAttribute implements NitfAttribute<LabelSegmentHeader> {
     LABEL_BACKGROUND_COLOR("labelBackgroundColor", "LBC",
             segment -> segment.getLabelBackgroundColour().toString()),
     EXTENDED_SUBHEADER_DATA_LENGTH("extendedSubheaderDataLength", "LXSHDL",
-            LabelSegmentHeader::getExtendedHeaderDataOverflow, BasicTypes.INTEGER_TYPE);
+            LabelSegment::getExtendedHeaderDataOverflow, BasicTypes.INTEGER_TYPE);
 
     public static final String ATTRIBUTE_NAME_PREFIX = "nitf.label.";
 
@@ -67,17 +67,17 @@ enum LabelAttribute implements NitfAttribute<LabelSegmentHeader> {
 
     private String longName;
 
-    private Function<LabelSegmentHeader, Serializable> accessorFunction;
+    private Function<LabelSegment, Serializable> accessorFunction;
 
     private AttributeDescriptor attributeDescriptor;
 
     private LabelAttribute(final String lName, final String sName,
-            final Function<LabelSegmentHeader, Serializable> accessor) {
+            final Function<LabelSegment, Serializable> accessor) {
         this(lName, sName, accessor, BasicTypes.STRING_TYPE);
     }
 
     private LabelAttribute(final String lName, final String sName,
-            final Function<LabelSegmentHeader, Serializable> accessor, AttributeType attributeType) {
+            final Function<LabelSegment, Serializable> accessor, AttributeType attributeType) {
         this.accessorFunction = accessor;
         this.shortName = sName;
         this.longName = lName;
@@ -105,7 +105,7 @@ enum LabelAttribute implements NitfAttribute<LabelSegmentHeader> {
      * {@inheritDoc}
      */
     @Override
-    public Function<LabelSegmentHeader, Serializable> getAccessorFunction() {
+    public Function<LabelSegment, Serializable> getAccessorFunction() {
         return accessorFunction;
     }
 

--- a/catalog/imaging/catalog-imaging-transformer/src/main/java/org/codice/alliance/transformer/nitf/NitfAttribute.java
+++ b/catalog/imaging/catalog-imaging-transformer/src/main/java/org/codice/alliance/transformer/nitf/NitfAttribute.java
@@ -16,8 +16,6 @@ package org.codice.alliance.transformer.nitf;
 import java.io.Serializable;
 import java.util.function.Function;
 
-import org.codice.imaging.nitf.core.common.CommonNitfSegment;
-
 import ddf.catalog.data.AttributeDescriptor;
 
 /**
@@ -28,7 +26,7 @@ import ddf.catalog.data.AttributeDescriptor;
  *
  * @param <T> The type of CommonNitfSegment that implementations of NitfAttribute represent.
  */
-interface NitfAttribute<T extends CommonNitfSegment> {
+interface NitfAttribute<T> {
     /**
      *
      * @return the attribute's long name in CamelCase.

--- a/catalog/imaging/catalog-imaging-transformer/src/main/java/org/codice/alliance/transformer/nitf/NitfHeaderAttribute.java
+++ b/catalog/imaging/catalog-imaging-transformer/src/main/java/org/codice/alliance/transformer/nitf/NitfHeaderAttribute.java
@@ -19,8 +19,8 @@ import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.function.Function;
 
-import org.codice.imaging.nitf.core.NitfFileHeader;
-import org.codice.imaging.nitf.core.common.NitfDateTime;
+import org.codice.imaging.nitf.core.common.DateTime;
+import org.codice.imaging.nitf.core.header.NitfHeader;
 
 import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.AttributeType;
@@ -30,48 +30,48 @@ import ddf.catalog.data.impl.BasicTypes;
 /**
  * NitfAttributes to represent the properties of a NitfFileHeader.
  */
-enum NitfHeaderAttribute implements NitfAttribute<NitfFileHeader> {
+enum NitfHeaderAttribute implements NitfAttribute<NitfHeader> {
     FILE_PROFILE_NAME("fileProfileName", "FHDR", header -> header.getFileType().name()),
     FILE_VERSION("fileVersion", "FVER", header -> header.getFileType().name()),
-    COMPLEXITY_LEVEL("complexityLevel", "CLEVEL", NitfFileHeader::getComplexityLevel,
+    COMPLEXITY_LEVEL("complexityLevel", "CLEVEL", NitfHeader::getComplexityLevel,
             BasicTypes.INTEGER_TYPE),
-    STANDARD_TYPE("standardType", "STYPE", NitfFileHeader::getStandardType),
+    STANDARD_TYPE("standardType", "STYPE", NitfHeader::getStandardType),
     ORIGINATING_STATION_ID("originatingStationId", "OSTAID",
-            NitfFileHeader::getOriginatingStationId),
+            NitfHeader::getOriginatingStationId),
     FILE_DATE_AND_TIME("fileDateAndTime", "FDT",
             header -> convertNitfDate(header.getFileDateTime()), BasicTypes.DATE_TYPE),
-    FILE_TITLE("fileTitle", "FTITLE", NitfFileHeader::getFileTitle),
+    FILE_TITLE("fileTitle", "FTITLE", NitfHeader::getFileTitle),
     FILE_SECURITY_CLASSIFICATION("fileSecurityClassification", "FSCLAS",
-            header -> header.getSecurityMetadata().getSecurityClassification().name()),
+            header -> header.getFileSecurityMetadata().getSecurityClassification().name()),
     FILE_CLASSIFICATION_SECURITY_SYSTEM("fileClassificationSecuritySystem", "FSCLSY",
-            header -> header.getSecurityMetadata().getSecurityClassificationSystem()),
+            header -> header.getFileSecurityMetadata().getSecurityClassificationSystem()),
     FILE_CODE_WORDS("fileCodewords", "FSCODE",
-            header -> header.getSecurityMetadata().getCodewords()),
+            header -> header.getFileSecurityMetadata().getCodewords()),
     FILE_CONTROL_AND_HANDLING("fileControlAndHandling", "FSCTLH",
-            header -> header.getSecurityMetadata().getControlAndHandling()),
+            header -> header.getFileSecurityMetadata().getControlAndHandling()),
     FILE_RELEASING_INSTRUCTIONS("fileReleasingInstructions", "FSREL",
-            header -> header.getSecurityMetadata().getReleaseInstructions()),
+            header -> header.getFileSecurityMetadata().getReleaseInstructions()),
     FILE_DECLASSIFICATION_TYPE("fileDeclassificationType", "FSDCTP",
-            header -> header.getSecurityMetadata().getDeclassificationType()),
+            header -> header.getFileSecurityMetadata().getDeclassificationType()),
     FILE_DECLASSIFICATION_DATE("fileDeclassificationDate", "FSDCDT",
-            header -> header.getSecurityMetadata().getDeclassificationDate()),
+            header -> header.getFileSecurityMetadata().getDeclassificationDate()),
     FILE_DECLASSIFICATION_EXEMPTION("fileDeclassificationExemption", "FSDCXM",
-            header -> header.getSecurityMetadata().getDeclassificationExemption()),
-    FILE_DOWNGRADE("fileDowngrade", "FSDG", header -> header.getSecurityMetadata().getDowngrade()),
+            header -> header.getFileSecurityMetadata().getDeclassificationExemption()),
+    FILE_DOWNGRADE("fileDowngrade", "FSDG", header -> header.getFileSecurityMetadata().getDowngrade()),
     FILE_DOWNGRADE_DATE("fileDowngradeDate", "FSDGDT",
-            header -> header.getSecurityMetadata().getDowngradeDate()),
+            header -> header.getFileSecurityMetadata().getDowngradeDate()),
     FILE_CLASSIFICATION_TEXT("fileClassificationText", "FSCLTX",
-            header -> header.getSecurityMetadata().getClassificationText()),
+            header -> header.getFileSecurityMetadata().getClassificationText()),
     FILE_CLASSIFICATION_AUTHORITY_TYPE("fileClassificationAuthorityType", "FSCATP",
-            header -> header.getSecurityMetadata().getClassificationAuthorityType()),
+            header -> header.getFileSecurityMetadata().getClassificationAuthorityType()),
     FILE_CLASSIFICATION_AUTHORITY("fileClassificationAuthority", "FSCAUT",
-            header -> header.getSecurityMetadata().getClassificationAuthority()),
+            header -> header.getFileSecurityMetadata().getClassificationAuthority()),
     FILE_CLASSIFICATION_REASON("fileClassificationReason", "FSCRSN",
-            header -> header.getSecurityMetadata().getClassificationReason()),
+            header -> header.getFileSecurityMetadata().getClassificationReason()),
     FILE_SECURITY_SOURCE_DATE("fileSecuritySourceDate", "FSSRDT",
-            header -> header.getSecurityMetadata().getSecuritySourceDate()),
+            header -> header.getFileSecurityMetadata().getSecuritySourceDate()),
     FILE_SECURITY_CONTROL_NUMBER("fileSecurityControlNumber", "FSCTLN",
-            header -> header.getSecurityMetadata().getSecurityControlNumber()),
+            header -> header.getFileSecurityMetadata().getSecurityControlNumber()),
     FILE_COPY_NUMBER("fileCopyNumber", "FSCOP",
             header -> header.getFileSecurityMetadata().getFileCopyNumber()),
     FILE_NUMBER_OF_COPIES("fileNumberOfCopies", "FSCPYS",
@@ -80,11 +80,9 @@ enum NitfHeaderAttribute implements NitfAttribute<NitfFileHeader> {
             header -> header.getFileBackgroundColour() != null ?
                     header.getFileBackgroundColour().toString() :
                     ""),
-    ORIGINATORS_NAME("originatorsName", "ONAME", NitfFileHeader::getOriginatorsName),
+    ORIGINATORS_NAME("originatorsName", "ONAME", NitfHeader::getOriginatorsName),
     ORIGINATORS_PHONE_NUMBER("originatorsPhoneNumber", "OPHONE",
-            NitfFileHeader::getOriginatorsPhoneNumber),
-    NUMBER_OF_IMAGE_SEGMENTS("numberOfImageSegments", "NUMI",
-            header -> header.getImageSegmentSubHeaderLengths().size(), BasicTypes.INTEGER_TYPE);
+            NitfHeader::getOriginatorsPhoneNumber);
 
     public static final String ATTRIBUTE_NAME_PREFIX = "nitf.";
 
@@ -92,17 +90,17 @@ enum NitfHeaderAttribute implements NitfAttribute<NitfFileHeader> {
 
     private String longName;
 
-    private Function<NitfFileHeader, Serializable> accessorFunction;
+    private Function<NitfHeader, Serializable> accessorFunction;
 
     private AttributeDescriptor attributeDescriptor;
 
     private NitfHeaderAttribute(final String lName, final String sName,
-            final Function<NitfFileHeader, Serializable> function) {
+            final Function<NitfHeader, Serializable> function) {
         this(lName, sName, function, BasicTypes.STRING_TYPE);
     }
 
     private NitfHeaderAttribute(final String lName, final String sName,
-            final Function<NitfFileHeader, Serializable> function, AttributeType attributeType) {
+            final Function<NitfHeader, Serializable> function, AttributeType attributeType) {
         this.shortName = sName;
         this.longName = lName;
         this.accessorFunction = function;
@@ -110,7 +108,7 @@ enum NitfHeaderAttribute implements NitfAttribute<NitfFileHeader> {
                 false, false, attributeType);
     }
 
-    private static Date convertNitfDate(NitfDateTime nitfDateTime) {
+    private static Date convertNitfDate(DateTime nitfDateTime) {
         if (nitfDateTime == null || nitfDateTime.getZonedDateTime() == null) {
             return null;
         }
@@ -142,7 +140,7 @@ enum NitfHeaderAttribute implements NitfAttribute<NitfFileHeader> {
     /**
      * {@inheritDoc}
      */
-    public Function<NitfFileHeader, Serializable> getAccessorFunction() {
+    public Function<NitfHeader, Serializable> getAccessorFunction() {
         return accessorFunction;
     }
 

--- a/catalog/imaging/catalog-imaging-transformer/src/main/java/org/codice/alliance/transformer/nitf/SymbolAttribute.java
+++ b/catalog/imaging/catalog-imaging-transformer/src/main/java/org/codice/alliance/transformer/nitf/SymbolAttribute.java
@@ -16,7 +16,7 @@ package org.codice.alliance.transformer.nitf;
 import java.io.Serializable;
 import java.util.function.Function;
 
-import org.codice.imaging.nitf.core.symbol.SymbolSegmentHeader;
+import org.codice.imaging.nitf.core.symbol.SymbolSegment;
 
 import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.AttributeType;
@@ -24,12 +24,12 @@ import ddf.catalog.data.impl.AttributeDescriptorImpl;
 import ddf.catalog.data.impl.BasicTypes;
 
 /**
- * NitfAttributes to represent the properties of a SymbolSegmentHeader.
+ * NitfAttributes to represent the properties of a SymbolSegment.
  */
-enum SymbolAttribute implements NitfAttribute<SymbolSegmentHeader> {
+enum SymbolAttribute implements NitfAttribute<SymbolSegment> {
     FILE_PART_TYPE("filePartType", "SY", segment -> "SY"),
-    SYMBOL_ID("symbolID", "SID", SymbolSegmentHeader::getIdentifier),
-    SYMBOL_NAME("symbolName", "SNAME", SymbolSegmentHeader::getSymbolName),
+    SYMBOL_ID("symbolID", "SID", SymbolSegment::getIdentifier),
+    SYMBOL_NAME("symbolName", "SNAME", SymbolSegment::getSymbolName),
     SYMBOL_SECURITY_CLASSIFICATION("symbolSecurityClassification", "SSCLAS",
             segment -> segment.getSecurityMetadata().getSecurityClassification().name()),
     SYMBOL_CODEWORDS("symbolCodewords", "SSCODE",
@@ -48,24 +48,24 @@ enum SymbolAttribute implements NitfAttribute<SymbolSegmentHeader> {
             segment -> segment.getSecurityMetadata().getDowngradeEvent()),
     SYMBOL_TYPE("symbolType", "STYPE", segment -> segment.getSymbolType().name()),
     NUMBER_OF_LINES_PER_SYMBOL("numberOfLinesPerSymbol", "NLIPS",
-            SymbolSegmentHeader::getNumberOfLinesPerSymbol, BasicTypes.INTEGER_TYPE),
+            SymbolSegment::getNumberOfLinesPerSymbol, BasicTypes.INTEGER_TYPE),
     NUMBER_OF_PIXELS_PER_LINE("numberOfPixelsPerLine", "NPIXPL",
-            SymbolSegmentHeader::getNumberOfPixelsPerLine, BasicTypes.INTEGER_TYPE),
-    LINE_WIDTH("lineWidth", "NWDTH", SymbolSegmentHeader::getLineWidth, BasicTypes.INTEGER_TYPE),
+            SymbolSegment::getNumberOfPixelsPerLine, BasicTypes.INTEGER_TYPE),
+    LINE_WIDTH("lineWidth", "NWDTH", SymbolSegment::getLineWidth, BasicTypes.INTEGER_TYPE),
     NUMBER_OF_BITS_PER_PIXEL("numberOfBitsPerPixel", "NBPP",
-            SymbolSegmentHeader::getNumberOfBitsPerPixel, BasicTypes.INTEGER_TYPE),
-    DISPLAY_LEVEL("displayLevel", "SDLVL", SymbolSegmentHeader::getSymbolDisplayLevel, BasicTypes.INTEGER_TYPE),
-    ATTACHMENT_LEVEL("attachmentLevel", "SALVL", SymbolSegmentHeader::getAttachmentLevel, BasicTypes.INTEGER_TYPE),
+            SymbolSegment::getNumberOfBitsPerPixel, BasicTypes.INTEGER_TYPE),
+    DISPLAY_LEVEL("displayLevel", "SDLVL", SymbolSegment::getSymbolDisplayLevel, BasicTypes.INTEGER_TYPE),
+    ATTACHMENT_LEVEL("attachmentLevel", "SALVL", SymbolSegment::getAttachmentLevel, BasicTypes.INTEGER_TYPE),
     SYMBOL_LOCATION("symbolLocation", "SLOC", segment -> String
             .format("%s,%s", segment.getSymbolLocationRow(), segment.getSymbolLocationColumn())),
     SECOND_SYMBOL_LOCATION("secondSymbolLocation", "SLOC2", segment -> String
             .format("%s,%s", segment.getSymbolLocation2Row(),
                     segment.getSymbolLocation2Column())),
     SYMBOL_COLOR("symbolColor", "SCOLOR", segment -> segment.getSymbolColour().toString()),
-    SYMBOL_NUMBER("symbolNumber", "SNUM", SymbolSegmentHeader::getSymbolNumber),
-    SYMBOL_ROTATION("symbolRotation", "SROT", SymbolSegmentHeader::getSymbolRotation, BasicTypes.INTEGER_TYPE),
+    SYMBOL_NUMBER("symbolNumber", "SNUM", SymbolSegment::getSymbolNumber),
+    SYMBOL_ROTATION("symbolRotation", "SROT", SymbolSegment::getSymbolRotation, BasicTypes.INTEGER_TYPE),
     EXTENDED_SUBHEADER_DATA_LENGTH("extendedSubheaderDataLength", "SXSHDL",
-            SymbolSegmentHeader::getExtendedHeaderDataOverflow, BasicTypes.INTEGER_TYPE);
+            SymbolSegment::getExtendedHeaderDataOverflow, BasicTypes.INTEGER_TYPE);
 
     public static final String ATTRIBUTE_NAME_PREFIX = "nitf.symbol.";
 
@@ -73,17 +73,17 @@ enum SymbolAttribute implements NitfAttribute<SymbolSegmentHeader> {
 
     private String longName;
 
-    private Function<SymbolSegmentHeader, Serializable> accessorFunction;
+    private Function<SymbolSegment, Serializable> accessorFunction;
 
     private AttributeDescriptor attributeDescriptor;
 
     private SymbolAttribute(final String lName, final String sName,
-            final Function<SymbolSegmentHeader, Serializable> accessor) {
+            final Function<SymbolSegment, Serializable> accessor) {
         this(lName, sName, accessor, BasicTypes.STRING_TYPE);
     }
 
     private SymbolAttribute(final String lName, final String sName,
-            final Function<SymbolSegmentHeader, Serializable> accessor, AttributeType attributeType) {
+            final Function<SymbolSegment, Serializable> accessor, AttributeType attributeType) {
         this.accessorFunction = accessor;
         this.shortName = sName;
         this.longName = lName;
@@ -117,7 +117,7 @@ enum SymbolAttribute implements NitfAttribute<SymbolSegmentHeader> {
      * {@inheritDoc}
      */
     @Override
-    public Function<SymbolSegmentHeader, Serializable> getAccessorFunction() {
+    public Function<SymbolSegment, Serializable> getAccessorFunction() {
         return accessorFunction;
     }
 

--- a/catalog/imaging/catalog-imaging-transformer/src/main/java/org/codice/alliance/transformer/nitf/TextAttribute.java
+++ b/catalog/imaging/catalog-imaging-transformer/src/main/java/org/codice/alliance/transformer/nitf/TextAttribute.java
@@ -19,8 +19,8 @@ import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.function.Function;
 
-import org.codice.imaging.nitf.core.common.NitfDateTime;
-import org.codice.imaging.nitf.core.text.TextSegmentHeader;
+import org.codice.imaging.nitf.core.common.DateTime;
+import org.codice.imaging.nitf.core.text.TextSegment;
 
 import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.AttributeType;
@@ -28,16 +28,16 @@ import ddf.catalog.data.impl.AttributeDescriptorImpl;
 import ddf.catalog.data.impl.BasicTypes;
 
 /**
- * NitfAttributes to represent the properties of a TextSegmentHeader.
+ * NitfAttributes to represent the properties of a TextSegment.
  */
-enum TextAttribute implements NitfAttribute<TextSegmentHeader> {
+enum TextAttribute implements NitfAttribute<TextSegment> {
     FILE_PART_TYPE("filePartType", "TE", segment -> "TE"),
-    TEXT_IDENTIFIER("textIdentifier", "TEXTID", TextSegmentHeader::getIdentifier),
+    TEXT_IDENTIFIER("textIdentifier", "TEXTID", TextSegment::getIdentifier),
     TEXT_ATTACHMENT_LEVEL("textAttachmentLevel", "TXTALVL",
-            TextSegmentHeader::getAttachmentLevel, BasicTypes.INTEGER_TYPE),
+            TextSegment::getAttachmentLevel, BasicTypes.INTEGER_TYPE),
     TEXT_DATE_AND_TIME("textDateAndTime", "TXTDT",
             segment -> convertNitfDate(segment.getTextDateTime()), BasicTypes.DATE_TYPE),
-    TEXT_TITLE("textTitle", "TXTITL", TextSegmentHeader::getTextTitle),
+    TEXT_TITLE("textTitle", "TXTITL", TextSegment::getTextTitle),
     TEXT_SECURITY_CLASSIFICATION("textSecurityClassification", "TSCLAS",
             segment -> segment.getSecurityMetadata().getSecurityClassificationSystem()),
     TEXT_CLASSIFICATION_SECURITY_SYSTEM("textClassificationSecuritySystem", "TSCLSY",
@@ -72,7 +72,7 @@ enum TextAttribute implements NitfAttribute<TextSegmentHeader> {
             segment -> segment.getSecurityMetadata().getSecurityControlNumber()),
     TEXT_FORMAT("textFormat", "TXTFMT", segment -> segment.getTextFormat().name()),
     TEXT_EXTENDED_SUBHEADER_DATA_LENGTH("textExtendedSubheaderDataLength", "TXSHDL",
-            TextSegmentHeader::getExtendedHeaderDataOverflow, BasicTypes.INTEGER_TYPE);
+            TextSegment::getExtendedHeaderDataOverflow, BasicTypes.INTEGER_TYPE);
 
     public static final String ATTRIBUTE_NAME_PREFIX = "nitf.text.";
 
@@ -80,17 +80,17 @@ enum TextAttribute implements NitfAttribute<TextSegmentHeader> {
 
     private String longName;
 
-    private Function<TextSegmentHeader, Serializable> accessorFunction;
+    private Function<TextSegment, Serializable> accessorFunction;
 
     private AttributeDescriptor attributeDescriptor;
 
     private TextAttribute(final String lName, final String sName,
-            final Function<TextSegmentHeader, Serializable> accessor) {
+            final Function<TextSegment, Serializable> accessor) {
         this(lName, sName, accessor, BasicTypes.STRING_TYPE);
     }
 
     private TextAttribute(final String lName, final String sName,
-            final Function<TextSegmentHeader, Serializable> accessor, AttributeType attributeType) {
+            final Function<TextSegment, Serializable> accessor, AttributeType attributeType) {
         this.longName = lName;
         this.shortName = sName;
         this.accessorFunction = accessor;
@@ -124,7 +124,7 @@ enum TextAttribute implements NitfAttribute<TextSegmentHeader> {
      * {@inheritDoc}
      */
     @Override
-    public Function<TextSegmentHeader, Serializable> getAccessorFunction() {
+    public Function<TextSegment, Serializable> getAccessorFunction() {
         return accessorFunction;
     }
 
@@ -145,7 +145,7 @@ enum TextAttribute implements NitfAttribute<TextSegmentHeader> {
         return this.attributeDescriptor;
     }
 
-    private static Date convertNitfDate(NitfDateTime nitfDateTime) {
+    private static Date convertNitfDate(DateTime nitfDateTime) {
         if (nitfDateTime == null || nitfDateTime.getZonedDateTime() == null) {
             return null;
         }

--- a/catalog/imaging/catalog-imaging-transformer/src/test/java/org/codice/alliance/transformer/nitf/TestNitfInputTransformer.java
+++ b/catalog/imaging/catalog-imaging-transformer/src/test/java/org/codice/alliance/transformer/nitf/TestNitfInputTransformer.java
@@ -143,7 +143,6 @@ public class TestNitfInputTransformer {
         assertThat(metacard.getAttribute("nitf." + NitfHeaderAttribute.FILE_BACKGROUND_COLOR).getValue(), is("[0xff,0xff,0xff]"));
         assertThat(metacard.getAttribute("nitf." + NitfHeaderAttribute.ORIGINATORS_NAME).getValue(), is("JITC Fort Huachuca, AZ"));
         assertThat(metacard.getAttribute("nitf." + NitfHeaderAttribute.ORIGINATORS_PHONE_NUMBER).getValue(), is("(520) 538-5458"));
-        assertThat(metacard.getAttribute("nitf." + NitfHeaderAttribute.NUMBER_OF_IMAGE_SEGMENTS).getValue(), is(1));
 
         assertThat(metacard.getAttribute("nitf.image." + ImageAttribute.FILE_PART_TYPE).getValue(), is("IM"));
         assertThat(metacard.getAttribute("nitf.image." + ImageAttribute.IMAGE_IDENTIFIER_1).getValue(), is("Missing ID"));

--- a/catalog/imaging/pom.xml
+++ b/catalog/imaging/pom.xml
@@ -26,7 +26,7 @@
     <name>Alliance :: Imaging</name>
 
     <properties>
-        <nitf-imaging.version>0.2</nitf-imaging.version>
+        <nitf-imaging.version>0.3</nitf-imaging.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
#### What does this PR do?
Updated class and method names as required by imaging-nitf 0.3.  Also changed the nitf-transformer to use the imaginag-nitf fluent API.

#### Who is reviewing it?
@bdeining 
@jlcsmith 
@jaymcnallie 

#### How should this be tested?
Ingest a NITF as you would have prior to this change.  The only difference in functionality is that I removed the 'nitf.numberOfImages' attribute.  That attribute won't be part of our taxonomy and it's easy enough to see based on the multi-valued fields.  The value is not easily retrievable in 0.3.

#### Any background context you want to provide?

#### What are the relevant tickets?
CAL-48

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

No changes to documentation or tests.
