### PR TITLE
CAL-52 add udp activity timeout

### DIFF
--- a/catalog/video/video-mpegts-stream/src/test/java/org/codice/alliance/video/stream/mpegts/netty/TestPacketBuffer.java
+++ b/catalog/video/video-mpegts-stream/src/test/java/org/codice/alliance/video/stream/mpegts/netty/TestPacketBuffer.java
@@ -95,6 +95,32 @@ public class TestPacketBuffer {
     }
 
     /**
+     * With the sleep, the last three packets gets flushed.
+     *
+     * @throws InterruptedException
+     */
+    @Test
+    public void testActivityTimeout() throws InterruptedException {
+
+        packetBuffer.setOutputStreamFactory((file, append) -> os);
+
+        completeVideoSequence(new byte[] {0x01, 0x02, 0x03, 0x01, 0x02, 0x03, 0x01, 0x02, 0x03,
+                0x01, 0x02, 0x03});
+
+        RolloverCondition rc = mock(RolloverCondition.class);
+        when(rc.isRolloverReady(any())).thenReturn(true);
+
+        Thread.sleep(PacketBuffer.ACTIVITY_TIMEOUT);
+
+        Optional<File> file = packetBuffer.rotate(rc);
+        assertThat(file.isPresent(), is(true));
+
+        assertThat(os.toByteArray(),
+                is(new byte[] {0x01, 0x02, 0x03, 0x01, 0x02, 0x03, 0x01, 0x02, 0x03, 0x01, 0x02,
+                        0x03}));
+    }
+
+    /**
      * A full frameset has been written, verify that only the compelete frameset has been flushed
      */
     @Test


### PR DESCRIPTION
#### What does this PR do?
Add a udp activity timeout so that incomplete framesets get flushed when udp data stops arriving.

#### Who is reviewing it?
@jrnorth @rzwiefel @bdeining @kcwire 
#### How should this be tested?
Build Alliance Experimental.
Configure an MPEG-TS stream monitor.
Transmit a udp stream.
After the stream has completed, wait long enough for the last bit of data to get ingested (the wait time should not exceed the rollover timeout condition). Shutdown Alliance. Alliance should not attempt to upload a final video chunk during the shutdown process.
#### Any background context you want to provide?
#### What are the relevant tickets?
CAL-52
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
