### PR TITLE
CAL-43 add a delay before updating a metacard after immediately creat…

### DIFF
--- a/catalog/video/catalog-mpegts-stream/src/test/java/org/codice/alliance/video/stream/mpegts/rollover/TestCatalogRolloverAction.java
+++ b/catalog/video/catalog-mpegts-stream/src/test/java/org/codice/alliance/video/stream/mpegts/rollover/TestCatalogRolloverAction.java
@@ -84,7 +84,7 @@ public class TestCatalogRolloverAction {
         FilenameGenerator filenameGenerator = mock(FilenameGenerator.class);
         String filenameTemplate = "filenameTemplate";
         StreamProcessor streamProcessor = mock(StreamProcessor.class);
-        when(streamProcessor.getMetacardUpdateInitialDelay()).thenReturn(1000L);
+        when(streamProcessor.getMetacardUpdateInitialDelay()).thenReturn(1L);
         catalogFramework = mock(CatalogFramework.class);
         Security security = mock(Security.class);
         MetacardType metacardType = mock(MetacardType.class);


### PR DESCRIPTION
#### What does this PR do?
Add a delay before updating a metacard after immediately creating a metacard.
#### Who is reviewing it?
@ben @troy @jaymcnallie 
#### How should this be tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

