### PR TITLE
CAL-53 Added Metacard Action for Image Chipping

### DIFF
--- a/catalog/imaging/imaging-actionprovider-chip/.bowerrc
+++ b/catalog/imaging/imaging-actionprovider-chip/.bowerrc
@@ -1,0 +1,3 @@
+{
+   "directory": "target/webapp/lib"
+}

--- a/catalog/imaging/imaging-actionprovider-chip/Gruntfile.js
+++ b/catalog/imaging/imaging-actionprovider-chip/Gruntfile.js
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global module,require*/
+
+module.exports = function (grunt) {
+
+    require('load-grunt-tasks')(grunt);
+    grunt.loadTasks('src/main/grunt/tasks');
+
+    grunt.initConfig({
+       
+        pkg: grunt.file.readJSON('package.json'),
+
+        clean: {
+          build: ['target/webapp']
+        },
+        bower: {
+            install: {
+                options: {
+                    bowerOptions: {"--offline": true}
+                }
+
+            }
+        },
+        cssmin: {
+            compress: {
+                files: {
+                    "target/webapp/css/index.css": ["src/main/webapp/css/*.css"]
+                }
+            }
+        },
+        jshint: {
+            files: ['Gruntfile.js', 'src/main/webapp/js/**/*.js'],
+            options: {
+                bitwise: true,        // Prohibits the use of bitwise operators such as ^ (XOR), | (OR) and others.
+                forin: true,          // Requires all for in loops to filter object's items.
+                latedef: true,        // Prohibits the use of a variable before it was defined.
+                newcap: true,         // Requires you to capitalize names of constructor functions.
+                noarg: true,          // Prohibits the use of arguments.caller and arguments.callee. Both .caller and .callee make quite a few optimizations impossible so they were deprecated in future versions of JavaScript.
+                noempty: true,         // Warns when you have an empty block in your code.
+                regexp: true,         // Prohibits the use of unsafe . in regular expressions.
+                undef: true,          // Prohibits the use of explicitly undeclared variables.
+                unused: true,         // Warns when you define and never use your variables.
+                maxlen: 250,          // Set the maximum length of a line to 250 characters.  If triggered, the line should be wrapped.
+                eqeqeq: true,         // Prohibits the use of == and != in favor of === and !==
+
+                // Relaxing Options
+                scripturl: true,      // This option suppresses warnings about the use of script-targeted URLsâ€”such as
+
+                // options here to override JSHint defaults
+                globals: {
+                    console: true,
+                    module: true,
+                    $: true,
+                    window: true
+                }
+            }
+        },
+        watch: {
+            jsFiles: {
+                files: ['<%= jshint.files %>'],
+                tasks: ['jshint']
+            },
+            livereload : {
+                options : {livereload :true},
+                files : ['target/webapp/css/style.css'
+                    // this one is more dangerous, tends to reload the page if one file changes
+                    // probably too annoying to be useful, uncomment if you want to try it out
+//                    '<%= jshint.files %>'
+                ]
+            },
+            cssFiles : {
+                files :['src/main/webapp/css/*.css'],
+                tasks : ['cssmin']
+            },
+            bowerFile: {
+                files: ['src/main/webapp/bower.json'],
+                tasks: ['bower']
+            }
+        },
+        express: {
+            options: {
+                port: 8282,
+                hostname: '*'
+            },
+            
+            server: {
+                options: {
+                    server: './server.js'
+                }
+            }
+        }
+    });
+
+    grunt.loadNpmTasks('grunt-bower-task');
+    grunt.loadNpmTasks('grunt-contrib-clean');
+    grunt.loadNpmTasks('grunt-contrib-jshint');
+    grunt.loadNpmTasks('grunt-contrib-watch');
+    grunt.loadNpmTasks('grunt-express');
+
+    var buildTasks = ['clean', 'bower-offline-install', 'cssmin'];
+
+    grunt.registerTask('build', buildTasks);
+    grunt.registerTask('default', ['build','express', 'watch']);
+};

--- a/catalog/imaging/imaging-actionprovider-chip/bower.json
+++ b/catalog/imaging/imaging-actionprovider-chip/bower.json
@@ -1,0 +1,13 @@
+{
+  "name": "imaging-actionprovider-chip",
+  "version": "0.0.1",
+  "private": true,
+  "dependencies": {
+    "components-bootstrap": "3.1.1",
+    "components-font-awesome": "4.0.3",
+    "jquery": "components/jquery#1.11.0"
+  },
+  "resolutions": {
+    "jquery": "~1.11.0"
+  }
+}

--- a/catalog/imaging/imaging-actionprovider-chip/package.json
+++ b/catalog/imaging/imaging-actionprovider-chip/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "imaging-actionprovider-chip",
+  "author": "Codice",
+  "description": "Image chipping action provider for a metacard.",
+  "version": "0.0.1",
+  "license": "LGPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codice/alliance.git"
+  },
+  "engines": {
+    "node": ">=0.10.5"
+  },
+  "devDependencies": {
+    "grunt": "0.4.1",
+    "bower": "1.4.1",
+    "grunt-bower-task": "0.4.0",
+    "grunt-contrib-jshint": "0.3.0",
+    "grunt-contrib-clean": "0.4.0",
+    "grunt-contrib-watch": "0.4.4",
+    "grunt-contrib-cssmin": "0.5.0",
+    "connect-livereload": "0.3.2",
+    "grunt-cli": "0.1.13",
+    "grunt-express": "1.2.1",
+    "load-grunt-tasks": "1.0.0"
+  },
+  "dependencies": {
+    "express": "^4.13.3",
+    "http-proxy": "^1.12.0"
+  }
+}

--- a/catalog/imaging/imaging-actionprovider-chip/pom.xml
+++ b/catalog/imaging/imaging-actionprovider-chip/pom.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.codice.alliance.imaging</groupId>
+        <artifactId>imaging</artifactId>
+        <version>0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>imaging-actionprovider-chip</artifactId>
+    <packaging>bundle</packaging>
+    <name>Alliance :: Imaging :: Action Provider :: Chip</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.action.core</groupId>
+            <artifactId>action-core-impl</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.action.core</groupId>
+            <artifactId>action-core-api</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+            <version>${ddf.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.00</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.00</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.00</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.00</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.github.eirslett</groupId>
+                <artifactId>frontend-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>grunt install</id>
+                        <goals>
+                            <goal>grunt</goal>
+                        </goals>
+                        <phase>install</phase>
+                        <configuration>
+                            <arguments>build</arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Web-ContextPath>/chipping</Web-ContextPath>
+                        <_wab>src/main/webapp,${project.build.directory}/webapp</_wab>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>
+                            commons-lang3
+                        </Embed-Dependency>
+                        <Export-Package />
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/catalog/imaging/imaging-actionprovider-chip/src/main/grunt/tasks/bower.js
+++ b/catalog/imaging/imaging-actionprovider-chip/src/main/grunt/tasks/bower.js
@@ -1,0 +1,50 @@
+/*
+ * *
+ *  * Copyright (c) Codice Foundation
+ *  *
+ *  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ *  * General Public License as published by the Free Software Foundation, either version 3 of the
+ *  * License, or any later version.
+ *  *
+ *  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ *  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ *  * is distributed along with this program and can be found at
+ *  * <http://www.gnu.org/licenses/lgpl.html>.
+ *  *
+ *  *
+ */
+
+module.exports = function(grunt) {
+    grunt.registerTask('bower-offline-install', 'Offline first Bower install', function() {
+        var bower = require('bower');
+        var done = this.async();
+        grunt.log.debug("Trying to install bower packages offline.");
+        bower.commands
+            .install([], {'save': false, 'save-dev': false}, {offline: true})
+            .on('data', function (data) {
+                grunt.log.debug(data);
+            })
+            .on('error', function (data) {
+                grunt.log.debug(data);
+                grunt.log.debug("Trying to install bower packages online.");
+                bower.commands
+                    .install([], {'save': false, 'save-dev': false})
+                    .on('data', function (data) {
+                        grunt.log.debug(data);
+                    })
+                    .on('error', function (data) {
+                        grunt.log.error(data);
+                        done(false);
+                    })
+                    .on('end', function () {
+                        grunt.log.debug("Bower installed online.");
+                        done();
+                    });
+            })
+            .on('end', function () {
+                grunt.log.debug("Bower installed offline.");
+                done();
+            });
+    });
+};

--- a/catalog/imaging/imaging-actionprovider-chip/src/main/java/org/codice/alliance/imaging/chip/actionprovider/ImagingChipActionProvider.java
+++ b/catalog/imaging/imaging-actionprovider-chip/src/main/java/org/codice/alliance/imaging/chip/actionprovider/ImagingChipActionProvider.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.imaging.chip.actionprovider;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.codice.ddf.configuration.SystemBaseUrl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.action.Action;
+import ddf.action.ActionProvider;
+import ddf.action.impl.ActionImpl;
+import ddf.catalog.data.Metacard;
+
+public class ImagingChipActionProvider implements ActionProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ImagingChipActionProvider.class);
+
+    public static final String TITLE = "Chip Image";
+
+    public static final String DESCRIPTION =
+            "Opens a new window to enter the boundaries of an image chip for a Metacard.";
+
+    public static final String PATH = "/chipping/chipping.html";
+
+    public static final String ID = "catalog.data.metacard.image.chipping";
+
+    public static final String NITF_CONTENT_TYPE = "image/nitf";
+
+    @Override
+    public <T> List<Action> getActions(T input) {
+        if (input == null) {
+            LOGGER.warn("Metacard can not be null.");
+            return new ArrayList<>();
+        }
+
+        if (canHandle(input)) {
+            final Metacard metacard = (Metacard) input;
+
+            URL url;
+            String chipPath = null;
+            try {
+                chipPath =
+                        SystemBaseUrl.getBaseUrl() + PATH + "?id=" + metacard.getId() + "&source="
+                                + metacard.getSourceId();
+                url = new URL(chipPath);
+            } catch (MalformedURLException e) {
+                LOGGER.debug("Invalid URL for chipping path : {}", chipPath, e);
+                return new ArrayList<>();
+            }
+            return Arrays.asList(new ActionImpl(getId(), TITLE, DESCRIPTION, url));
+        }
+        return new ArrayList<>();
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @Override
+    public <T> boolean canHandle(T subject) {
+        if (subject instanceof Metacard) {
+            Metacard metacard = (Metacard) subject;
+            String contentTypeName = metacard.getContentTypeName();
+            if (NITF_CONTENT_TYPE.equals(contentTypeName) && metacard.getLocation() != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+

--- a/catalog/imaging/imaging-actionprovider-chip/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/imaging/imaging-actionprovider-chip/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+
+    <service interface="ddf.action.ActionProvider">
+        <service-properties>
+            <entry key="id" value="catalog.data.metacard.image.chipping"/>
+            <entry key="shortname" value="catalog.data.metacard.image.chipping"/>
+            <entry key="title" value="Image Chipping"/>
+            <entry key="description" value="Invoke Image Chipping on metacards."/>
+        </service-properties>
+        <bean class="org.codice.alliance.imaging.chip.actionprovider.ImagingChipActionProvider" />
+    </service>
+
+</blueprint>

--- a/catalog/imaging/imaging-actionprovider-chip/src/main/webapp/chipping.html
+++ b/catalog/imaging/imaging-actionprovider-chip/src/main/webapp/chipping.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<html lang="en">
+    <head>
+        <title>Image Chipping</title>
+
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="chrome=1">
+        <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
+
+        <script src="/chipping/lib/jquery/jquery.min.js"></script>
+        <link rel="stylesheet" type="text/css" href="/chipping/lib/components-font-awesome/css/font-awesome.min.css">
+        <link href="css/index.css" rel="stylesheet">
+        <link href="/search/standard/css/index.css" rel="stylesheet">
+        <link href="/chipping/lib/components-bootstrap/css/bootstrap.css" rel="stylesheet">
+    </head>
+
+    <body class="chipping-pane">
+        <div id="content">
+            <div><canvas id="canvas" width="1024" height="1024"></canvas></div>
+            <div>
+                <a class="btn chip-image" download>Download</a><button class="btn reset">Reset</button>
+            </div>
+        </div>
+
+        <script src="js/chipping.js"></script>
+        <script src="/chipping/lib/components-bootstrap/js/bootstrap.min.js"></script>
+    </body>
+</html>

--- a/catalog/imaging/imaging-actionprovider-chip/src/main/webapp/css/style.css
+++ b/catalog/imaging/imaging-actionprovider-chip/src/main/webapp/css/style.css
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+.chipping-pane {
+    color:white;
+    background-image:linear-gradient(to bottom,#252525,#252525);
+}
+
+.chip-image {
+    background-color:#2a9fd6;
+    color:white;
+}
+
+.reset {
+    background-color:#575757;
+    color:white;
+}

--- a/catalog/imaging/imaging-actionprovider-chip/src/main/webapp/js/chipping.js
+++ b/catalog/imaging/imaging-actionprovider-chip/src/main/webapp/js/chipping.js
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ /*global document,Image*/
+
+var source, id, canvas, context;
+var overviewUrl, rect, imageObj, drag;
+
+function setUrlParameters() {
+    var pageUrl = window.location.search.substring(1);
+    var parameters = pageUrl.split('&');
+
+    $.each(parameters, function(index, value) {
+        var parameter = value.split("=");
+        if(parameter[0] === "id") {
+            id = parameter[1];
+        } else if(parameter[0] === "source") {
+            source = parameter[1];
+        }
+    });
+    overviewUrl = "/services/catalog/sources/" + source + "/" + id + "?transform=resource&qualifier=overview";
+}
+
+function mouseDown(e) {
+    rect.startX = e.pageX - this.offsetLeft;
+    rect.startY = e.pageY - this.offsetTop;
+    drag = true;
+}
+
+function mouseUp() {
+    drag = false;
+}
+
+function draw() {
+    context.beginPath();
+    context.lineWidth="4";
+    context.strokeStyle="#f0e786";
+    context.rect(rect.startX, rect.startY, rect.w, rect.h);
+    context.stroke();
+}
+
+function mouseMove(e) {
+    if (drag) {
+        rect.w = (e.pageX - this.offsetLeft) - rect.startX;
+        rect.h = (e.pageY - this.offsetTop) - rect.startY ;
+        context.drawImage(imageObj, 0, 0, imageObj.width, imageObj.height, 0, 0, canvas.width, canvas.height);
+        draw();
+    }
+}
+
+function drawImage(srcImageUrl) {
+    rect = {};
+    imageObj = new Image();
+    imageObj.src = srcImageUrl;
+
+    canvas = document.getElementById('canvas');
+    context = canvas.getContext('2d');
+
+    imageObj.onload = function() {
+        $('canvas').attr('height', this.height);
+        $('canvas').attr('width', this.width);
+        context.drawImage(imageObj, 0, 0, imageObj.width, imageObj.height, 0, 0, canvas.width, canvas.height);
+    };
+    canvas.addEventListener('mousedown', mouseDown, false);
+    canvas.addEventListener('mouseup', mouseUp, false);
+    canvas.addEventListener('mousemove', mouseMove, false);
+}
+
+function setOnClickListeners() {
+    $('.chip-image').on('click', function() {
+        var x = rect.startX;
+        var y = rect.startY
+        var w = rect.w;
+        var h = rect.h;
+        var chipUrl = "/services/catalog/sources/" + source + "/" + id + "?transform=chip&qualifier=overview&x=" + x + "&y=" + y + "&w=" + w + "&h=" + h ;
+        $('.chip-image').attr('href',chipUrl);
+    });
+
+    $('.reset').on('click', function() {
+        drawImage(overviewUrl);
+    });
+}
+
+$(document).ready(function() {
+    setUrlParameters();
+    drawImage(overviewUrl);
+    setOnClickListeners();
+});
+
+

--- a/catalog/imaging/imaging-actionprovider-chip/src/test/java/org/codice/alliance/imaging/chip/actionprovider/TestImageChipActionProvider.java
+++ b/catalog/imaging/imaging-actionprovider-chip/src/test/java/org/codice/alliance/imaging/chip/actionprovider/TestImageChipActionProvider.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.imaging.chip.actionprovider;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+
+import org.codice.ddf.configuration.SystemBaseUrl;
+import org.junit.Before;
+import org.junit.Test;
+
+import ddf.action.Action;
+import ddf.catalog.data.impl.MetacardImpl;
+
+public class TestImageChipActionProvider {
+
+    private static final String ZIP_CONTENT_TYPE = "application/zip";
+
+    private static final String ID = "12345";
+
+    private static final String SOURCE = "alliance.distribution";
+
+    private static final String LOCATION =
+            "POLYGON((0.1234 2.222, 0.4444 1.222, 0.1234 1.222, 0.1234 2.222, 0.1234 2.222))";
+
+    private ImagingChipActionProvider imagingChipActionProvider;
+
+    private MetacardImpl metacard;
+
+    @Before
+    public void setUp() {
+        imagingChipActionProvider = new ImagingChipActionProvider();
+        metacard = new MetacardImpl();
+        metacard.setContentTypeName(ImagingChipActionProvider.NITF_CONTENT_TYPE);
+        metacard.setId(ID);
+        metacard.setSourceId(SOURCE);
+        metacard.setLocation(LOCATION);
+    }
+
+    @Test
+    public void testCanHandleNullMetacard() {
+        assertThat(imagingChipActionProvider.canHandle(null), is(false));
+    }
+
+    @Test
+    public void testCanHandleInvalidMetacard() {
+        assertThat(imagingChipActionProvider.canHandle(new Object()), is(false));
+    }
+
+    @Test
+    public void testCanHandleInvalidLocationOnMetacard() {
+        metacard.setLocation(null);
+        assertThat(imagingChipActionProvider.canHandle(metacard), is(false));
+    }
+
+    @Test
+    public void testCanHandleNullContentTypeMetacard() {
+        MetacardImpl metacard = new MetacardImpl();
+        assertThat(imagingChipActionProvider.canHandle(metacard), is(false));
+    }
+
+    @Test
+    public void testCanHandleNonImageryMetacard() {
+        MetacardImpl metacard = new MetacardImpl();
+        metacard.setContentTypeName(ZIP_CONTENT_TYPE);
+        assertThat(imagingChipActionProvider.canHandle(metacard), is(false));
+    }
+
+    @Test
+    public void testCanHandleImageryMetacard() {
+        assertThat(imagingChipActionProvider.canHandle(metacard), is(true));
+    }
+
+    @Test
+    public void testGetId() {
+        assertThat(imagingChipActionProvider.getId(), is(ImagingChipActionProvider.ID));
+    }
+
+    @Test
+    public void testGetActionsNullMetacard() {
+        assertThat(imagingChipActionProvider.getActions(null), hasSize(0));
+    }
+
+    @Test
+    public void testGetActionsCanNotHandleMetacard() {
+        metacard.setLocation(null);
+        assertThat(imagingChipActionProvider.getActions(metacard), hasSize(0));
+    }
+
+    @Test
+    public void testGetActionsUnsupportedProtocolOnMetacard() {
+        String protocol = SystemBaseUrl.getProtocol();
+        System.setProperty("org.codice.ddf.system.protocol", "udp://");
+        assertThat(imagingChipActionProvider.getActions(metacard), hasSize(0));
+        System.setProperty("org.codice.ddf.system.protocol", protocol);
+    }
+
+    @Test
+    public void testGetActionsMetacard() {
+        List<Action> actions = imagingChipActionProvider.getActions(metacard);
+        assertThat(actions, hasSize(1));
+
+        Action action = actions.get(0);
+        assertThat(action.getId(), is(ImagingChipActionProvider.ID));
+        assertThat(action.getDescription(), is(ImagingChipActionProvider.DESCRIPTION));
+        assertThat(action.getTitle(), is(ImagingChipActionProvider.TITLE));
+
+        String url = action.getUrl()
+                .toString();
+        assertThat(url, containsString(ImagingChipActionProvider.PATH));
+        assertThat(url, containsString("id=" + ID));
+        assertThat(url, containsString("source=" + SOURCE));
+    }
+}

--- a/catalog/imaging/imaging-app/pom.xml
+++ b/catalog/imaging/imaging-app/pom.xml
@@ -50,6 +50,11 @@
             <artifactId>imaging-transformer-chipping</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.codice.alliance.imaging</groupId>
+            <artifactId>imaging-actionprovider-chip</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/catalog/imaging/imaging-app/src/main/resources/features.xml
+++ b/catalog/imaging/imaging-app/src/main/resources/features.xml
@@ -23,5 +23,6 @@
         <bundle>mvn:org.codice.alliance.imaging/imaging-service-impl/${project.version}</bundle>
         <bundle>mvn:org.codice.alliance.imaging/imaging-transformer-nitf/${project.version}</bundle>
         <bundle>mvn:org.codice.alliance.imaging/imaging-transformer-chipping/${project.version}</bundle>
+        <bundle>mvn:org.codice.alliance.imaging/imaging-actionprovider-chip/${project.version}</bundle>
     </feature>
 </features>

--- a/catalog/imaging/pom.xml
+++ b/catalog/imaging/pom.xml
@@ -49,5 +49,6 @@
         <module>imaging-transformer-nitf</module>
         <module>imaging-transformer-chipping</module>
         <module>imaging-app</module>
+        <module>imaging-actionprovider-chip</module>
     </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -58,10 +58,10 @@
         <jcodec.version>0.2.0_1</jcodec.version>
         <mpegts-streamer.version>0.1.0_1</mpegts-streamer.version>
         <commons-collections4.version>4.1</commons-collections4.version>
-        <commons-configuration.version>1.10</commons-configuration.version>
         <commons-io.version>2.1</commons-io.version>
         <node.version>v4.4.4</node.version>
         <npm.version>2.15.6</npm.version>
+        <commons-configuration.version>1.10</commons-configuration.version>
     </properties>
 
     <scm>
@@ -306,7 +306,6 @@
                         </execution>
                     </executions>
                 </plugin>
-
                 <plugin>
                     <groupId>com.github.eirslett</groupId>
                     <artifactId>frontend-maven-plugin</artifactId>


### PR DESCRIPTION
#### What does this PR do?
This PR adds an Action Page for the Image Chipping Service
#### Who is reviewing it?
@dcruver @glenhein 
@jlcsmith @kcwire 
#### How should this be tested?
Build Alliance and Install.  Ingest a NITF that has a Geolocation.  Click the `Chip Image` Action from the Action tab and Chip the image in various ways.
#### Any background context you want to provide?
This PR is intended to be used in the new Catalog UI and the Action Page may be too large to be used reasonably in the Search UI.  There is currently a bug in the backend image chipping service that inverts north/south coordinates that is currently being resolved.  
#### What are the relevant tickets?
https://codice.atlassian.net/browse/CAL-53
#### Screenshots (if appropriate)
https://codice.atlassian.net/browse/CAL-53
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
