### PR TITLE
CAL-61: Added the ability to specify sources by name on the NSILI Endpoint

### DIFF
--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/Nsili.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/Nsili.java
@@ -25,7 +25,6 @@ import javax.ws.rs.core.MediaType;
 public interface Nsili {
 
     @GET
-    @Consumes({MediaType.TEXT_PLAIN, MediaType.APPLICATION_OCTET_STREAM, MediaType.WILDCARD})
     @Produces({MediaType.TEXT_PLAIN, MediaType.APPLICATION_OCTET_STREAM, MediaType.WILDCARD})
     InputStream getIorFile();
 }

--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliAttributeMap.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliAttributeMap.java
@@ -58,7 +58,7 @@ public class NsiliAttributeMap {
         nsiliToDdfMap.put(NsiliConstants.NSIL_COMMON + "." + NsiliConstants.TARGET_NUMBER,
                 "targetNumber");
         nsiliToDdfMap.put(NsiliConstants.NSIL_COMMON + "." + NsiliConstants.TYPE, "productType");
-        nsiliToDdfMap.put(NsiliConstants.NSIL_CXP + "." + NsiliConstants.STATUS, "status");
+        nsiliToDdfMap.put(NsiliConstants.NSIL_CXP + "." + NsiliConstants.STATUS, "cxpStatus");
         nsiliToDdfMap.put(NsiliConstants.NSIL_COVERAGE + "." + NsiliConstants.SPATIAL_COUNTRY_CODE,
                 "countryCode");
         nsiliToDdfMap.put(
@@ -148,7 +148,7 @@ public class NsiliAttributeMap {
                 "forInformation");
         nsiliToDdfMap.put(NsiliConstants.NSIL_RFI + "." + NsiliConstants.SERIAL_NUMBER,
                 "serialNumber");
-        nsiliToDdfMap.put(NsiliConstants.NSIL_RFI + "." + NsiliConstants.STATUS, "status");
+        nsiliToDdfMap.put(NsiliConstants.NSIL_RFI + "." + NsiliConstants.STATUS, "rfiStatus");
         nsiliToDdfMap.put(NsiliConstants.NSIL_RFI + "." + NsiliConstants.WORKFLOW_STATUS,
                 "workflowStatus");
         nsiliToDdfMap.put(NsiliConstants.NSIL_SDS + "." + NsiliConstants.OPERATIONAL_STATUS,
@@ -168,7 +168,7 @@ public class NsiliAttributeMap {
         nsiliToDdfMap.put(NsiliConstants.NSIL_STREAM + "." + NsiliConstants.SOURCE_URL,
                 Metacard.RESOURCE_DOWNLOAD_URL);
         nsiliToDdfMap.put(NsiliConstants.NSIL_TASK + "." + NsiliConstants.COMMENTS, "comments");
-        nsiliToDdfMap.put(NsiliConstants.NSIL_TASK + "." + NsiliConstants.STATUS, "status");
+        nsiliToDdfMap.put(NsiliConstants.NSIL_TASK + "." + NsiliConstants.STATUS, "taskStatus");
         nsiliToDdfMap.put(NsiliConstants.NSIL_TDL + "." + NsiliConstants.ACTIVITY, "activity");
         nsiliToDdfMap.put(NsiliConstants.NSIL_TDL + "." + NsiliConstants.MESSAGE_NUM,
                 "messageNumber");

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/NsiliEndpoint.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/NsiliEndpoint.java
@@ -17,6 +17,8 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.codice.ddf.security.handler.api.AuthenticationHandler;
 import org.codice.ddf.security.handler.api.BaseAuthenticationToken;
@@ -72,11 +74,11 @@ public class NsiliEndpoint {
 
     private FilterBuilder filterBuilder;
 
-    private boolean enterpriseSearch = false;
-
     private int defaultUpdateFrequencySec = 60;
 
     private int maxPendingResults = 10000;
+
+    private List<String> querySources = new ArrayList<>();
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NsiliEndpoint.class);
 
@@ -85,6 +87,8 @@ public class NsiliEndpoint {
     }
 
     public void shutdown() {
+        LOGGER.info("Attempting to Shutdown the ORB");
+
         if (orb != null) {
             LOGGER.debug("Stopping ORB on port: {}", corbaPort);
             orb.shutdown(true);
@@ -123,6 +127,21 @@ public class NsiliEndpoint {
         }
     }
 
+    public List<String> getQuerySources() {
+        return querySources;
+    }
+
+    public void setQuerySources(List<String> querySources) {
+        this.querySources.clear();
+        if (querySources != null) {
+            this.querySources.addAll(querySources);
+        }
+
+        if (library != null) {
+            library.setQuerySources(querySources);
+        }
+    }
+
     public void setDefaultUpdateFrequencySec(int defaultUpdateFrequencySec) {
         this.defaultUpdateFrequencySec = defaultUpdateFrequencySec;
         if (library != null) {
@@ -152,17 +171,6 @@ public class NsiliEndpoint {
 
     public void setFramework(CatalogFramework framework) {
         this.framework = framework;
-    }
-
-    public void setEnterpriseSearch(boolean enterpriseSearch) {
-        if (library != null) {
-            library.setEnterpriseSearch(enterpriseSearch);
-        }
-        this.enterpriseSearch = enterpriseSearch;
-    }
-
-    public boolean getEnterpriseSearch() {
-        return enterpriseSearch;
     }
 
     public void setFilterBuilder(FilterBuilder filterBuilder) {
@@ -217,9 +225,9 @@ public class NsiliEndpoint {
         Subject guestSubject = getGuestSubject();
         library.setGuestSubject(guestSubject);
         library.setFilterBuilder(filterBuilder);
-        library.setEnterpriseSearch(enterpriseSearch);
         library.setDefaultUpdateFrequencyMsec(defaultUpdateFrequencySec * 1000);
         library.setMaxPendingResults(maxPendingResults);
+        library.setQuerySources(querySources);
 
         org.omg.CORBA.Object objref = rootPOA.servant_to_reference(library);
 

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/managers/AccessManagerImpl.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/managers/AccessManagerImpl.java
@@ -66,6 +66,8 @@ public class AccessManagerImpl extends AccessManagerPOA {
 
     private Subject subject;
 
+    private List<String> querySources = new ArrayList<>();
+
     private int defaultTimeout = DEFAULT_TIMEOUT;
 
     public AccessManagerImpl() {
@@ -82,6 +84,13 @@ public class AccessManagerImpl extends AccessManagerPOA {
 
     public void setSubject(Subject subject) {
         this.subject = subject;
+    }
+
+    public void setQuerySources(List<String> querySources) {
+        this.querySources.clear();
+        if (querySources != null) {
+            this.querySources.addAll(querySources);
+        }
     }
 
     @Override
@@ -190,7 +199,13 @@ public class AccessManagerImpl extends AccessManagerPOA {
         catalogQuery.setRequestsTotalResultsCount(false);
         catalogQuery.setPageSize(10);
 
-        QueryRequestImpl catalogQueryRequest = new QueryRequestImpl(catalogQuery);
+        QueryRequestImpl catalogQueryRequest;
+
+        if (querySources == null || querySources.isEmpty()) {
+            catalogQueryRequest = new QueryRequestImpl(catalogQuery);
+        } else {
+            catalogQueryRequest = new QueryRequestImpl(catalogQuery, false, querySources, null);
+        }
 
         try {
             QueryResultsCallable

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/managers/OrderMgrImpl.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/managers/OrderMgrImpl.java
@@ -61,6 +61,8 @@ public class OrderMgrImpl extends OrderMgrPOA {
 
     private Subject subject;
 
+    private List<String> querySources = new ArrayList<>();
+
     public void setCatalogFramework(CatalogFramework catalogFramework) {
         this.catalogFramework = catalogFramework;
     }
@@ -71,6 +73,13 @@ public class OrderMgrImpl extends OrderMgrPOA {
 
     public void setSubject(Subject subject) {
         this.subject = subject;
+    }
+
+    public void setQuerySources(List<String> querySources) {
+        this.querySources.clear();
+        if (querySources != null) {
+            this.querySources.addAll(querySources);
+        }
     }
 
     @Override
@@ -219,6 +228,7 @@ public class OrderMgrImpl extends OrderMgrPOA {
             accessManager.setCatalogFramework(catalogFramework);
             accessManager.setFilterBuilder(filterBuilder);
             accessManager.setSubject(subject);
+            accessManager.setQuerySources(querySources);
 
             String managerId = UUID.randomUUID()
                     .toString();

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/managers/ProductMgrImpl.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/managers/ProductMgrImpl.java
@@ -72,12 +72,12 @@ public class ProductMgrImpl extends ProductMgrPOA {
 
     private Subject subject;
 
+    private List<String> querySources;
+
     private AccessManagerImpl accessManager;
 
-    private boolean enterpriseSearch = false;
-
-    public ProductMgrImpl(boolean enterpriseSearch) {
-        this.enterpriseSearch = enterpriseSearch;
+    public ProductMgrImpl(List<String> querySources) {
+        this.querySources = querySources;
     }
 
     public void setCatalogFramework(CatalogFramework catalogFramework) {
@@ -110,7 +110,7 @@ public class ProductMgrImpl extends ProductMgrPOA {
                     catalogFramework,
                     filterBuilder,
                     subject,
-                    enterpriseSearch);
+                    querySources);
             _poa().activate_object_with_id(id.getBytes(Charset.forName(NsiliEndpoint.ENCODING)),
                     getParametersRequest);
 
@@ -273,6 +273,7 @@ public class ProductMgrImpl extends ProductMgrPOA {
             accessManager.setCatalogFramework(catalogFramework);
             accessManager.setFilterBuilder(filterBuilder);
             accessManager.setSubject(subject);
+            accessManager.setQuerySources(querySources);
 
             String managerId = UUID.randomUUID()
                     .toString();

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/managers/StandingQueryMgrImpl.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/managers/StandingQueryMgrImpl.java
@@ -14,6 +14,8 @@
 package org.codice.alliance.nsili.endpoint.managers;
 
 import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import org.codice.alliance.nsili.common.GIAS.Event;
@@ -60,12 +62,14 @@ public class StandingQueryMgrImpl extends StandingQueryMgrPOA {
 
     private int maxPendingResults;
 
-    private boolean enterpriseSearch;
+    private List<String> querySources = new ArrayList<>();
 
     private long defaultTimeout = AccessManagerImpl.DEFAULT_TIMEOUT;
 
-    public StandingQueryMgrImpl(boolean enterpriseSearch) {
-        this.enterpriseSearch = enterpriseSearch;
+    public StandingQueryMgrImpl(List<String> querySources) {
+        if (querySources != null) {
+            this.querySources.addAll(querySources);
+        }
         init();
     }
 
@@ -131,7 +135,7 @@ public class StandingQueryMgrImpl extends StandingQueryMgrPOA {
                 subject,
                 filterBuilder,
                 defaultUpdateFrequencyMsec,
-                enterpriseSearch,
+                querySources,
                 maxPendingResults);
 
         String id = UUID.randomUUID()

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -34,9 +34,11 @@
         <property name="filterBuilder" ref="filterBuilder" />
         <property name="securityHandler" ref="securityHandler" />
         <property name="securityManager" ref="securityManager" />
-        <property name="enterpriseSearch" value="false" />
         <property name="defaultUpdateFrequencySec" value="60" />
         <property name="maxPendingResults" value="10000" />
+        <property name="querySources">
+            <array/>
+        </property>
     </bean>
 
     <bean id="nsiliWebSvc" class="org.codice.alliance.nsili.endpoint.NsiliWebEndpoint">

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -27,11 +27,6 @@
                 default="500"
         />
         <AD
-                description="Select for enterprise searching (deselected is local catalog only)."
-                name="Enterprise Search" id="enterpriseSearch" required="true" type="Boolean"
-                default="false"
-        />
-        <AD
                 description="Default update rate for standing queries (seconds)"
                 name="Standing Query Update Rate" id="defaultUpdateFrequencySec" required="true" type="Integer"
                 default="60"
@@ -41,6 +36,10 @@
                 name="Maximum Number Pending Results" id="maxPendingResults" required="true" type="Integer"
                 default="10000"
         />
+
+        <AD name="Sources to Query:" id="querySources" description="Configured sources to query from this endpoint. Empty list defaults to local only."
+            required="true" type="String" cardinality="1000"
+            default=""/>
     </OCD>
 
     <Designate pid="org.codice.alliance.nsili.endpoint">

--- a/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/TestCatalogMgrImpl.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/TestCatalogMgrImpl.java
@@ -93,7 +93,7 @@ public class TestCatalogMgrImpl extends TestNsiliCommon {
 
         testQuery = new Query(NsiliConstants.NSIL_ALL_VIEW, bqsQuery);
 
-        catalogMgr = new CatalogMgrImpl(rootPOA, new GeotoolsFilterBuilder(), false);
+        catalogMgr = new CatalogMgrImpl(rootPOA, new GeotoolsFilterBuilder(), null);
         catalogMgr.setGuestSubject(mockSubject);
         catalogMgr.setCatalogFramework(mockCatalogFramework);
     }

--- a/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/TestProductMgrImpl.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/TestProductMgrImpl.java
@@ -99,7 +99,7 @@ public class TestProductMgrImpl extends TestNsiliCommon {
         }
 
         String managerId = UUID.randomUUID().toString();
-        productMgr = new ProductMgrImpl(false);
+        productMgr = new ProductMgrImpl(null);
         productMgr.setFilterBuilder(new GeotoolsFilterBuilder());
         productMgr.setSubject(mockSubject);
         productMgr.setCatalogFramework(mockCatalogFramework);

--- a/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/TestStandingQueryMgrImpl.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/TestStandingQueryMgrImpl.java
@@ -104,7 +104,7 @@ public class TestStandingQueryMgrImpl extends TestNsiliCommon {
         }
 
         String managerId = UUID.randomUUID().toString();
-        standingQueryMgr = new StandingQueryMgrImpl(false);
+        standingQueryMgr = new StandingQueryMgrImpl(null);
         standingQueryMgr.setFilterBuilder(new GeotoolsFilterBuilder());
         standingQueryMgr.setSubject(mockSubject);
         standingQueryMgr.setCatalogFramework(mockCatalogFramework);

--- a/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/TestSubmitStandingQueryRequestImpl.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/TestSubmitStandingQueryRequestImpl.java
@@ -383,7 +383,7 @@ public class TestSubmitStandingQueryRequestImpl extends TestNsiliCommon {
                 mockSubject,
                 filterBuilder,
                 defaultUpdateFrequencyMsec,
-                false,
+                null,
                 maxPendingResults);
         standingQueryRequest.register_callback(mockCallback2);
 

--- a/catalog/nsili/catalog-nsili-source/src/main/java/org/codice/alliance/nsili/source/NsiliFilterDelegate.java
+++ b/catalog/nsili/catalog-nsili-source/src/main/java/org/codice/alliance/nsili/source/NsiliFilterDelegate.java
@@ -437,7 +437,7 @@ public class  NsiliFilterDelegate extends FilterDelegate<String> {
 
     @Override
     public String propertyIsLike(String propertyName, String pattern, boolean isCaseSensitive) {
-        String filter = filterFactory.buildPropertyIsLike(pattern);
+        String filter = filterFactory.buildPropertyIsLike(propertyName, pattern);
         return filter;
     }
 

--- a/catalog/nsili/catalog-nsili-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/nsili/catalog-nsili-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -23,15 +23,21 @@
     <!-- Metacard Type Subclasses to register -->
     <bean id="nsiliMetacardType" class="org.codice.alliance.nsili.common.NsiliMetacardType"/>
     <bean id="nsiliCxpMetacardType" class="org.codice.alliance.nsili.common.NsiliCxpMetacardType"/>
-    <bean id="nsiliGmtiMetacardType" class="org.codice.alliance.nsili.common.NsiliGmtiMetacardType"/>
-    <bean id="nsiliImageryMetacardType" class="org.codice.alliance.nsili.common.NsiliImageryMetacardType"/>
+    <bean id="nsiliGmtiMetacardType"
+          class="org.codice.alliance.nsili.common.NsiliGmtiMetacardType"/>
+    <bean id="nsiliImageryMetacardType"
+          class="org.codice.alliance.nsili.common.NsiliImageryMetacardType"/>
     <bean id="nsiliIRMetacardType" class="org.codice.alliance.nsili.common.NsiliIRMetacardType"/>
-    <bean id="nsiliMessageMetacardType" class="org.codice.alliance.nsili.common.NsiliMessageMetacardType"/>
-    <bean id="nsiliReportMetacardType" class="org.codice.alliance.nsili.common.NsiliReportMetacardType"/>
+    <bean id="nsiliMessageMetacardType"
+          class="org.codice.alliance.nsili.common.NsiliMessageMetacardType"/>
+    <bean id="nsiliReportMetacardType"
+          class="org.codice.alliance.nsili.common.NsiliReportMetacardType"/>
     <bean id="nsiliRfiMetacardType" class="org.codice.alliance.nsili.common.NsiliRfiMetacardType"/>
-    <bean id="nsiliTaskMetacardType" class="org.codice.alliance.nsili.common.NsiliTaskMetacardType"/>
+    <bean id="nsiliTaskMetacardType"
+          class="org.codice.alliance.nsili.common.NsiliTaskMetacardType"/>
     <bean id="nsiliTdlMetacardType" class="org.codice.alliance.nsili.common.NsiliTdlMetacardType"/>
-    <bean id="nsiliVideoMetacardType" class="org.codice.alliance.nsili.common.NsiliVideoMetacardType"/>
+    <bean id="nsiliVideoMetacardType"
+          class="org.codice.alliance.nsili.common.NsiliVideoMetacardType"/>
 
     <reference id="filterAdapter" interface="ddf.catalog.filter.FilterAdapter"/>
 
@@ -64,11 +70,13 @@
             <property name="corbaTimeout" value="60"/>
             <property name="pollInterval" value="5"/>
             <property name="maxHitCount" value="250"/>
-            <property name="numberWorkerThreads" value="4" />
-            <property name="accessUserId" value="" />
-            <property name="accessPassword" value="" />
-            <property name="accessLicenseKey" value="" />
-            <property name="excludeSortOrder" value="false" />
+            <property name="additionalQueryParams"
+                      value="and (not NSIL_PRODUCT:NSIL_CARD.status = 'OBSOLETE')"/>
+            <property name="numberWorkerThreads" value="4"/>
+            <property name="accessUserId" value=""/>
+            <property name="accessPassword" value=""/>
+            <property name="accessLicenseKey" value=""/>
+            <property name="excludeSortOrder" value="false"/>
             <property name="filterAdapter" ref="filterAdapter"/>
             <property name="resourceReader" ref="urlReader"/>
         </cm:managed-component>
@@ -91,11 +99,13 @@
             <property name="corbaTimeout" value="60"/>
             <property name="pollInterval" value="5"/>
             <property name="maxHitCount" value="250"/>
-            <property name="numberWorkerThreads" value="4" />
-            <property name="accessUserId" value="" />
-            <property name="accessPassword" value="" />
-            <property name="accessLicenseKey" value="" />
-            <property name="excludeSortOrder" value="false" />
+            <property name="additionalQueryParams"
+                      value="and (not NSIL_PRODUCT:NSIL_CARD.status = 'OBSOLETE')"/>
+            <property name="numberWorkerThreads" value="4"/>
+            <property name="accessUserId" value=""/>
+            <property name="accessPassword" value=""/>
+            <property name="accessLicenseKey" value=""/>
+            <property name="excludeSortOrder" value="false"/>
             <property name="filterAdapter" ref="filterAdapter"/>
             <property name="resourceReader" ref="urlReader"/>
         </cm:managed-component>

--- a/catalog/nsili/catalog-nsili-source/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/nsili/catalog-nsili-source/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -41,27 +41,37 @@
         <AD description="The Maximum Hit Count for Queries to the Source" name="Max Hit Count"
             id="maxHitCount" required="true" type="Integer" default="250"/>
 
+        <AD description="NSILI Query Parameters to always include" name="Additional Query Params"
+            id="additionalQueryParams" required="false" type="String"
+            default="and (not NSIL_PRODUCT:NSIL_CARD.status = 'OBSOLETE')"/>
+
         <AD description="Poll Interval to Check if the Source is available (in minutes - minimum 1)."
             name="Poll Interval" id="pollInterval"
             required="true" type="Integer" default="5"/>
 
-        <AD description="Maximum parallel threads for converting results and retrieving thumbnails" name="Num Worker Threads"
+        <AD description="Maximum parallel threads for converting results and retrieving thumbnails"
+            name="Num Worker Threads"
             id="numberWorkerThreads" required="true" type="Integer" default="4"/>
 
         <AD description="Whether or not to exclude sort order in query."
-            name="Exclude Sort Order" id="excludeSortOrder" required="false" type="Boolean" default="false"/>
+            name="Exclude Sort Order" id="excludeSortOrder" required="false" type="Boolean"
+            default="false"/>
 
         <AD description="Swap coordinates for systems that send latitude in the X field of the coordinate."
-            name="Swap X/Y Coordinates" id="swapCoordinates" required="false" type="Boolean" default="false"/>
+            name="Swap X/Y Coordinates" id="swapCoordinates" required="false" type="Boolean"
+            default="false"/>
 
         <AD description="User ID for NSILI Access Criteria"
-            name="NSILI Access Criteria User" id="accessUserId" required="false" type="String" default=""/>
+            name="NSILI Access Criteria User" id="accessUserId" required="false" type="String"
+            default=""/>
 
         <AD description="Password for NSILI Access Criteria"
-            name="NSILI Access Criteria Password" id="accessPassword" required="false" type="Password" default=""/>
+            name="NSILI Access Criteria Password" id="accessPassword" required="false"
+            type="Password" default=""/>
 
         <AD description="License Key for NSILI Access Criteria"
-            name="NSILI Access Criteria License Key" id="accessLicenseKey" required="false" type="String" default=""/>
+            name="NSILI Access Criteria License Key" id="accessLicenseKey" required="false"
+            type="String" default=""/>
     </OCD>
 
     <OCD name="NSILI Connected Source" id="NSILI_Connected_Source"
@@ -91,27 +101,37 @@
         <AD description="The Maximum Hit Count for Queries to the Source" name="Max Hit Count"
             id="maxHitCount" required="true" type="Integer" default="250"/>
 
+        <AD description="NSILI Query Parameters to always include" name="Additional Query Params"
+            id="additionalQueryParams" required="false" type="String"
+            default="and (not NSIL_PRODUCT:NSIL_CARD.status = 'OBSOLETE')"/>
+
         <AD description="Poll Interval to Check if the Source is available (in minutes - minimum 1)."
             name="Poll Interval" id="pollInterval"
             required="true" type="Integer" default="5"/>
 
-        <AD description="Maximum parallel threads for converting results and retrieving thumbnails" name="Num Worker Threads"
+        <AD description="Maximum parallel threads for converting results and retrieving thumbnails"
+            name="Num Worker Threads"
             id="numberWorkerThreads" required="true" type="Integer" default="4"/>
 
         <AD description="Whether or not to exclude sort order in query."
-            name="Exclude Sort Order" id="excludeSortOrder" required="false" type="Boolean" default="false"/>
+            name="Exclude Sort Order" id="excludeSortOrder" required="false" type="Boolean"
+            default="false"/>
 
         <AD description="Swap coordinates for systems that send latitude in the X field of the coordinate."
-            name="Swap X/Y Coordinates" id="swapCoordinates" required="false" type="Boolean" default="false"/>
+            name="Swap X/Y Coordinates" id="swapCoordinates" required="false" type="Boolean"
+            default="false"/>
 
         <AD description="User ID for NSILI Access Criteria"
-            name="NSILI Access Criteria User" id="accessUserId" required="false" type="String" default=""/>
+            name="NSILI Access Criteria User" id="accessUserId" required="false" type="String"
+            default=""/>
 
         <AD description="Password for NSILI Access Criteria"
-            name="NSILI Access Criteria Password" id="accessPassword" required="false" type="Password" default=""/>
+            name="NSILI Access Criteria Password" id="accessPassword" required="false"
+            type="Password" default=""/>
 
         <AD description="License Key for NSILI Access Criteria"
-            name="NSILI Access Criteria License Key" id="accessLicenseKey" required="false" type="String" default=""/>
+            name="NSILI Access Criteria License Key" id="accessLicenseKey" required="false"
+            type="String" default=""/>
     </OCD>
 
     <Designate pid="NSILI_Federated_Source" factoryPid="NSILI_Federated_Source">

--- a/catalog/nsili/catalog-nsili-source/src/test/java/org/codice/alliance/nsili/source/TestNsiliFilterDelegate.java
+++ b/catalog/nsili/catalog-nsili-source/src/test/java/org/codice/alliance/nsili/source/TestNsiliFilterDelegate.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.TimeZone;
 
 import org.apache.commons.lang3.StringUtils;
-
 import org.codice.alliance.nsili.common.GIAS.AttributeInformation;
 import org.codice.alliance.nsili.common.GIAS.AttributeType;
 import org.codice.alliance.nsili.common.GIAS.DateRange;
@@ -37,7 +36,6 @@ import org.codice.alliance.nsili.common.GIAS.RequirementMode;
 import org.codice.alliance.nsili.common.NsiliConstants;
 import org.codice.alliance.nsili.common.UCO.Coordinate2d;
 import org.codice.alliance.nsili.common.UCO.Rectangle;
-
 import org.junit.Before;
 import org.junit.Test;
 
@@ -45,11 +43,13 @@ import ddf.catalog.data.Metacard;
 
 public class TestNsiliFilterDelegate {
 
-    private static final String ANY_TEXT = "anyText";
+    private static final String ANY_TEXT = Metacard.ANY_TEXT;
 
     private static NsiliFilterDelegate filterDelegate;
 
-    private static final String PROPERTY = "property";
+    private static final String PROPERTY = "publisher";
+
+    private static final String DATE_PROPERTY = Metacard.MODIFIED;
 
     private static final String ATTRIBUTE = "attribute";
 
@@ -99,15 +99,17 @@ public class TestNsiliFilterDelegate {
     @Test
     public void testPropertyIsEqualToStringLiteral() {
         String filter = filterDelegate.propertyIsEqualTo(PROPERTY, ATTRIBUTE, false);
-        assertThat(filter, is(getPrimary(NsiliFilterFactory.EQ,
-                NsiliFilterDelegate.SQ + ATTRIBUTE + NsiliFilterDelegate.SQ)));
+        assertThat(filter,
+                is(getPrimary(NsiliFilterFactory.EQ,
+                        NsiliFilterDelegate.SQ + ATTRIBUTE + NsiliFilterDelegate.SQ)));
     }
 
     @Test
     public void testPropertyIsEqualToDateLiteral() {
         String filter = filterDelegate.propertyIsEqualTo(PROPERTY, DATE);
-        assertThat(filter, is(getPrimary(NsiliFilterFactory.EQ,
-                NsiliFilterDelegate.SQ + DATE_STRING + NsiliFilterDelegate.SQ)));
+        assertThat(filter,
+                is(getPrimary(NsiliFilterFactory.EQ,
+                        NsiliFilterDelegate.SQ + DATE_STRING + NsiliFilterDelegate.SQ)));
     }
 
     @Test
@@ -143,8 +145,9 @@ public class TestNsiliFilterDelegate {
     @Test
     public void testPropertyIsEqualToBooleanLiteral() {
         String filter = filterDelegate.propertyIsEqualTo(PROPERTY, false);
-        assertThat(filter, is(getPrimary(NsiliFilterFactory.EQ,
-                NsiliFilterDelegate.SQ + FALSE + NsiliFilterDelegate.SQ)));
+        assertThat(filter,
+                is(getPrimary(NsiliFilterFactory.EQ,
+                        NsiliFilterDelegate.SQ + FALSE + NsiliFilterDelegate.SQ)));
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -160,57 +163,55 @@ public class TestNsiliFilterDelegate {
     @Test
     public void testPropertyIsNotEqualToStringLiteral() {
         String filter = filterDelegate.propertyIsNotEqualTo(PROPERTY, ATTRIBUTE, false);
-        assertThat(filter, is(NsiliFilterFactory.NOT + getPrimary(NsiliFilterFactory.EQ,
-                NsiliFilterDelegate.SQ + ATTRIBUTE + NsiliFilterDelegate.SQ)));
+        assertThat(filter,
+                is(NsiliFilterFactory.NOT + getPrimary(NsiliFilterFactory.EQ,
+                        NsiliFilterDelegate.SQ + ATTRIBUTE + NsiliFilterDelegate.SQ)));
     }
 
     @Test
     public void testPropertyIsNotEqualToDateLiteral() {
         String filter = filterDelegate.propertyIsNotEqualTo(PROPERTY, DATE);
-        assertThat(filter, is(NsiliFilterFactory.NOT + getPrimary(NsiliFilterFactory.EQ,
-                NsiliFilterDelegate.SQ + DATE_STRING + NsiliFilterDelegate.SQ)));
+        assertThat(filter,
+                is(NsiliFilterFactory.NOT + getPrimary(NsiliFilterFactory.EQ,
+                        NsiliFilterDelegate.SQ + DATE_STRING + NsiliFilterDelegate.SQ)));
     }
 
     @Test
     public void testPropertyIsNotEqualToIntLiteral() {
         String filter = filterDelegate.propertyIsNotEqualTo(PROPERTY, INT);
-        assertThat(filter, is(NsiliFilterFactory.NOT + getPrimary(NsiliFilterFactory.EQ,
-                INT)));
+        assertThat(filter, is(NsiliFilterFactory.NOT + getPrimary(NsiliFilterFactory.EQ, INT)));
     }
 
     @Test
     public void testPropertyIsNotEqualToShortLiteral() {
         String filter = filterDelegate.propertyIsNotEqualTo(PROPERTY, (short) INT);
-        assertThat(filter, is(NsiliFilterFactory.NOT + getPrimary(NsiliFilterFactory.EQ,
-                INT)));
+        assertThat(filter, is(NsiliFilterFactory.NOT + getPrimary(NsiliFilterFactory.EQ, INT)));
     }
 
     @Test
     public void testPropertyIsNotEqualToLongLiteral() {
         String filter = filterDelegate.propertyIsNotEqualTo(PROPERTY, (long) INT);
-        assertThat(filter, is(NsiliFilterFactory.NOT + getPrimary(NsiliFilterFactory.EQ,
-                INT)));
+        assertThat(filter, is(NsiliFilterFactory.NOT + getPrimary(NsiliFilterFactory.EQ, INT)));
     }
 
     @Test
     public void testPropertyIsNotEqualToFloatLiteral() {
         String filter = filterDelegate.propertyIsNotEqualTo(PROPERTY, FLOAT);
-        assertThat(filter, is(NsiliFilterFactory.NOT + getPrimary(NsiliFilterFactory.EQ,
-                FLOAT)));
+        assertThat(filter, is(NsiliFilterFactory.NOT + getPrimary(NsiliFilterFactory.EQ, FLOAT)));
     }
 
     @Test
     public void testPropertyIsNotEqualToDoubleLiteral() {
         String filter = filterDelegate.propertyIsNotEqualTo(PROPERTY, (double) FLOAT);
-        assertThat(filter, is(NsiliFilterFactory.NOT + getPrimary(NsiliFilterFactory.EQ,
-                FLOAT)));
+        assertThat(filter, is(NsiliFilterFactory.NOT + getPrimary(NsiliFilterFactory.EQ, FLOAT)));
     }
 
     @Test
     public void testPropertyIsNotEqualToBooleanLiteral() {
         String filter = filterDelegate.propertyIsNotEqualTo(PROPERTY, false);
-        assertThat(filter, is(NsiliFilterFactory.NOT + getPrimary(NsiliFilterFactory.EQ,
-                NsiliFilterDelegate.SQ + FALSE + NsiliFilterDelegate.SQ)));
+        assertThat(filter,
+                is(NsiliFilterFactory.NOT + getPrimary(NsiliFilterFactory.EQ,
+                        NsiliFilterDelegate.SQ + FALSE + NsiliFilterDelegate.SQ)));
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -226,15 +227,17 @@ public class TestNsiliFilterDelegate {
     @Test
     public void testPropertyIsGreaterThanStringLiteral() {
         String filter = filterDelegate.propertyIsGreaterThan(PROPERTY, ATTRIBUTE);
-        assertThat(filter, is(getPrimary(NsiliFilterFactory.GT,
-                NsiliFilterDelegate.SQ + ATTRIBUTE + NsiliFilterDelegate.SQ)));
+        assertThat(filter,
+                is(getPrimary(NsiliFilterFactory.GT,
+                        NsiliFilterDelegate.SQ + ATTRIBUTE + NsiliFilterDelegate.SQ)));
     }
 
     @Test
     public void testPropertyIsGreaterThanDateLiteral() {
         String filter = filterDelegate.propertyIsGreaterThan(PROPERTY, DATE);
-        assertThat(filter, is(getPrimary(NsiliFilterFactory.GT,
-                NsiliFilterDelegate.SQ + DATE_STRING + NsiliFilterDelegate.SQ)));
+        assertThat(filter,
+                is(getPrimary(NsiliFilterFactory.GT,
+                        NsiliFilterDelegate.SQ + DATE_STRING + NsiliFilterDelegate.SQ)));
     }
 
     @Test
@@ -285,15 +288,17 @@ public class TestNsiliFilterDelegate {
     @Test
     public void testPropertyIsGreaterThanOrEqualToStringLiteral() {
         String filter = filterDelegate.propertyIsGreaterThanOrEqualTo(PROPERTY, ATTRIBUTE);
-        assertThat(filter, is(getPrimary(NsiliFilterFactory.GTE,
-                NsiliFilterDelegate.SQ + ATTRIBUTE + NsiliFilterDelegate.SQ)));
+        assertThat(filter,
+                is(getPrimary(NsiliFilterFactory.GTE,
+                        NsiliFilterDelegate.SQ + ATTRIBUTE + NsiliFilterDelegate.SQ)));
     }
 
     @Test
     public void testPropertyIsGreaterThanOrEqualToDateLiteral() {
         String filter = filterDelegate.propertyIsGreaterThanOrEqualTo(PROPERTY, DATE);
-        assertThat(filter, is(getPrimary(NsiliFilterFactory.GTE,
-                NsiliFilterDelegate.SQ + DATE_STRING + NsiliFilterDelegate.SQ)));
+        assertThat(filter,
+                is(getPrimary(NsiliFilterFactory.GTE,
+                        NsiliFilterDelegate.SQ + DATE_STRING + NsiliFilterDelegate.SQ)));
     }
 
     @Test
@@ -344,15 +349,17 @@ public class TestNsiliFilterDelegate {
     @Test
     public void testPropertyIsLessThanStringLiteral() {
         String filter = filterDelegate.propertyIsLessThan(PROPERTY, ATTRIBUTE);
-        assertThat(filter, is(getPrimary(NsiliFilterFactory.LT,
-                NsiliFilterDelegate.SQ + ATTRIBUTE + NsiliFilterDelegate.SQ)));
+        assertThat(filter,
+                is(getPrimary(NsiliFilterFactory.LT,
+                        NsiliFilterDelegate.SQ + ATTRIBUTE + NsiliFilterDelegate.SQ)));
     }
 
     @Test
     public void testPropertyIsLessThanDateLiteral() {
         String filter = filterDelegate.propertyIsLessThan(PROPERTY, DATE);
-        assertThat(filter, is(getPrimary(NsiliFilterFactory.LT,
-                NsiliFilterDelegate.SQ + DATE_STRING + NsiliFilterDelegate.SQ)));
+        assertThat(filter,
+                is(getPrimary(NsiliFilterFactory.LT,
+                        NsiliFilterDelegate.SQ + DATE_STRING + NsiliFilterDelegate.SQ)));
     }
 
     @Test
@@ -403,15 +410,17 @@ public class TestNsiliFilterDelegate {
     @Test
     public void testPropertyIsLessThanOrEqualToStringLiteral() {
         String filter = filterDelegate.propertyIsLessThanOrEqualTo(PROPERTY, ATTRIBUTE);
-        assertThat(filter, is(getPrimary(NsiliFilterFactory.LTE,
-                NsiliFilterDelegate.SQ + ATTRIBUTE + NsiliFilterDelegate.SQ)));
+        assertThat(filter,
+                is(getPrimary(NsiliFilterFactory.LTE,
+                        NsiliFilterDelegate.SQ + ATTRIBUTE + NsiliFilterDelegate.SQ)));
     }
 
     @Test
     public void testPropertyIsLessThanOrEqualToDateLiteral() {
         String filter = filterDelegate.propertyIsLessThanOrEqualTo(PROPERTY, DATE);
-        assertThat(filter, is(getPrimary(NsiliFilterFactory.LTE,
-                NsiliFilterDelegate.SQ + DATE_STRING + NsiliFilterDelegate.SQ)));
+        assertThat(filter,
+                is(getPrimary(NsiliFilterFactory.LTE,
+                        NsiliFilterDelegate.SQ + DATE_STRING + NsiliFilterDelegate.SQ)));
     }
 
     @Test
@@ -462,52 +471,53 @@ public class TestNsiliFilterDelegate {
     @Test
     public void testPropertyBetweenStringLiterals() {
         String filter = filterDelegate.propertyIsBetween(PROPERTY, ATTRIBUTE, ATTRIBUTE);
-        assertThat(filter, is(getPrimary(NsiliFilterFactory.BTW,
-                NsiliFilterDelegate.SQ + ATTRIBUTE + NsiliFilterDelegate.SQ
-                        + NsiliFilterFactory.COMMA + NsiliFilterDelegate.SQ + ATTRIBUTE
-                        + NsiliFilterDelegate.SQ)));
+        assertThat(filter,
+                is(getPrimary(NsiliFilterFactory.BTW,
+                        NsiliFilterDelegate.SQ + ATTRIBUTE + NsiliFilterDelegate.SQ
+                                + NsiliFilterFactory.COMMA + NsiliFilterDelegate.SQ + ATTRIBUTE
+                                + NsiliFilterDelegate.SQ)));
     }
 
     @Test
     public void testPropertyBetweenIntLiterals() {
         String filter = filterDelegate.propertyIsBetween(PROPERTY, INT, INT);
-        assertThat(filter, is(getPrimary(NsiliFilterFactory.BTW,
-                INT + NsiliFilterFactory.COMMA + INT)));
+        assertThat(filter,
+                is(getPrimary(NsiliFilterFactory.BTW, INT + NsiliFilterFactory.COMMA + INT)));
     }
 
     @Test
     public void testPropertyBetweenShortLiterals() {
         String filter = filterDelegate.propertyIsBetween(PROPERTY, (short) INT, (short) INT);
-        assertThat(filter, is(getPrimary(NsiliFilterFactory.BTW,
-                INT + NsiliFilterFactory.COMMA + INT)));
+        assertThat(filter,
+                is(getPrimary(NsiliFilterFactory.BTW, INT + NsiliFilterFactory.COMMA + INT)));
     }
 
     @Test
     public void testPropertyBetweenLongLiterals() {
         String filter = filterDelegate.propertyIsBetween(PROPERTY, (long) INT, (long) INT);
-        assertThat(filter, is(getPrimary(NsiliFilterFactory.BTW,
-                INT + NsiliFilterFactory.COMMA + INT)));
+        assertThat(filter,
+                is(getPrimary(NsiliFilterFactory.BTW, INT + NsiliFilterFactory.COMMA + INT)));
     }
 
     @Test
     public void testPropertyBetweenFloatLiterals() {
         String filter = filterDelegate.propertyIsBetween(PROPERTY, FLOAT, FLOAT);
-        assertThat(filter, is(getPrimary(NsiliFilterFactory.BTW,
-                FLOAT + NsiliFilterFactory.COMMA + FLOAT)));
+        assertThat(filter,
+                is(getPrimary(NsiliFilterFactory.BTW, FLOAT + NsiliFilterFactory.COMMA + FLOAT)));
     }
 
     @Test
     public void testPropertyBetweenDoubleLiterals() {
         String filter = filterDelegate.propertyIsBetween(PROPERTY, (double) FLOAT, (double) FLOAT);
-        assertThat(filter, is(getPrimary(NsiliFilterFactory.BTW,
-                FLOAT + NsiliFilterFactory.COMMA + FLOAT)));
+        assertThat(filter,
+                is(getPrimary(NsiliFilterFactory.BTW, FLOAT + NsiliFilterFactory.COMMA + FLOAT)));
     }
 
     @Test
     public void testPropertyNull() {
         String filter = filterDelegate.propertyIsNull(PROPERTY);
-        assertThat(filter, is(
-                NsiliFilterFactory.NOT + getPrimary(NsiliFilterDelegate.EMPTY_STRING,
+        assertThat(filter,
+                is(NsiliFilterFactory.NOT + getPrimary(NsiliFilterDelegate.EMPTY_STRING,
                         NsiliFilterFactory.EXISTS)));
     }
 
@@ -567,8 +577,8 @@ public class TestNsiliFilterDelegate {
         List<String> filterList = new ArrayList<>();
         filterList.add(filterDelegate.propertyIsBetween(PROPERTY, INT, INT));
         String filter = filterDelegate.and(filterList);
-        assertThat(filter, is(getPrimary(NsiliFilterFactory.BTW,
-                INT + NsiliFilterFactory.COMMA + INT)));
+        assertThat(filter,
+                is(getPrimary(NsiliFilterFactory.BTW, INT + NsiliFilterFactory.COMMA + INT)));
     }
 
     @Test
@@ -597,8 +607,8 @@ public class TestNsiliFilterDelegate {
         List<String> filterList = new ArrayList<>();
         filterList.add(filterDelegate.propertyIsBetween(PROPERTY, INT, INT));
         String filter = filterDelegate.or(filterList);
-        assertThat(filter, is(getPrimary(NsiliFilterFactory.BTW,
-                INT + NsiliFilterFactory.COMMA + INT)));
+        assertThat(filter,
+                is(getPrimary(NsiliFilterFactory.BTW, INT + NsiliFilterFactory.COMMA + INT)));
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -618,8 +628,7 @@ public class TestNsiliFilterDelegate {
 
     @Test
     public void testNullAttributesList() {
-        NsiliFilterDelegate filterDelegate = new NsiliFilterDelegate(
-                generateAttributeInformation(),
+        NsiliFilterDelegate filterDelegate = new NsiliFilterDelegate(generateAttributeInformation(),
                 PROPERTY);
         String filter = filterDelegate.propertyIsLike(PROPERTY, ATTRIBUTE, false);
         assertThat(filter, is(NsiliFilterDelegate.EMPTY_STRING));
@@ -633,10 +642,11 @@ public class TestNsiliFilterDelegate {
 
     @Test
     public void testBeforeSupportedTemporal() {
-        String filter = filterDelegate.before(NsiliConstants.DATE_TIME_MODIFIED, DATE);
-        assertThat(filter, is(getPrimary(NsiliConstants.DATE_TIME_MODIFIED,
-                NsiliFilterFactory.LTE,
-                NsiliFilterDelegate.SQ + DATE_STRING + NsiliFilterDelegate.SQ)));
+        String filter = filterDelegate.before(DATE_PROPERTY, DATE);
+        assertThat(filter,
+                is(getPrimary(NsiliConstants.NSIL_CARD + "." + NsiliConstants.DATE_TIME_MODIFIED,
+                        NsiliFilterFactory.LTE,
+                        NsiliFilterDelegate.SQ + DATE_STRING + NsiliFilterDelegate.SQ)));
     }
 
     @Test
@@ -647,10 +657,11 @@ public class TestNsiliFilterDelegate {
 
     @Test
     public void testAfterSupportedTemporal() {
-        String filter = filterDelegate.after(NsiliConstants.DATE_TIME_MODIFIED, DATE);
-        assertThat(filter, is(getPrimary(NsiliConstants.DATE_TIME_MODIFIED,
-                NsiliFilterFactory.GTE,
-                NsiliFilterDelegate.SQ + DATE_STRING + NsiliFilterDelegate.SQ)));
+        String filter = filterDelegate.after(DATE_PROPERTY, DATE);
+        assertThat(filter,
+                is(getPrimary(NsiliConstants.NSIL_CARD + "." + NsiliConstants.DATE_TIME_MODIFIED,
+                        NsiliFilterFactory.GTE,
+                        NsiliFilterDelegate.SQ + DATE_STRING + NsiliFilterDelegate.SQ)));
     }
 
     @Test
@@ -661,7 +672,7 @@ public class TestNsiliFilterDelegate {
 
     @Test
     public void testDuringSupported() {
-        String filter = filterDelegate.during(NsiliConstants.DATE_TIME_MODIFIED, DATE, DATE);
+        String filter = filterDelegate.during(DATE_PROPERTY, DATE, DATE);
         assertThat(StringUtils.isEmpty(filter), is(false));
     }
 
@@ -749,7 +760,8 @@ public class TestNsiliFilterDelegate {
         Domain domain = new Domain();
 
         domain.t(36);
-        attributeInformationList.add(createAttributeInformation(NsiliConstants.IDENTIFIER_UUID,
+        attributeInformationList.add(createAttributeInformation(
+                NsiliConstants.NSIL_COMMON + "." + NsiliConstants.IDENTIFIER_UUID,
                 AttributeType.TEXT,
                 domain,
                 NsiliFilterDelegate.EMPTY_STRING,
@@ -762,7 +774,8 @@ public class TestNsiliFilterDelegate {
         domain = new Domain();
         DateRange dateRange = new DateRange();
         domain.d(dateRange);
-        attributeInformationList.add(createAttributeInformation(NsiliConstants.DATE_TIME_MODIFIED,
+        attributeInformationList.add(createAttributeInformation(
+                NsiliConstants.NSIL_CARD + "." + NsiliConstants.DATE_TIME_MODIFIED,
                 AttributeType.TEXT,
                 domain,
                 NsiliFilterDelegate.EMPTY_STRING,
@@ -774,7 +787,8 @@ public class TestNsiliFilterDelegate {
 
         domain = new Domain();
         domain.g(RECTANGLE_DOMAIN);
-        attributeInformationList.add(createAttributeInformation(NsiliConstants.SPATIAL_GEOGRAPHIC_REF_BOX,
+        attributeInformationList.add(createAttributeInformation(
+                NsiliConstants.NSIL_COVERAGE + "." + NsiliConstants.SPATIAL_GEOGRAPHIC_REF_BOX,
                 AttributeType.UCOS_RECTANGLE,
                 domain,
                 NsiliFilterDelegate.EMPTY_STRING,
@@ -786,7 +800,8 @@ public class TestNsiliFilterDelegate {
 
         domain = new Domain();
         domain.ir(new IntegerRange(0, 100));
-        attributeInformationList.add(createAttributeInformation(NsiliConstants.NUMBER_OF_BANDS,
+        attributeInformationList.add(createAttributeInformation(
+                NsiliConstants.NSIL_IMAGERY + "." + NsiliConstants.NUMBER_OF_BANDS,
                 AttributeType.INTEGER,
                 domain,
                 NsiliFilterDelegate.EMPTY_STRING,
@@ -817,12 +832,11 @@ public class TestNsiliFilterDelegate {
     }
 
     private String getPrimary(String operator, Object attribute) {
-        return getPrimary(PROPERTY, operator, attribute);
+        return getPrimary(NsiliConstants.NSIL_CARD + "." + PROPERTY, operator, attribute);
     }
 
     private String getPrimary(String property, String operator, Object attribute) {
-        return NsiliFilterFactory.LP + property + operator + attribute
-                + NsiliFilterFactory.RP;
+        return NsiliFilterFactory.LP + property + operator + attribute + NsiliFilterFactory.RP;
     }
 
     private static Date getDate() {

--- a/catalog/nsili/catalog-nsili-source/src/test/java/org/codice/alliance/nsili/source/TestNsiliSource.java
+++ b/catalog/nsili/catalog-nsili-source/src/test/java/org/codice/alliance/nsili/source/TestNsiliSource.java
@@ -366,6 +366,7 @@ public class TestNsiliSource {
         source.setCatalogMgr(getMockCatalogMgr());
         source.setFilterAdapter(new GeotoolsFilterAdapterImpl());
         source.setNumberWorkerThreads(6);
+        source.setAdditionalQueryParams("and (not NSIL_PRODUCT:NSIL_CARD.status = 'OBSOLETE')");
 
         // Suppress CORBA communications to test refresh
         doNothing().when(source)


### PR DESCRIPTION
#### What does this PR do?
Added the ability to specify sources by name on the NSILI Endpoint for restricting enterprise searches
 - Added query params to the source that get applied to each outgoing query to that source
 - Fixed an issue with setting the port for the endpoint was causing port conflicts with the source
 - Resolved 406 issues when attempting self-federation
 - Resolved self-federation federated searching problems Self NSILI Source - NSILI Endpoint - External NSIL implementation

#### Who is reviewing it?
@jaymcnallie @bdeining @millerw8 @kcwire 

#### How should this be tested?
Run the JUnit tests

#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/CAL-61

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

