### PR TITLE
CAL-68 NitfPreStoragePlugin should create a scaled overview image.

### DIFF
--- a/catalog/imaging/catalog-imaging-transformer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/imaging/catalog-imaging-transformer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -12,7 +12,13 @@
  *
  **/
  -->
-<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+           xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0
+           http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+           http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0
+           http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd">
 
     <bean id="metacardType" class="org.codice.alliance.transformer.nitf.NitfMetacardType"/>
 
@@ -20,7 +26,11 @@
         <property name="nitfMetacardType" ref="metacardType"/>
     </bean>
 
-    <bean id="plugin" class="org.codice.alliance.transformer.nitf.NitfPreStoragePlugin"/>
+    <bean id="plugin" class="org.codice.alliance.transformer.nitf.NitfPreStoragePlugin">
+        <cm:managed-properties persistent-id="NITF_Input_Transformer"
+                               update-strategy="container-managed"/>
+        <property name="maxSideLength" value="1024"/>
+    </bean>
 
     <service ref="transformer" interface="ddf.catalog.transform.InputTransformer">
         <service-properties>

--- a/catalog/imaging/catalog-imaging-transformer/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/imaging/catalog-imaging-transformer/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
+
+    <OCD name="Nitf Imaging Input Transformer"
+         id="NITF_Input_Transformer">
+        <AD
+                description="Maximum length of longest side of NITF overview image in pixels. The input transformer will calculate the size of the shorter side so that the overview will have the same aspect ratio as the original."
+                name="Overview image maximum side length (pixels)" id="maxSideLength" required="true"
+                type="Integer" default="1024"/>
+
+    </OCD>
+
+    <Designate pid="NITF_Input_Transformer">
+        <Object ocdref="NITF_Input_Transformer"/>
+    </Designate>
+
+</metatype:MetaData>

--- a/catalog/imaging/catalog-imaging-transformer/src/test/java/org/codice/alliance/transformer/nitf/TestNitfInputTransformer.java
+++ b/catalog/imaging/catalog-imaging-transformer/src/test/java/org/codice/alliance/transformer/nitf/TestNitfInputTransformer.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertTrue;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
@@ -59,8 +58,7 @@ public class TestNitfInputTransformer {
 
     @Test(expected = CatalogTransformerException.class)
     public void testNullInput()
-            throws IOException, CatalogTransformerException, UnsupportedQueryException,
-            SourceUnavailableException, FederationException {
+            throws Exception {
         transformer.transform(null);
     }
 
@@ -73,8 +71,7 @@ public class TestNitfInputTransformer {
 
     @Test
     public void testSorcerWithBE()
-            throws IOException, CatalogTransformerException, UnsupportedQueryException,
-            SourceUnavailableException, FederationException, ParseException {
+            throws Exception {
         Metacard metacard = transformer.transform(getInputStream(BE_NUM_NITF));
 
         assertNotNull(metacard);
@@ -84,8 +81,7 @@ public class TestNitfInputTransformer {
 
     @Test
     public void testTreParsing()
-            throws IOException, CatalogTransformerException, UnsupportedQueryException,
-            SourceUnavailableException, FederationException, ParseException {
+            throws Exception {
         Metacard metacard = transformer.transform(getInputStream(TRE_NITF));
 
         assertNotNull(metacard);
@@ -95,8 +91,7 @@ public class TestNitfInputTransformer {
 
     @Test
     public void testNitfParsing()
-            throws IOException, CatalogTransformerException, UnsupportedQueryException,
-            SourceUnavailableException, FederationException, ParseException {
+            throws Exception {
         Metacard metacard = transformer.transform(getInputStream(GEO_NITF));
 
         assertNotNull(metacard);

--- a/catalog/imaging/catalog-imaging-transformer/src/test/java/org/codice/alliance/transformer/nitf/TestPreStoragePlugin.java
+++ b/catalog/imaging/catalog-imaging-transformer/src/test/java/org/codice/alliance/transformer/nitf/TestPreStoragePlugin.java
@@ -121,12 +121,12 @@ public class TestPreStoragePlugin {
 
 
     private void validate() {
-        verify(contentItem, times(1)).getId();
-        verify(metacard, times(2)).setAttribute(attributeArgumentCaptor.capture());
+        verify(contentItem, times(2)).getId();
+        verify(metacard, times(3)).setAttribute(attributeArgumentCaptor.capture());
         Attribute thumbnail = attributeArgumentCaptor.getAllValues()
                 .get(0);
         Attribute overview = attributeArgumentCaptor.getAllValues()
-                .get(1);
+                .get(2);
         assertThat(thumbnail.getName(), is("thumbnail"));
         assertThat(thumbnail.getValue(), is(notNullValue()));
         assertThat(overview.getName(), is(Metacard.DERIVED_RESOURCE_URI));

--- a/catalog/imaging/catalog-imaging-transformer/src/test/java/org/codice/alliance/transformer/nitf/TestPreStoragePluginMulti.java
+++ b/catalog/imaging/catalog-imaging-transformer/src/test/java/org/codice/alliance/transformer/nitf/TestPreStoragePluginMulti.java
@@ -142,8 +142,8 @@ public class TestPreStoragePluginMulti {
     }
 
     private void validateNitf(ContentItem contentItem, Metacard metacard) {
-        verify(contentItem, times(1)).getId();
-        verify(metacard, times(2)).setAttribute(attributeArgumentCaptor.capture());
+        verify(contentItem, times(2)).getId();
+        verify(metacard, times(3)).setAttribute(attributeArgumentCaptor.capture());
         Attribute thumbnail1 = attributeArgumentCaptor.getAllValues()
                 .get(0);
         Attribute overview1 = attributeArgumentCaptor.getAllValues()


### PR DESCRIPTION
#### What does this PR do?
Scales the overview image and added a separate derived resource for the full-scale image.

#### Who is reviewing it?
@bdeining 
@jlcsmith 
@jaymcnallie 

#### How should this be tested?
1) ingest a nitf
2) search for the nitf
3) on the actions tab, select 'view overview' and 'view original'
    --verify that neither side of the overview is greater than the maximum (1024).
    --verify that the overview maintained aspect ratio.
    --verify that the original has the same size given on the metacard.

#### Any background context you want to provide?
#### What are the relevant tickets?
CAL-68

#### Screenshots (if appropriate)

![overview-ss](https://cloud.githubusercontent.com/assets/5922390/16054265/3767fb66-3221-11e6-8e06-57de9e0bd0f7.png)


#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

