### PR TITLE
CAL-56: Updated the Result DAG converter to only export attributes that are requested.

### DIFF
--- a/catalog/nsili/catalog-nsili-common/src/test/java/org/codice/alliance/nsili/common/TestResultDAGConverter.java
+++ b/catalog/nsili/catalog-nsili-common/src/test/java/org/codice/alliance/nsili/common/TestResultDAGConverter.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.common;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.codice.alliance.nsili.common.UCO.DAG;
+import org.junit.Test;
+import org.omg.CORBA.ORB;
+import org.omg.PortableServer.POA;
+import org.omg.PortableServer.POAHelper;
+
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.data.impl.ResultImpl;
+
+public class TestResultDAGConverter {
+
+    @Test
+    public void testResultAttributes() throws Exception {
+        String id = UUID.randomUUID()
+                .toString();
+        MetacardImpl card = new MetacardImpl();
+        card.setId(id);
+        card.setTitle("Test Title");
+        card.setSourceId("Test Source");
+
+        ResultImpl result = new ResultImpl();
+        result.setMetacard(card);
+
+        ORB orb = ORB.init(new String[0], null);
+        POA rootPOA = POAHelper.narrow(orb.resolve_initial_references("RootPOA"));
+        rootPOA.the_POAManager()
+                .activate();
+
+        String sourceAttr = NsiliConstants.NSIL_PRODUCT + ":" + NsiliConstants.NSIL_CARD + "."
+                + NsiliConstants.SOURCE_LIBRARY;
+
+        DAG dag = ResultDAGConverter.convertResult(result, orb, rootPOA, new ArrayList<>());
+        assertThat(checkDagContains(dag, sourceAttr), is(true));
+
+        List<String> singleAttrList = new ArrayList<>();
+        singleAttrList.add(NsiliConstants.NSIL_PRODUCT + ":" + NsiliConstants.NSIL_CARD + "."
+                + NsiliConstants.IDENTIFIER);
+        DAG oneAttrDAG = ResultDAGConverter.convertResult(result, orb, rootPOA, singleAttrList);
+        assertThat(checkDagContains(oneAttrDAG, sourceAttr), is(false));
+    }
+
+    private static boolean checkDagContains(DAG dag, String attribute) {
+        List<String> dagAttrs = ResultDAGConverter.getAttributes(dag);
+        return dagAttrs.contains(attribute);
+    }
+}

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/managers/CatalogMgrImpl.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/managers/CatalogMgrImpl.java
@@ -137,6 +137,8 @@ public class CatalogMgrImpl extends CatalogMgrPOA {
         submitQueryRequest.set_number_of_hits(maxNumResults);
         submitQueryRequest.setTimeout(defaultTimeout);
 
+        submitQueryRequest.setResultAttributes(result_attributes);
+
         String queryId = UUID.randomUUID()
                 .toString();
         try {

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/requests/GetParametersRequestImpl.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/requests/GetParametersRequestImpl.java
@@ -14,6 +14,7 @@
 package org.codice.alliance.nsili.endpoint.requests;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
@@ -89,15 +90,26 @@ public class GetParametersRequestImpl extends GetParametersRequestPOA {
         if (result != null) {
             if (desiredParameters != null) {
                 if (isParamContained(desiredParameters, "ALL")) {
-                    parameters.value = ResultDAGConverter.convertResult(result, _orb(), _poa());
+                    parameters.value = ResultDAGConverter.convertResult(result,
+                            _orb(),
+                            _poa(),
+                            new ArrayList<>());
                 } else if (isParamContained(desiredParameters, "CORE")) {
                     throw new NO_IMPLEMENT("CORE desired_parameter not supported");
                 } else if (isParamContained(desiredParameters, "ORDER")) {
                     throw new NO_IMPLEMENT("ORDER desired_parameter not supported");
+                } else {
+                    parameters.value = ResultDAGConverter.convertResult(result,
+                            _orb(),
+                            _poa(),
+                            Arrays.asList(desiredParameters));
                 }
             } else {
                 if (result != null) {
-                    parameters.value = ResultDAGConverter.convertResult(result, _orb(), _poa());
+                    parameters.value = ResultDAGConverter.convertResult(result,
+                            _orb(),
+                            _poa(),
+                            new ArrayList<>());
                 }
             }
         }

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/requests/SubmitQueryRequestImpl.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/requests/SubmitQueryRequestImpl.java
@@ -14,11 +14,13 @@
 package org.codice.alliance.nsili.endpoint.requests;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
 
 import org.apache.shiro.subject.ExecutionException;
 import org.codice.alliance.nsili.common.BqsConverter;
@@ -74,6 +76,8 @@ public class SubmitQueryRequestImpl extends SubmitQueryRequestPOA {
 
     private Map<String, Callback> callbacks = new HashMap<>();
 
+    private List<String> resultAttributes = new ArrayList<>();
+
     public SubmitQueryRequestImpl(Query query, BqsConverter bqsConverter,
             CatalogFramework catalogFramework, Subject guestSubject, List<String> querySources) {
         this.query = query;
@@ -84,8 +88,6 @@ public class SubmitQueryRequestImpl extends SubmitQueryRequestPOA {
         if (querySources != null) {
             this.querySources.addAll(querySources);
         }
-
-        notifyCallbacks();
     }
 
     public void setTimeout(long timeout) {
@@ -105,6 +107,12 @@ public class SubmitQueryRequestImpl extends SubmitQueryRequestPOA {
         }
     }
 
+    public void setResultAttributes(String[] resultAttributes) {
+        if (resultAttributes != null) {
+            this.resultAttributes.addAll(Arrays.asList(resultAttributes));
+        }
+    }
+
     @Override
     public State complete_DAG_results(DAGListHolder results) throws ProcessingFault, SystemFault {
         DAG[] noResults = new DAG[0];
@@ -117,7 +125,7 @@ public class SubmitQueryRequestImpl extends SubmitQueryRequestPOA {
         LOGGER.debug("Query: {} return NSILI results: {}", query.bqs_query, queryResults.size());
 
         for (Result result : queryResults) {
-            DAG dag = ResultDAGConverter.convertResult(result, _orb(), _poa());
+            DAG dag = ResultDAGConverter.convertResult(result, _orb(), _poa(), resultAttributes);
             if (dag != null) {
                 dags.add(dag);
                 totalHits++;

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/requests/SubmitStandingQueryRequestImpl.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/requests/SubmitStandingQueryRequestImpl.java
@@ -93,7 +93,7 @@ public class SubmitStandingQueryRequestImpl extends SubmitStandingQueryRequestPO
 
     private BqsConverter bqsConverter;
 
-    private String[] resultAttributes;
+    private List<String> resultAttributes = new ArrayList<>();
 
     private SortAttribute[] sortAttributes;
 
@@ -144,7 +144,9 @@ public class SubmitStandingQueryRequestImpl extends SubmitStandingQueryRequestPO
             long defaultUpdateFrequencyMsec, List<String> querySources, int maxPendingResults) {
         id = UUID.randomUUID()
                 .toString();
-        this.resultAttributes = result_attributes;
+        if (result_attributes != null) {
+            this.resultAttributes.addAll(Arrays.asList(result_attributes));
+        }
         this.sortAttributes = sort_attributes;
         this.lifespan = lifespan;
         this.properties = properties;
@@ -529,7 +531,7 @@ public class SubmitStandingQueryRequestImpl extends SubmitStandingQueryRequestPO
             List<DAG> dags = new ArrayList<>();
 
             for (Result catalogResult : catalogResults) {
-                DAG dag = ResultDAGConverter.convertResult(catalogResult, _orb(), _poa());
+                DAG dag = ResultDAGConverter.convertResult(catalogResult, _orb(), _poa(), resultAttributes);
                 dags.add(dag);
             }
 

--- a/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/TestAccessManagerImpl.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/TestAccessManagerImpl.java
@@ -124,7 +124,7 @@ public class TestAccessManagerImpl extends TestNsiliCommon {
         testMetacard.setTitle("JUnit Test Card");
         Result testResult = new ResultImpl(testMetacard);
 
-        DAG dag = ResultDAGConverter.convertResult(testResult, orb, rootPOA);
+        DAG dag = ResultDAGConverter.convertResult(testResult, orb, rootPOA, new ArrayList<>());
         Product product = ProductHelper.extract(dag.nodes[0].value);
         boolean avail = accessManager.is_available(product, null);
         assertThat(avail, is(false));
@@ -146,7 +146,7 @@ public class TestAccessManagerImpl extends TestNsiliCommon {
         QueryResponse testResponse = new QueryResponseImpl(null, results, results.size());
         when(mockCatalogFramework.query(any(QueryRequest.class))).thenReturn(testResponse);
 
-        DAG dag = ResultDAGConverter.convertResult(testResult, orb, rootPOA);
+        DAG dag = ResultDAGConverter.convertResult(testResult, orb, rootPOA, new ArrayList<>());
         Product product = ProductHelper.extract(dag.nodes[0].value);
         boolean avail = accessManager.is_available(product, null);
         assertThat(avail, is(false));

--- a/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/TestOrderMgrImpl.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/TestOrderMgrImpl.java
@@ -118,7 +118,7 @@ public class TestOrderMgrImpl extends TestNsiliCommon {
         testMetacard.setTitle("JUnit Test Card");
         Result testResult = new ResultImpl(testMetacard);
 
-        DAG dag = ResultDAGConverter.convertResult(testResult, orb, rootPOA);
+        DAG dag = ResultDAGConverter.convertResult(testResult, orb, rootPOA, new ArrayList<>());
         Product product = ProductHelper.extract(dag.nodes[0].value);
         boolean avail = orderMgr.is_available(product, null);
         assertThat(avail, is(false));

--- a/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/TestProductMgrImpl.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/TestProductMgrImpl.java
@@ -125,7 +125,7 @@ public class TestProductMgrImpl extends TestNsiliCommon {
         testMetacard.setTitle("JUnit Test Card");
         Result testResult = new ResultImpl(testMetacard);
 
-        DAG dag = ResultDAGConverter.convertResult(testResult, orb, rootPOA);
+        DAG dag = ResultDAGConverter.convertResult(testResult, orb, rootPOA, new ArrayList<>());
         Product product = ProductHelper.extract(dag.nodes[0].value);
         boolean avail = productMgr.is_available(product, null);
         assertThat(avail, is(false));
@@ -141,7 +141,7 @@ public class TestProductMgrImpl extends TestNsiliCommon {
         testMetacard.setTitle("JUnit Test Card");
         Result testResult = new ResultImpl(testMetacard);
 
-        DAG dag = ResultDAGConverter.convertResult(testResult, orb, rootPOA);
+        DAG dag = ResultDAGConverter.convertResult(testResult, orb, rootPOA, new ArrayList<>());
         Product product = ProductHelper.extract(dag.nodes[0].value);
         GetParametersRequest parametersRequest = productMgr.get_parameters(product, new String[]{"ALL"}, null);
         assertThat(parametersRequest, notNullValue());
@@ -158,7 +158,7 @@ public class TestProductMgrImpl extends TestNsiliCommon {
         testMetacard.setTitle("JUnit Test Card");
         Result testResult = new ResultImpl(testMetacard);
 
-        DAG dag = ResultDAGConverter.convertResult(testResult, orb, rootPOA);
+        DAG dag = ResultDAGConverter.convertResult(testResult, orb, rootPOA, new ArrayList<>());
         Product product = ProductHelper.extract(dag.nodes[0].value);
         GetParametersRequest parametersRequest = productMgr.get_parameters(product, null, null);
         assertThat(parametersRequest, notNullValue());
@@ -181,7 +181,7 @@ public class TestProductMgrImpl extends TestNsiliCommon {
         testMetacard.setTitle("JUnit Test Card");
         Result testResult = new ResultImpl(testMetacard);
 
-        DAG dag = ResultDAGConverter.convertResult(testResult, orb, rootPOA);
+        DAG dag = ResultDAGConverter.convertResult(testResult, orb, rootPOA, new ArrayList<>());
         Product product = ProductHelper.extract(dag.nodes[0].value);
         Product[] products = new Product[]{product};
         String userName = "";
@@ -202,7 +202,7 @@ public class TestProductMgrImpl extends TestNsiliCommon {
         testMetacard.setTitle("JUnit Test Card");
         Result testResult = new ResultImpl(testMetacard);
 
-        DAG dag = ResultDAGConverter.convertResult(testResult, orb, rootPOA);
+        DAG dag = ResultDAGConverter.convertResult(testResult, orb, rootPOA, new ArrayList<>());
         Product product = ProductHelper.extract(dag.nodes[0].value);
         Product[] products = new Product[]{product};
         String userName = "";
@@ -227,7 +227,7 @@ public class TestProductMgrImpl extends TestNsiliCommon {
         testMetacard.setTitle("JUnit Test Card");
         Result testResult = new ResultImpl(testMetacard);
 
-        DAG dag = ResultDAGConverter.convertResult(testResult, orb, rootPOA);
+        DAG dag = ResultDAGConverter.convertResult(testResult, orb, rootPOA, new ArrayList<>());
         Product product = ProductHelper.extract(dag.nodes[0].value);
         Product[] products = new Product[]{product};
         String userName = "";

--- a/catalog/nsili/catalog-nsili-transformer/src/main/java/org/codice/alliance/nsili/transformer/DAGConverter.java
+++ b/catalog/nsili/catalog-nsili-transformer/src/main/java/org/codice/alliance/nsili/transformer/DAGConverter.java
@@ -58,6 +58,7 @@ import org.codice.alliance.nsili.common.NsiliTdlMetacardType;
 import org.codice.alliance.nsili.common.NsiliVideoCategoryType;
 import org.codice.alliance.nsili.common.NsiliVideoEncodingScheme;
 import org.codice.alliance.nsili.common.NsiliVideoMetacardType;
+import org.codice.alliance.nsili.common.ResultDAGConverter;
 import org.codice.alliance.nsili.common.UCO.AbsTime;
 import org.codice.alliance.nsili.common.UCO.AbsTimeHelper;
 import org.codice.alliance.nsili.common.UCO.DAG;
@@ -120,7 +121,7 @@ public class DAGConverter {
 
         //Need to have at least 2 nodes and an edge for anything useful
         if (dag.nodes != null && dag.edges != null) {
-            Map<Integer, Node> nodeMap = createNodeMap(dag.nodes);
+            Map<Integer, Node> nodeMap = ResultDAGConverter.createNodeMap(dag.nodes);
             DirectedAcyclicGraph<Node, Edge> graph = new DirectedAcyclicGraph<>(Edge.class);
 
             //Build up the graph
@@ -141,15 +142,6 @@ public class DAGConverter {
         }
 
         return metacard;
-    }
-
-    private static Map<Integer, Node> createNodeMap(Node[] nodes) {
-        Map<Integer, Node> nodeMap = new HashMap<>();
-        for (Node node : nodes) {
-            nodeMap.put(node.id, node);
-        }
-
-        return nodeMap;
     }
 
     private MetacardImpl parseGraph(DirectedAcyclicGraph<Node, Edge> graph,
@@ -1269,7 +1261,7 @@ public class DAGConverter {
 
     public static void printDAG(DAG dag) {
         if (dag.nodes != null && dag.edges != null) {
-            Map<Integer, Node> nodeMap = createNodeMap(dag.nodes);
+            Map<Integer, Node> nodeMap = ResultDAGConverter.createNodeMap(dag.nodes);
             DirectedAcyclicGraph<Node, Edge> graph = new DirectedAcyclicGraph<>(Edge.class);
 
             for (Node node : dag.nodes) {
@@ -1351,11 +1343,14 @@ public class DAGConverter {
         } else if (any.type()
                 .kind() == TCKind.tk_boolean) {
             value = String.valueOf(any.extract_boolean());
-        } else if (any.type().kind() == TCKind.tk_double) {
+        } else if (any.type()
+                .kind() == TCKind.tk_double) {
             value = String.valueOf(any.extract_double());
         } else {
             try {
-                if (any.type().name().equals(AbsTime.class.getSimpleName())) {
+                if (any.type()
+                        .name()
+                        .equals(AbsTime.class.getSimpleName())) {
                     Date date = convertDate(any);
                     if (date != null) {
                         value = date.toString();


### PR DESCRIPTION
#### What does this PR do?
Result DAG Converter previously returned all values that were known, which was incorrect as the source system may not have requested every attribute. This changes it to only populate the intersection of requested attributes and attributes that can be populated from resulting data.
#### Who is reviewing it?
@jaymcnallie @kcwire @bdeining @dcruver 
#### How should this be tested?
Run the JUnit Tests
#### Any background context you want to provide?
This actually affected the Ad-Hoc queries as well as Standing Queries so the bug was expanded to handle both cases.
#### What are the relevant tickets?
https://codice.atlassian.net/browse/CAL-56
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests