### PR TITLE
CAL-57 Check that DAG is compliant with Data Model before returning

### DIFF
--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/DagParsingException.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/DagParsingException.java
@@ -1,0 +1,51 @@
+/**
+ *  Copyright (c) Codice Foundation
+ *  <p>
+ *  This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ *  General Public License as published by the Free Software Foundation, either version 3 of the
+ *  License, or any later version.
+ *  <p>
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ *  even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ *  is distributed along with this program and can be found at
+ *  <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.alliance.nsili.common;
+
+/**
+ * Exception thrown when a {@link ResultDAGConverter} encounters problems turning metacards into DAG.
+ *
+ */
+public class DagParsingException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Instantiates a new DagParsingException from a given string.
+     *
+     * @param message the string to use for the exception.
+     */
+    public DagParsingException(String message) {
+        super(message);
+    }
+
+    /**
+     * Instantiates a new DagParsingException with given {@link Throwable}.
+     *
+     * @param throwable the throwable
+     */
+    public DagParsingException(Throwable throwable) {
+        super(throwable);
+    }
+
+    /**
+     * Instantiates a new DagParsingException with a message.
+     *
+     * @param message   the message
+     * @param throwable the throwable
+     */
+    public DagParsingException(String message, Throwable throwable) {
+        super(message, throwable);
+    }
+}

--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/datamodel/NsiliDataModel.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/datamodel/NsiliDataModel.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.codice.alliance.nsili.common.GIAS.RequirementMode;
 import org.codice.alliance.nsili.common.NsiliConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -277,6 +278,8 @@ public class NsiliDataModel {
 
     private List<Association> associations = new ArrayList<>();
 
+    private Map<String, Map<String, List<String>>> requiredAttrMap = new HashMap<>();
+
     public NsiliDataModel() {
         init();
     }
@@ -414,8 +417,10 @@ public class NsiliDataModel {
         conceptualPairs.add(modificationDatePair);
         conceptualPairs.add(productTitlePair);
         conceptualPairs.add(uniqueIdPair);
-
         conceptualAttrMap.put(NsiliConstants.NSIL_ALL_VIEW, conceptualPairs);
+        updateMandatoryAttrs(NsiliConstants.NSIL_ALL_VIEW, viewNodes);
+
+
     }
 
     private void initImageryViewGraph() {
@@ -445,8 +450,9 @@ public class NsiliDataModel {
         conceptualPairs.add(modificationDatePair);
         conceptualPairs.add(productTitlePair);
         conceptualPairs.add(uniqueIdPair);
-
         conceptualAttrMap.put(NsiliConstants.NSIL_IMAGERY_VIEW, conceptualPairs);
+
+        updateMandatoryAttrs(NsiliConstants.NSIL_IMAGERY_VIEW, viewNodes);
     }
 
     private void initGmtiViewGraph() {
@@ -481,8 +487,8 @@ public class NsiliDataModel {
         conceptualPairs.add(modificationDatePair);
         conceptualPairs.add(productTitlePair);
         conceptualPairs.add(uniqueIdPair);
-
         conceptualAttrMap.put(NsiliConstants.NSIL_GMTI_VIEW, conceptualPairs);
+        updateMandatoryAttrs(NsiliConstants.NSIL_GMTI_VIEW, viewNodes);
     }
 
     private void initMessageViewGraph() {
@@ -516,8 +522,8 @@ public class NsiliDataModel {
         conceptualPairs.add(modificationDatePair);
         conceptualPairs.add(productTitlePair);
         conceptualPairs.add(uniqueIdPair);
-
         conceptualAttrMap.put(NsiliConstants.NSIL_MESSAGE_VIEW, conceptualPairs);
+        updateMandatoryAttrs(NsiliConstants.NSIL_MESSAGE_VIEW, viewNodes);
     }
 
     private void initVideoViewGraph() {
@@ -554,6 +560,7 @@ public class NsiliDataModel {
         conceptualPairs.add(uniqueIdPair);
 
         conceptualAttrMap.put(NsiliConstants.NSIL_VIDEO_VIEW, conceptualPairs);
+        updateMandatoryAttrs(NsiliConstants.NSIL_VIDEO_VIEW, viewNodes);
     }
 
     private void initAssociationViewGraph() {
@@ -571,8 +578,8 @@ public class NsiliDataModel {
         List<Pair<ConceptualAttributeType, String>> conceptualPairs = new ArrayList<>();
         conceptualPairs.add(modificationDatePair);
         conceptualPairs.add(uniqueIdPair);
-
         conceptualAttrMap.put(NsiliConstants.NSIL_ASSOCIATION_VIEW, conceptualPairs);
+        updateMandatoryAttrs(NsiliConstants.NSIL_ASSOCIATION_VIEW, viewNodes);
     }
 
     private void initReportViewGraph() {
@@ -606,8 +613,8 @@ public class NsiliDataModel {
         conceptualPairs.add(modificationDatePair);
         conceptualPairs.add(productTitlePair);
         conceptualPairs.add(uniqueIdPair);
-
         conceptualAttrMap.put(NsiliConstants.NSIL_REPORT_VIEW, conceptualPairs);
+        updateMandatoryAttrs(NsiliConstants.NSIL_REPORT_VIEW, viewNodes);
     }
 
     private void initTdlViewGraph() {
@@ -642,8 +649,8 @@ public class NsiliDataModel {
         conceptualPairs.add(modificationDatePair);
         conceptualPairs.add(productTitlePair);
         conceptualPairs.add(uniqueIdPair);
-
         conceptualAttrMap.put(NsiliConstants.NSIL_TDL_VIEW, conceptualPairs);
+        updateMandatoryAttrs(NsiliConstants.NSIL_TDL_VIEW, viewNodes);
     }
 
     private void initCcirmViewGraph() {
@@ -678,8 +685,8 @@ public class NsiliDataModel {
         conceptualPairs.add(modificationDatePair);
         conceptualPairs.add(productTitlePair);
         conceptualPairs.add(uniqueIdPair);
-
         conceptualAttrMap.put(NsiliConstants.NSIL_CCIRM_VIEW, conceptualPairs);
+        updateMandatoryAttrs(NsiliConstants.NSIL_CCIRM_VIEW, viewNodes);
     }
 
     private void initAliasCategoryMap() {
@@ -937,6 +944,37 @@ public class NsiliDataModel {
 
     public List<Association> getAssociations() {
         return associations;
+    }
+
+    public Map<String, List<String>> getRequiredAttrsForView(String viewName) {
+        return requiredAttrMap.get(viewName);
+    }
+
+    private void updateMandatoryAttrs(String viewName, EntityNode[] viewNodes) {
+        Map<String, List<String>> attrMap = new HashMap<>();
+
+        for (EntityNode entityNode : viewNodes) {
+            List<AttributeInformation> nodeAttrs = getAttributeInformation(entityNode.entity_name);
+            if (nodeAttrs != null) {
+                for (AttributeInformation nodeAttr : nodeAttrs) {
+                    if (nodeAttr.mode == RequirementMode.MANDATORY) {
+                        String attributeName = nodeAttr.attribute_name;
+                        String[] attrNameArr = attributeName.split("\\.");
+                        if (attrNameArr.length == 2) {
+                            String parentNode = attrNameArr[0];
+                            String attrName = attrNameArr[1];
+                            List<String> attrs = attrMap.get(parentNode);
+                            if (attrs == null) {
+                                attrs = new ArrayList<>(4);
+                                attrMap.put(parentNode, attrs);
+                            }
+                            attrs.add(attrName);
+                        }
+                    }
+                }
+            }
+        }
+        requiredAttrMap.put(viewName, attrMap);
     }
 
 }

--- a/catalog/nsili/catalog-nsili-common/src/test/java/org/codice/alliance/nsili/common/TestNsiliDataModel.java
+++ b/catalog/nsili/catalog-nsili-common/src/test/java/org/codice/alliance/nsili/common/TestNsiliDataModel.java
@@ -15,8 +15,10 @@ package org.codice.alliance.nsili.common;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Test;
@@ -103,5 +105,13 @@ public class TestNsiliDataModel {
         for (Association association : associations) {
             assertThat(association.attribute_info.length, is(12));
         }
+    }
+
+    @Test
+    public void testNsiliMandatoryAttrs() {
+        Map<String, List<String>> mandatoryAttrs = nsiliDataModel.getRequiredAttrsForView(NsiliConstants.NSIL_ALL_VIEW);
+        List<String> commonAttrs = mandatoryAttrs.get(NsiliConstants.NSIL_COMMON);
+        assertThat(commonAttrs, notNullValue());
+        assertThat(commonAttrs.size(), is(2));
     }
 }

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/LibraryImpl.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/LibraryImpl.java
@@ -84,6 +84,8 @@ public class LibraryImpl extends LibraryPOA {
 
     private int maxPendingResults;
 
+    private boolean outgoingValidationEnabled;
+
     private List<String> querySources = new ArrayList<>();
 
     private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(LibraryImpl.class);
@@ -123,6 +125,10 @@ public class LibraryImpl extends LibraryPOA {
         }
     }
 
+    public void setOutgoingValidationEnabled(boolean outgoingValidationEnabled) {
+        this.outgoingValidationEnabled = outgoingValidationEnabled;
+    }
+
     @Override
     public String[] get_manager_types() throws ProcessingFault, SystemFault {
         LOGGER.trace("get_manager_types() called");
@@ -141,6 +147,7 @@ public class LibraryImpl extends LibraryPOA {
             CatalogMgrImpl catalogMgr = new CatalogMgrImpl(poa, filterBuilder, querySources);
             catalogMgr.setCatalogFramework(catalogFramework);
             catalogMgr.setGuestSubject(guestSubject);
+            catalogMgr.setOutgoingValidationEnabled(outgoingValidationEnabled);
             if (!CorbaUtils.isIdActive(poa,
                     managerId.getBytes(Charset.forName(NsiliEndpoint.ENCODING)))) {
                 try {
@@ -177,6 +184,7 @@ public class LibraryImpl extends LibraryPOA {
             productMgr.setCatalogFramework(catalogFramework);
             productMgr.setFilterBuilder(filterBuilder);
             productMgr.setSubject(guestSubject);
+            productMgr.setOutgoingValidationEnabled(outgoingValidationEnabled);
             if (!CorbaUtils.isIdActive(poa,
                     managerId.getBytes(Charset.forName(NsiliEndpoint.ENCODING)))) {
                 try {
@@ -227,6 +235,7 @@ public class LibraryImpl extends LibraryPOA {
             standingQueryMgr.setSubject(guestSubject);
             standingQueryMgr.setDefaultUpdateFrequencyMsec(defaultUpdateFrequencyMsec);
             standingQueryMgr.setMaxPendingResults(maxPendingResults);
+            standingQueryMgr.setOutgoingValidationEnabled(outgoingValidationEnabled);
             if (!CorbaUtils.isIdActive(poa,
                     managerId.getBytes(Charset.forName(NsiliEndpoint.ENCODING)))) {
                 try {

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/NsiliEndpoint.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/NsiliEndpoint.java
@@ -81,6 +81,8 @@ public class NsiliEndpoint implements CorbaServiceListener {
 
     private org.omg.CORBA.Object libraryRef = null;
 
+    private boolean outgoingValidationEnabled = false;
+
     private List<String> querySources = new ArrayList<>();
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NsiliEndpoint.class);
@@ -186,6 +188,13 @@ public class NsiliEndpoint implements CorbaServiceListener {
         this.orb = orb;
     }
 
+    public void setOutgoingValidationEnabled(boolean outgoingValidationEnabled) {
+        this.outgoingValidationEnabled = outgoingValidationEnabled;
+        if (library != null) {
+            library.setOutgoingValidationEnabled(outgoingValidationEnabled);
+        }
+    }
+
     public void destroy() {
         LOGGER.debug("Destroying NSILI Endpoint");
         if (corbaOrb != null) {
@@ -258,6 +267,7 @@ public class NsiliEndpoint implements CorbaServiceListener {
         library.setDefaultUpdateFrequencyMsec(defaultUpdateFrequencySec * 1000);
         library.setMaxPendingResults(maxPendingResults);
         library.setQuerySources(querySources);
+        library.setOutgoingValidationEnabled(outgoingValidationEnabled);
 
         libraryRef = rootPOA.servant_to_reference(library);
 

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/managers/CatalogMgrImpl.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/managers/CatalogMgrImpl.java
@@ -70,6 +70,8 @@ public class CatalogMgrImpl extends CatalogMgrPOA {
 
     private List<String> querySources = new ArrayList<>();
 
+    private boolean outgoingValidationEnabled;
+
     public CatalogMgrImpl(POA poa, FilterBuilder filterBuilder, List<String> querySources) {
         this.poa = poa;
         this.filterBuilder = filterBuilder;
@@ -88,6 +90,10 @@ public class CatalogMgrImpl extends CatalogMgrPOA {
 
     public void setGuestSubject(Subject guestSubject) {
         this.guestSubject = guestSubject;
+    }
+
+    public void setOutgoingValidationEnabled(boolean outgoingValidationEnabled) {
+        this.outgoingValidationEnabled = outgoingValidationEnabled;
     }
 
     @Override
@@ -136,6 +142,7 @@ public class CatalogMgrImpl extends CatalogMgrPOA {
                 querySources);
         submitQueryRequest.set_number_of_hits(maxNumResults);
         submitQueryRequest.setTimeout(defaultTimeout);
+        submitQueryRequest.setOutgoingValidationEnabled(outgoingValidationEnabled);
 
         submitQueryRequest.setResultAttributes(result_attributes);
 

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/managers/ProductMgrImpl.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/managers/ProductMgrImpl.java
@@ -76,6 +76,8 @@ public class ProductMgrImpl extends ProductMgrPOA {
 
     private AccessManagerImpl accessManager;
 
+    private boolean outgoingValidationEnabled;
+
     public ProductMgrImpl(List<String> querySources) {
         this.querySources = querySources;
     }
@@ -90,6 +92,10 @@ public class ProductMgrImpl extends ProductMgrPOA {
 
     public void setSubject(Subject subject) {
         this.subject = subject;
+    }
+
+    public void setOutgoingValidationEnabled(boolean outgoingValidationEnabled) {
+        this.outgoingValidationEnabled = outgoingValidationEnabled;
     }
 
     @Override
@@ -110,7 +116,8 @@ public class ProductMgrImpl extends ProductMgrPOA {
                     catalogFramework,
                     filterBuilder,
                     subject,
-                    querySources);
+                    querySources,
+                    outgoingValidationEnabled);
             _poa().activate_object_with_id(id.getBytes(Charset.forName(NsiliEndpoint.ENCODING)),
                     getParametersRequest);
 

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/managers/StandingQueryMgrImpl.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/managers/StandingQueryMgrImpl.java
@@ -64,6 +64,8 @@ public class StandingQueryMgrImpl extends StandingQueryMgrPOA {
 
     private List<String> querySources = new ArrayList<>();
 
+    private boolean outgoingValidationEnabled;
+
     private long defaultTimeout = AccessManagerImpl.DEFAULT_TIMEOUT;
 
     public StandingQueryMgrImpl(List<String> querySources) {
@@ -91,6 +93,10 @@ public class StandingQueryMgrImpl extends StandingQueryMgrPOA {
 
     public void setMaxPendingResults(int maxPendingResults) {
         this.maxPendingResults = maxPendingResults;
+    }
+
+    public void setOutgoingValidationEnabled(boolean outgoingValidationEnabled) {
+        this.outgoingValidationEnabled = outgoingValidationEnabled;
     }
 
     protected void init() {
@@ -136,7 +142,8 @@ public class StandingQueryMgrImpl extends StandingQueryMgrPOA {
                 filterBuilder,
                 defaultUpdateFrequencyMsec,
                 querySources,
-                maxPendingResults);
+                maxPendingResults,
+                outgoingValidationEnabled);
 
         String id = UUID.randomUUID()
                 .toString();

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -40,6 +40,7 @@
         <property name="securityManager" ref="securityManager" />
         <property name="defaultUpdateFrequencySec" value="60" />
         <property name="maxPendingResults" value="10000" />
+        <property name="outgoingValidationEnabled" value="false" />
         <property name="querySources">
             <array/>
         </property>

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -31,6 +31,11 @@
                 name="Maximum Number Pending Results" id="maxPendingResults" required="true" type="Integer"
                 default="10000"
         />
+        <AD
+                description="Enabled or disabled outgoing DAG validation against mandatory attributes"
+                name="Enabled Outgoing Validation" id="outgoingValidationEnabled" required="true" type="Boolean"
+                default="10000"
+        />
 
         <AD name="Sources to Query:" id="querySources" description="Configured sources to query from this endpoint. Empty list defaults to local only."
             required="true" type="String" cardinality="1000"

--- a/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/TestAccessManagerImpl.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/TestAccessManagerImpl.java
@@ -17,30 +17,14 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
-
-import org.codice.alliance.nsili.endpoint.managers.AccessManagerImpl;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.omg.CORBA.ORB;
-import org.omg.CORBA.ORBPackage.InvalidName;
-import org.omg.PortableServer.POA;
-import org.omg.PortableServer.POAHelper;
-import org.omg.PortableServer.POAManagerPackage.AdapterInactive;
-import org.omg.PortableServer.POAPackage.ObjectAlreadyActive;
-import org.omg.PortableServer.POAPackage.ServantAlreadyActive;
-import org.omg.PortableServer.POAPackage.ServantNotActive;
-import org.omg.PortableServer.POAPackage.WrongPolicy;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import org.codice.alliance.nsili.common.CorbaUtils;
 import org.codice.alliance.nsili.common.GIAS.ProductMgrHelper;
@@ -51,8 +35,19 @@ import org.codice.alliance.nsili.common.ResultDAGConverter;
 import org.codice.alliance.nsili.common.UCO.DAG;
 import org.codice.alliance.nsili.common.UID.Product;
 import org.codice.alliance.nsili.common.UID.ProductHelper;
+import org.codice.alliance.nsili.endpoint.managers.AccessManagerImpl;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.omg.CORBA.ORBPackage.InvalidName;
+import org.omg.PortableServer.POAManagerPackage.AdapterInactive;
+import org.omg.PortableServer.POAPackage.ObjectAlreadyActive;
+import org.omg.PortableServer.POAPackage.ServantAlreadyActive;
+import org.omg.PortableServer.POAPackage.ServantNotActive;
+import org.omg.PortableServer.POAPackage.WrongPolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import ddf.catalog.CatalogFramework;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
 import ddf.catalog.data.impl.AttributeImpl;
@@ -62,7 +57,6 @@ import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder;
 import ddf.catalog.operation.QueryRequest;
 import ddf.catalog.operation.QueryResponse;
 import ddf.catalog.operation.impl.QueryResponseImpl;
-import ddf.security.Subject;
 import ddf.security.service.SecurityServiceException;
 
 public class TestAccessManagerImpl extends TestNsiliCommon {
@@ -75,7 +69,11 @@ public class TestAccessManagerImpl extends TestNsiliCommon {
 
     private Product testProduct = null;
 
-    private String testMetacardId = UUID.randomUUID().toString().replaceAll("-", "");;
+    private String testMetacardId = UUID.randomUUID()
+            .toString()
+            .replaceAll("-", "");
+
+    ;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TestAccessManagerImpl.class);
 
@@ -97,7 +95,8 @@ public class TestAccessManagerImpl extends TestNsiliCommon {
 
         testQuery = new Query(NsiliConstants.NSIL_ALL_VIEW, bqsQuery);
 
-        String managerId = UUID.randomUUID().toString();
+        String managerId = UUID.randomUUID()
+                .toString();
         accessManager = new AccessManagerImpl();
         accessManager.setFilterBuilder(new GeotoolsFilterBuilder());
         accessManager.setSubject(mockSubject);
@@ -124,7 +123,11 @@ public class TestAccessManagerImpl extends TestNsiliCommon {
         testMetacard.setTitle("JUnit Test Card");
         Result testResult = new ResultImpl(testMetacard);
 
-        DAG dag = ResultDAGConverter.convertResult(testResult, orb, rootPOA, new ArrayList<>());
+        DAG dag = ResultDAGConverter.convertResult(testResult,
+                orb,
+                rootPOA,
+                new ArrayList<>(),
+                new HashMap<>());
         Product product = ProductHelper.extract(dag.nodes[0].value);
         boolean avail = accessManager.is_available(product, null);
         assertThat(avail, is(false));
@@ -138,7 +141,8 @@ public class TestAccessManagerImpl extends TestNsiliCommon {
         MetacardImpl testMetacard = new MetacardImpl();
         testMetacard.setId(testMetacardId);
         testMetacard.setTitle("JUnit Test Card");
-        testMetacard.setAttribute(new AttributeImpl(Metacard.RESOURCE_DOWNLOAD_URL, "http://localhost:20000/not/present"));
+        testMetacard.setAttribute(new AttributeImpl(Metacard.RESOURCE_DOWNLOAD_URL,
+                "http://localhost:20000/not/present"));
         Result testResult = new ResultImpl(testMetacard);
 
         List<Result> results = new ArrayList<>();
@@ -146,7 +150,11 @@ public class TestAccessManagerImpl extends TestNsiliCommon {
         QueryResponse testResponse = new QueryResponseImpl(null, results, results.size());
         when(mockCatalogFramework.query(any(QueryRequest.class))).thenReturn(testResponse);
 
-        DAG dag = ResultDAGConverter.convertResult(testResult, orb, rootPOA, new ArrayList<>());
+        DAG dag = ResultDAGConverter.convertResult(testResult,
+                orb,
+                rootPOA,
+                new ArrayList<>(),
+                new HashMap<>());
         Product product = ProductHelper.extract(dag.nodes[0].value);
         boolean avail = accessManager.is_available(product, null);
         assertThat(avail, is(false));

--- a/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/TestOrderMgrImpl.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/TestOrderMgrImpl.java
@@ -19,12 +19,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 
@@ -44,10 +44,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.omg.CORBA.Any;
 import org.omg.CORBA.NO_IMPLEMENT;
-import org.omg.CORBA.ORB;
 import org.omg.CORBA.ORBPackage.InvalidName;
-import org.omg.PortableServer.POA;
-import org.omg.PortableServer.POAHelper;
 import org.omg.PortableServer.POAManagerPackage.AdapterInactive;
 import org.omg.PortableServer.POAPackage.ObjectAlreadyActive;
 import org.omg.PortableServer.POAPackage.ServantAlreadyActive;
@@ -56,7 +53,6 @@ import org.omg.PortableServer.POAPackage.WrongPolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import ddf.catalog.CatalogFramework;
 import ddf.catalog.data.Result;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.ResultImpl;
@@ -64,14 +60,15 @@ import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder;
 import ddf.catalog.operation.QueryRequest;
 import ddf.catalog.operation.QueryResponse;
 import ddf.catalog.operation.impl.QueryResponseImpl;
-import ddf.security.Subject;
 import ddf.security.service.SecurityServiceException;
 
 public class TestOrderMgrImpl extends TestNsiliCommon {
 
     private OrderMgrImpl orderMgr;
 
-    private String testMetacardId = UUID.randomUUID().toString().replaceAll("-", "");
+    private String testMetacardId = UUID.randomUUID()
+            .toString()
+            .replaceAll("-", "");
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TestOrderMgrImpl.class);
 
@@ -91,7 +88,8 @@ public class TestOrderMgrImpl extends TestNsiliCommon {
             LOGGER.error("Unable to setup guest security credentials", e);
         }
 
-        String managerId = UUID.randomUUID().toString();
+        String managerId = UUID.randomUUID()
+                .toString();
         orderMgr = new OrderMgrImpl();
         orderMgr.setFilterBuilder(new GeotoolsFilterBuilder());
         orderMgr.setSubject(mockSubject);
@@ -108,7 +106,7 @@ public class TestOrderMgrImpl extends TestNsiliCommon {
         }
 
         rootPOA.create_reference_with_id(managerId.getBytes(Charset.forName(NsiliEndpoint.ENCODING)),
-                        ProductMgrHelper.id());
+                ProductMgrHelper.id());
     }
 
     @Test
@@ -118,7 +116,11 @@ public class TestOrderMgrImpl extends TestNsiliCommon {
         testMetacard.setTitle("JUnit Test Card");
         Result testResult = new ResultImpl(testMetacard);
 
-        DAG dag = ResultDAGConverter.convertResult(testResult, orb, rootPOA, new ArrayList<>());
+        DAG dag = ResultDAGConverter.convertResult(testResult,
+                orb,
+                rootPOA,
+                new ArrayList<>(),
+                new HashMap<>());
         Product product = ProductHelper.extract(dag.nodes[0].value);
         boolean avail = orderMgr.is_available(product, null);
         assertThat(avail, is(false));
@@ -126,7 +128,6 @@ public class TestOrderMgrImpl extends TestNsiliCommon {
         avail = orderMgr.is_available(null, null);
         assertThat(avail, is(false));
     }
-
 
     @Test
     public void testOrder() throws Exception {
@@ -147,7 +148,7 @@ public class TestOrderMgrImpl extends TestNsiliCommon {
     }
 
     @Test
-    public void testGetTimeout() throws Exception{
+    public void testGetTimeout() throws Exception {
         int timeout = orderMgr.get_timeout(null);
         assertThat(timeout, is(AccessManagerImpl.DEFAULT_TIMEOUT));
     }
@@ -186,7 +187,7 @@ public class TestOrderMgrImpl extends TestNsiliCommon {
 
     @Test
     public void testSetAvailability() throws Exception {
-        SetAvailabilityRequest request = orderMgr.set_availability(null, null, null, (short)1);
+        SetAvailabilityRequest request = orderMgr.set_availability(null, null, null, (short) 1);
         assertThat(request, notNullValue());
     }
 
@@ -196,12 +197,12 @@ public class TestOrderMgrImpl extends TestNsiliCommon {
         assertThat(properties.length, is(2));
     }
 
-    @Test (expected = NO_IMPLEMENT.class)
+    @Test(expected = NO_IMPLEMENT.class)
     public void testGetPropertyValues() throws Exception {
         orderMgr.get_property_values(null);
     }
 
-    @Test (expected = NO_IMPLEMENT.class)
+    @Test(expected = NO_IMPLEMENT.class)
     public void testGetLibraries() throws Exception {
         orderMgr.get_libraries();
     }

--- a/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/TestSubmitStandingQueryRequestImpl.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/TestSubmitStandingQueryRequestImpl.java
@@ -384,7 +384,8 @@ public class TestSubmitStandingQueryRequestImpl extends TestNsiliCommon {
                 filterBuilder,
                 defaultUpdateFrequencyMsec,
                 null,
-                maxPendingResults);
+                maxPendingResults,
+                false);
         standingQueryRequest.register_callback(mockCallback2);
 
         String managerId = UUID.randomUUID().toString();

--- a/distribution/sdk/sample-nsili-client/src/main/java/org/codice/alliance/nsili/client/Client.java
+++ b/distribution/sdk/sample-nsili-client/src/main/java/org/codice/alliance/nsili/client/Client.java
@@ -139,7 +139,7 @@ public class Client {
     private void startHttpListener() {
         try {
             ResourceConfig rc = new PackagesResourceConfig(
-                    "org.codice.alliance.nsili.mockserver.client");
+                    "org.codice.alliance.nsili.client");
             server = GrizzlyServerFactory.createHttpServer("http://0.0.0.0:" + LISTEN_PORT, rc);
             NetworkListener networkListener = new NetworkListener("sample-listener",
                     "0.0.0.0",


### PR DESCRIPTION
#### What does this PR do?
CAL-57: ResultDAGConverter option to enforce mandatory nodes.. Can be enabled/disabled via the Admin UI.
#### Who is reviewing it?
@jaymcnallie @jlcsmith @dcruver @bdeining 
#### How should this be tested?
Build and run JUnit tests
#### Any background context you want to provide?
Depends on CAL-56 being merged 1st, only the CAL-57 commit should be reviewed with this. Both commits are present due to the dependency.
#### What are the relevant tickets?
https://codice.atlassian.net/browse/CAL-57
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
