### PR TITLE
CAL-72: Populates metadata field of Nsili metacards with serialization of the DAG's nodes

### DIFF
--- a/catalog/nsili/catalog-nsili-transformer/pom.xml
+++ b/catalog/nsili/catalog-nsili-transformer/pom.xml
@@ -57,7 +57,18 @@
             <artifactId>catalog-core-urlresourcereader</artifactId>
             <version>${ddf.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.thoughtworks.xstream</groupId>
+            <artifactId>xstream</artifactId>
+            <version>1.4.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>${commons-collections4.version}</version>
+        </dependency>
     </dependencies>
+
 
     <build>
         <plugins>

--- a/catalog/nsili/catalog-nsili-transformer/src/main/java/org/codice/alliance/nsili/transformer/AnyConverter.java
+++ b/catalog/nsili/catalog-nsili-transformer/src/main/java/org/codice/alliance/nsili/transformer/AnyConverter.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.transformer;
+
+import org.omg.CORBA.Any;
+
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+
+/**
+ * A {@link Converter} for serializing the {@link Any} object's {@code value} to XML.
+ */
+public class AnyConverter implements Converter {
+
+    @Override
+    public void marshal(Object o, HierarchicalStreamWriter writer, MarshallingContext context) {
+        String value = DAGConverter.getNodeValue((Any) o) != null ?
+                DAGConverter.getNodeValue((Any) o) :
+                "null";
+        writer.setValue(value);
+    }
+
+    @Override
+    public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+        return null;
+    }
+
+    @Override
+    public boolean canConvert(Class clazz) {
+        return Any.class.isAssignableFrom(clazz);
+    }
+}

--- a/catalog/nsili/catalog-nsili-transformer/src/test/java/org/codice/alliance/nsili/transformer/TestAnyConverter.java
+++ b/catalog/nsili/catalog-nsili-transformer/src/test/java/org/codice/alliance/nsili/transformer/TestAnyConverter.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.transformer;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.omg.CORBA.Any;
+import org.omg.CORBA.ORB;
+
+import com.thoughtworks.xstream.XStream;
+
+public class TestAnyConverter {
+
+    private static final String VALUE = "somevalue";
+
+    private static final String EXPECTED_RESULT = "<com.sun.corba.se.impl.corba.AnyImpl>somevalue</com.sun.corba.se.impl.corba.AnyImpl>";
+
+    private ORB orb;
+
+    private AnyConverter anyConverter;
+
+    @Before
+    public void setup() {
+        this.orb = ORB.init();
+
+        anyConverter = new AnyConverter();
+    }
+
+    @Test
+    public void convertAnyToXML() {
+        Any any = orb.create_any();
+        any.insert_wstring(VALUE);
+
+        assertThat(anyConverter.canConvert(any.getClass()), is(true));
+
+        XStream xstream = new XStream();
+        xstream.registerConverter(anyConverter);
+        String result = xstream.toXML(any);
+
+        assertThat(result, is(EXPECTED_RESULT));
+    }
+}


### PR DESCRIPTION
#### What does this PR do?
-The nodes of the original DAG response received from an Nsili source are serialized to XML and added to the metadata field of the Nsili metacards.
#### Who is reviewing it?
@troymohl @bdeining @jlcsmith 
#### How should this be tested?
Configure a Nsili Federated Source and do a search. Verify the Metadata field is populated with an XML version of the nodes from the DAG. 
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/CAL-72
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests