### PR TITLE
CAL-73 Create content metadata extractors for common and DoD banner markings.

### DIFF
--- a/catalog/security/alliance-security-app/pom.xml
+++ b/catalog/security/alliance-security-app/pom.xml
@@ -1,4 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/distribution/test/itests/test-itests-alliance/src/test/java/alliance/test/itests/TestBannerMarkings.java
+++ b/distribution/test/itests/test-itests-alliance/src/test/java/alliance/test/itests/TestBannerMarkings.java
@@ -139,7 +139,7 @@ public class TestBannerMarkings extends AbstractIntegrationTest {
 
         Attribute attribute = getAttribute(metacard,
                 BannerCommonMarkingExtractor.SECURITY_CLASSIFICATION);
-        assertThat(attribute.getValue(), equalTo("TS"));
+        assertThat(attribute.getValue(), equalTo("CTS-B"));
 
         attribute = getAttribute(metacard, BannerCommonMarkingExtractor.SECURITY_OWNER_PRODUCER);
         assertThat(attribute.getValue(), equalTo("COSMIC"));


### PR DESCRIPTION
#### What does this PR do?
This change fixes an itest that was broken when the classification format for NATO/COSMIC data was changed and adds a missing header to a pom file.

#### Who is reviewing it?
@stustison @kcwire 

#### How should this be tested?
Build/test

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
CAL-73

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [x] Update / Add Integration Tests