### PR TITLE
CAL-73 Create content metadata extractors for common and DoD banner markings.

### DIFF
--- a/catalog/security/banner-marking/src/main/java/org/codice/alliance/security/banner/marking/BannerCommonMarkingExtractor.java
+++ b/catalog/security/banner-marking/src/main/java/org/codice/alliance/security/banner/marking/BannerCommonMarkingExtractor.java
@@ -147,8 +147,12 @@ public class BannerCommonMarkingExtractor extends MarkingExtractor {
         case US:
             return new AttributeImpl(key, ImmutableList.<String>of("USA"));
         case FGI:
-            return new AttributeImpl(key,
-                    ImmutableList.<String>of(bannerMarkings.getFgiAuthority()));
+            if (bannerMarkings.getFgiAuthority().equals("COSMIC")) {
+                return new AttributeImpl(key, ImmutableList.<String>of("NATO"));
+            } else {
+                return new AttributeImpl(key,
+                        ImmutableList.<String>of(bannerMarkings.getFgiAuthority()));
+            }
         case JOINT:
             return new AttributeImpl(key,
                     ImmutableList.<String>copyOf(bannerMarkings.getJointAuthorities()));

--- a/catalog/security/banner-marking/src/test/groovy/org/codice/alliance/security/banner/marking/BannerCommonMarkingExtractorTest.groovy
+++ b/catalog/security/banner-marking/src/test/groovy/org/codice/alliance/security/banner/marking/BannerCommonMarkingExtractorTest.groovy
@@ -267,10 +267,10 @@ class BannerCommonMarkingExtractorTest extends Specification {
         '//NATO SECRET'                | false           | ['NATO']
         '//NATO SECRET//ATOMAL'        | false           | ['NATO']
         '//GBR SECRET'                 | false           | ['GBR']
-        '//COSMIC TOP SECRET'          | false           | ['COSMIC']
-        '//COSMIC TOP SECRET//ATOMAL'  | false           | ['COSMIC']
-        '//COSMIC TOP SECRET//BALK'    | false           | ['COSMIC']
-        '//COSMIC TOP SECRET//BOHEMIA' | false           | ['COSMIC']
+        '//COSMIC TOP SECRET'          | false           | ['NATO']
+        '//COSMIC TOP SECRET//ATOMAL'  | false           | ['NATO']
+        '//COSMIC TOP SECRET//BALK'    | false           | ['NATO']
+        '//COSMIC TOP SECRET//BOHEMIA' | false           | ['NATO']
         '//COSMIC SECRET//ATOMAL'      | true            | null
         '//COSMIC SECRET//BALK'        | true            | null
         '//COSMIC SECRET//BOHEMIA'     | true            | null
@@ -309,10 +309,10 @@ class BannerCommonMarkingExtractorTest extends Specification {
         '//NATO SECRET'                | false           | ['NATO']
         '//NATO SECRET//ATOMAL'        | false           | ['NATO']
         '//GBR SECRET'                 | false           | ['GBR']
-        '//COSMIC TOP SECRET'          | false           | ['COSMIC']
-        '//COSMIC TOP SECRET//ATOMAL'  | false           | ['COSMIC']
-        '//COSMIC TOP SECRET//BALK'    | false           | ['COSMIC']
-        '//COSMIC TOP SECRET//BOHEMIA' | false           | ['COSMIC']
+        '//COSMIC TOP SECRET'          | false           | ['NATO']
+        '//COSMIC TOP SECRET//ATOMAL'  | false           | ['NATO']
+        '//COSMIC TOP SECRET//BALK'    | false           | ['NATO']
+        '//COSMIC TOP SECRET//BOHEMIA' | false           | ['NATO']
         '//COSMIC SECRET//ATOMAL'      | true            | null
         '//COSMIC SECRET//BALK'        | true            | null
         '//COSMIC SECRET//BOHEMIA'     | true            | null


### PR DESCRIPTION
#### What does this PR do?
This change fixes the ownerProducer to be NATO in the case of COSMIC-marked files.

#### Who is reviewing it?
@stustison @ryeats @tbatie 

#### How should this be tested?
Build and run all tests.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
CAL-73

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
