### PR TITLE
CAL-88 Updates ImagingChipActionProvider to correctly implement MultiActionProvider

### DIFF
--- a/catalog/imaging/imaging-actionprovider-chip/src/main/java/org/codice/alliance/imaging/chip/actionprovider/ImagingChipActionProvider.java
+++ b/catalog/imaging/imaging-actionprovider-chip/src/main/java/org/codice/alliance/imaging/chip/actionprovider/ImagingChipActionProvider.java
@@ -24,11 +24,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import ddf.action.Action;
-import ddf.action.ActionProvider;
+import ddf.action.MultiActionProvider;
 import ddf.action.impl.ActionImpl;
 import ddf.catalog.data.Metacard;
 
-public class ImagingChipActionProvider implements ActionProvider {
+public class ImagingChipActionProvider implements MultiActionProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ImagingChipActionProvider.class);
 


### PR DESCRIPTION
#### What does this PR do?
For backwards compatibility, the ActionProvider interface was restored to its former definition and a new MultiActionProvider interface was added to DDF. This updates ImagingChipActionProvider to implement the new interface.

#### Who is reviewing it?
@pklinef @kcwire @jlcsmith 

#### How should this be tested?
Full build and integration tests should affirm this works correctly.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
CAL-88

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests