### PR TITLE
CAL-89 Prepare Alliance for 0.1 release

### DIFF
--- a/catalog/imaging/imaging-actionprovider-chip/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/imaging/imaging-actionprovider-chip/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -14,7 +14,7 @@
  -->
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 
-    <service interface="ddf.action.ActionProvider">
+    <service interface="ddf.action.MultiActionProvider">
         <service-properties>
             <entry key="id" value="catalog.data.metacard.image.chipping"/>
             <entry key="shortname" value="catalog.data.metacard.image.chipping"/>

--- a/catalog/imaging/imaging-transformer-nitf/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -60,36 +60,36 @@
         </service-properties>
     </service>
 
-    <service interface="ddf.catalog.transform.MetacardTransformer">
-        <service-properties>
-            <entry key="id" value="overlay.overview"/>
-            <!-- shortname only exists for backwards compatibility -->
-            <entry key="shortname" value="overlay.overview"/>
-            <entry key="mime-type" value="image/png"/>
-            <entry key="generateActionProvider" value="false"/>
-        </service-properties>
-        <bean class="ddf.catalog.transformer.OverlayMetacardTransformer">
-            <argument>
-                <bean class="org.codice.alliance.transformer.nitf.OverviewSupplier">
-                    <argument>
-                        <reference interface="ddf.catalog.transform.MetacardTransformer"
-                                   filter="(id=resource)"/>
-                    </argument>
-                </bean>
-            </argument>
-        </bean>
-    </service>
+    <!--<service interface="ddf.catalog.transform.MetacardTransformer">-->
+        <!--<service-properties>-->
+            <!--<entry key="id" value="overlay.overview"/>-->
+            <!--&lt;!&ndash; shortname only exists for backwards compatibility &ndash;&gt;-->
+            <!--<entry key="shortname" value="overlay.overview"/>-->
+            <!--<entry key="mime-type" value="image/png"/>-->
+            <!--<entry key="generateActionProvider" value="false"/>-->
+        <!--</service-properties>-->
+        <!--<bean class="ddf.catalog.transformer.OverlayMetacardTransformer">-->
+            <!--<argument>-->
+                <!--<bean class="org.codice.alliance.transformer.nitf.OverviewSupplier">-->
+                    <!--<argument>-->
+                        <!--<reference interface="ddf.catalog.transform.MetacardTransformer"-->
+                                   <!--filter="(id=resource)"/>-->
+                    <!--</argument>-->
+                <!--</bean>-->
+            <!--</argument>-->
+        <!--</bean>-->
+    <!--</service>-->
 
-    <service interface="ddf.action.ActionProvider">
-        <service-properties>
-            <entry key="id" value="catalog.data.metacard.map.overlay.overview"/>
-        </service-properties>
-        <bean class="ddf.catalog.transformer.OverlayActionProvider">
-            <argument>
-                <bean class="org.codice.alliance.transformer.nitf.OverviewPredicate"/>
-            </argument>
-            <argument value="overlay.overview"/>
-        </bean>
-    </service>
+    <!--<service interface="ddf.action.ActionProvider">-->
+        <!--<service-properties>-->
+            <!--<entry key="id" value="catalog.data.metacard.map.overlay.overview"/>-->
+        <!--</service-properties>-->
+        <!--<bean class="ddf.catalog.transformer.OverlayActionProvider">-->
+            <!--<argument>-->
+                <!--<bean class="org.codice.alliance.transformer.nitf.OverviewPredicate"/>-->
+            <!--</argument>-->
+            <!--<argument value="overlay.overview"/>-->
+        <!--</bean>-->
+    <!--</service>-->
 
 </blueprint>

--- a/distribution/test/itests/test-itests-alliance/src/test/java/alliance/test/itests/TestAllianceApps.java
+++ b/distribution/test/itests/test-itests-alliance/src/test/java/alliance/test/itests/TestAllianceApps.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package alliance.test.itests;
+
+import static org.codice.ddf.admin.application.service.ApplicationStatus.ApplicationState.ACTIVE;
+import static org.codice.ddf.admin.application.service.ApplicationStatus.ApplicationState.INACTIVE;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.ops4j.pax.exam.CoreOptions.maven;
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.CoreOptions.options;
+import static org.ops4j.pax.exam.CoreOptions.wrappedBundle;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+
+import java.io.File;
+
+import org.codice.ddf.admin.application.service.Application;
+import org.codice.ddf.admin.application.service.ApplicationService;
+import org.codice.ddf.admin.application.service.ApplicationServiceException;
+import org.codice.ddf.admin.application.service.ApplicationStatus;
+import org.codice.ddf.security.common.Security;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+
+import ddf.common.test.BeforeExam;
+import ddf.security.Subject;
+import ddf.test.itests.AbstractIntegrationTest;
+
+/**
+ * Ensures that all Alliance apps are able to be installed.
+ */
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public class TestAllianceApps extends AbstractIntegrationTest {
+    private static final String[] REQUIRED_APPS = {"catalog-app", "solr-app", "spatial-app"};
+
+    private static final String[] APPS =
+            {"alliance-security-app", "nsili-app", "imaging-app", "video-app"};
+
+    @Override
+    protected Option[] configureDistribution() {
+        return options(karafDistributionConfiguration(maven().groupId(
+                "org.codice.alliance.distribution")
+                .artifactId("alliance")
+                .type("zip")
+                .versionAsInProject()
+                .getURL(), "alliance", KARAF_VERSION).unpackDirectory(new File("target/exam"))
+                .useDeployFolder(false));
+    }
+
+    @Override
+    protected Option[] configureCustom() {
+        return options(wrappedBundle(mavenBundle("ddf.test.itests", "test-itests-ddf").classifier(
+                "tests")
+                .versionAsInProject()).bundleSymbolicName("test-itests-ddf")
+                .exports("ddf.test.itests.*"), keepRuntimeFolder());
+    }
+
+    @BeforeExam
+    public void beforeAllianceTest() throws Exception {
+        try {
+            basePort = getBasePort();
+            getAdminConfig().setLogLevels();
+
+            getServiceManager().waitForRequiredApps(REQUIRED_APPS);
+            getServiceManager().waitForAllBundles();
+            getCatalogBundle().waitForCatalogProvider();
+        } catch (Exception e) {
+            LOGGER.error("Failed in @BeforeExam: ", e);
+            fail("Failed in @BeforeExam: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void installAllianceApps() throws Exception {
+        ApplicationService applicationService = getServiceManager().getService(
+                ApplicationService.class);
+        Subject systemSubject = Security.runAsAdmin(() -> Security.getInstance()
+                .getSystemSubject());
+
+        systemSubject.execute(() -> {
+            for (String appName : APPS) {
+                Application app = applicationService.getApplication(appName);
+                assertNotNull(String.format("Application [%s] must not be null", appName), app);
+                ApplicationStatus status = applicationService.getApplicationStatus(app);
+                assertThat(String.format("%s should be INACTIVE", appName), status.getState(),
+                        is(INACTIVE));
+
+                try {
+                    applicationService.startApplication(app);
+                } catch (ApplicationServiceException e) {
+                    fail(String.format("Failed to start the %s: %s", appName, e.getMessage()));
+                }
+                status = applicationService.getApplicationStatus(app);
+                assertThat(String.format("%s should be ACTIVE after start, but was [%s]", appName,
+                        status.getState()), status.getState(), is(ACTIVE));
+            }
+
+            return null;
+        });
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <ddf.version>2.10.0-SNAPSHOT</ddf.version>
+        <ddf.version>2.9.1-SNAPSHOT</ddf.version>
         <ddf.support.version>2.3.6</ddf.support.version>
         <ddf.scm.connection.url/>
         <snapshots.repository.url/>


### PR DESCRIPTION
#### What does this PR do?
Alliance 0.1 will be released against DDF 2.9.1. Some of the services exported by the `imaging-app` can not be deployed because they were built against upcoming code in DDF 2.10.0. Comment out those services and create an integration test that affirms that all applications can be installed and started.

This additionally fixes an issue with the `imaging-actionprovider-chip` service.

#### Who is reviewing it?
@jlcsmith @kcwire @tbatie 

#### How should this be tested?
Full build with itests

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
CAL-89

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [x] Update / Add Integration Tests
