### PR TITLE
CAL-99 Updated text searches to only query free text fields within the NSILI data model

### DIFF
--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliConstants.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliConstants.java
@@ -191,6 +191,8 @@ public class NsiliConstants {
 
     public static final String SPATIAL_GEOGRAPHIC_REF_BOX = "spatialGeographicReferenceBox";
 
+    public static final String ADVANCED_GEOSPATIAL = "advancedGeoSpatial";
+
     public static final String TEMPORAL_START = "temporalStart";
 
     public static final String TEMPORAL_END = "temporalEnd";

--- a/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/TestAccessManagerImpl.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/TestAccessManagerImpl.java
@@ -142,7 +142,7 @@ public class TestAccessManagerImpl extends TestNsiliCommon {
         testMetacard.setId(testMetacardId);
         testMetacard.setTitle("JUnit Test Card");
         testMetacard.setAttribute(new AttributeImpl(Metacard.RESOURCE_DOWNLOAD_URL,
-                "http://localhost:20000/not/present"));
+                "http://localhost:20999/not/present"));
         Result testResult = new ResultImpl(testMetacard);
 
         List<Result> results = new ArrayList<>();

--- a/catalog/nsili/catalog-nsili-source/src/main/java/org/codice/alliance/nsili/source/NsiliFilterFactory.java
+++ b/catalog/nsili/catalog-nsili-source/src/main/java/org/codice/alliance/nsili/source/NsiliFilterFactory.java
@@ -181,7 +181,9 @@ public class NsiliFilterFactory {
     }
 
     public boolean isTextAttributeType(AttributeInformation attributeInformation) {
-        return attributeInformation.attribute_type.equals(AttributeType.TEXT)
+        return  !attributeInformation.attribute_name.contains(NsiliConstants.ADVANCED_GEOSPATIAL)
+                && attributeInformation.attribute_domain.discriminator() == DomainType.TEXT_VALUE
+                && attributeInformation.attribute_type.equals(AttributeType.TEXT)
                 && !attributeInformation.attribute_name.equals(TYPE);
     }
 

--- a/catalog/nsili/catalog-nsili-source/src/test/java/org/codice/alliance/nsili/source/TestNsiliFilterDelegate.java
+++ b/catalog/nsili/catalog-nsili-source/src/test/java/org/codice/alliance/nsili/source/TestNsiliFilterDelegate.java
@@ -13,6 +13,7 @@
  */
 package org.codice.alliance.nsili.source;
 
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -31,6 +32,7 @@ import org.codice.alliance.nsili.common.GIAS.AttributeInformation;
 import org.codice.alliance.nsili.common.GIAS.AttributeType;
 import org.codice.alliance.nsili.common.GIAS.DateRange;
 import org.codice.alliance.nsili.common.GIAS.Domain;
+import org.codice.alliance.nsili.common.GIAS.DomainType;
 import org.codice.alliance.nsili.common.GIAS.IntegerRange;
 import org.codice.alliance.nsili.common.GIAS.RequirementMode;
 import org.codice.alliance.nsili.common.NsiliConstants;
@@ -527,9 +529,10 @@ public class TestNsiliFilterDelegate {
 
         List<AttributeInformation> attributeInformationList = generateAttributeInformation().get(
                 NsiliConstants.NSIL_ALL_VIEW);
-        StringBuilder result = new StringBuilder(NsiliFilterFactory.LP);
+        StringBuilder result = new StringBuilder();
         for (AttributeInformation attributeInformation : attributeInformationList) {
-            if (attributeInformation.attribute_type.equals(AttributeType.TEXT)) {
+            if (attributeInformation.attribute_type.equals(AttributeType.TEXT) &&
+                    attributeInformation.attribute_domain.discriminator() == DomainType.TEXT_VALUE) {
                 result.append(getPrimary(attributeInformation.attribute_name,
                         NsiliFilterFactory.LIKE,
                         NsiliFilterDelegate.SQ + NsiliFilterDelegate.WILDCARD + ATTRIBUTE
@@ -539,8 +542,10 @@ public class TestNsiliFilterDelegate {
 
         }
         String resultString = result.toString();
-        resultString = resultString.substring(0, result.length() - 4) + NsiliFilterFactory.RP;
+        resultString = resultString.substring(0, result.length() - 4);
         assertThat(filter, is(resultString));
+
+        assertThat(filter, not(containsString(NsiliConstants.ADVANCED_GEOSPATIAL)));
     }
 
     @Test


### PR DESCRIPTION
#### What does this PR do?
CAL-99 Updated text searches to only query free text fields within the NSILI data model
Fixes handling of ANY_TEXT to NSILI text fields for queries.

#### Who is reviewing it?
@jaymcnallie @jlcsmith @bdeining @beyelerb 

#### How should this be tested?
Run the JUnit test cases

#### Any background context you want to provide?
Previously we were passing the ANY_TEXT search criteria to enumerated fields. This could cause problems with systems that only expect those enumerated values to be queried. 

#### What are the relevant tickets?
https://codice.atlassian.net/browse/CAL-99

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests