### PR TITLE
CAL-100 Removed alliance prefix from alliance-security-app

### DIFF
--- a/catalog/security/pom.xml
+++ b/catalog/security/pom.xml
@@ -30,6 +30,6 @@
 
     <modules>
         <module>banner-marking</module>
-        <module>alliance-security-app</module>
+        <module>security-app</module>
     </modules>
 </project>

--- a/catalog/security/security-app/pom.xml
+++ b/catalog/security/security-app/pom.xml
@@ -23,7 +23,7 @@
         <version>0.2-SNAPSHOT</version>
     </parent>
 
-    <artifactId>alliance-security-app</artifactId>
+    <artifactId>security-app</artifactId>
     <packaging>pom</packaging>
     <name>Alliance :: Security :: App</name>
 

--- a/catalog/security/security-app/src/main/resources/features.xml
+++ b/catalog/security/security-app/src/main/resources/features.xml
@@ -21,7 +21,7 @@
         <bundle>mvn:org.codice.alliance.security/banner-marking/${project.version}</bundle>
     </feature>
 
-    <feature name="alliance-security-app" install="auto" version="${project.version}"
+    <feature name="security-app" install="auto" version="${project.version}"
              description="The Alliance Security App provides features to enhance security. ::Alliance Security">
         <feature prerequisite="true">catalog-app</feature>
         <feature>banner-marking</feature>

--- a/distribution/alliance/pom.xml
+++ b/distribution/alliance/pom.xml
@@ -114,7 +114,7 @@
         </dependency>
         <dependency>
             <groupId>org.codice.alliance.security</groupId>
-            <artifactId>alliance-security-app</artifactId>
+            <artifactId>security-app</artifactId>
             <version>${project.version}</version>
             <classifier>features</classifier>
             <type>xml</type>
@@ -224,7 +224,7 @@
                                     mvn:org.codice.alliance.nsili/nsili-app/${project.version}/xml/features
                                 </descriptor>
                                 <descriptor>
-                                    mvn:org.codice.alliance.security/alliance-security-app/${project.version}/xml/features
+                                    mvn:org.codice.alliance.security/security-app/${project.version}/xml/features
                                 </descriptor>
                                 <descriptor>
                                     mvn:org.codice.alliance.distribution/install-profiles/${project.version}/xml/features

--- a/distribution/alliance/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
+++ b/distribution/alliance/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
@@ -22,7 +22,7 @@
 featuresRepositories= \
  mvn:org.codice.alliance.distribution/${project.artifactId}/${project.version}/xml/features, \
  mvn:org.codice.alliance.nsili/nsili-app/${project.version}/xml/features, \
- mvn:org.codice.alliance.security/alliance-security-app/${project.version}/xml/features, \
+ mvn:org.codice.alliance.security/security-app/${project.version}/xml/features, \
  mvn:org.codice.alliance.distribution/install-profiles/${project.version}/xml/features, \
  mvn:org.codice.alliance.imaging/imaging-app/${project.version}/xml/features, \
  mvn:org.codice.alliance.video/video-app/${project.version}/xml/features, \

--- a/distribution/install-profiles/src/main/resources/features.xml
+++ b/distribution/install-profiles/src/main/resources/features.xml
@@ -48,6 +48,7 @@
         <!-- Alliance Apps -->
         <feature>nsili-app</feature>
         <feature>imaging-app</feature>
+        <feature>security-app</feature>
         <!-- Experimental Apps-->
         <feature>resourcemanagement-app</feature>
         <feature>geowebcache-app</feature>

--- a/distribution/test/itests/test-itests-alliance/src/test/java/alliance/test/itests/TestAllianceApps.java
+++ b/distribution/test/itests/test-itests-alliance/src/test/java/alliance/test/itests/TestAllianceApps.java
@@ -53,7 +53,7 @@ public class TestAllianceApps extends AbstractIntegrationTest {
     private static final String[] REQUIRED_APPS = {"catalog-app", "solr-app", "spatial-app"};
 
     private static final String[] APPS =
-            {"alliance-security-app", "nsili-app", "imaging-app", "video-app"};
+            {"security-app", "nsili-app", "imaging-app", "video-app"};
 
     @Override
     protected Option[] configureDistribution() {

--- a/distribution/test/itests/test-itests-alliance/src/test/java/alliance/test/itests/TestBannerMarkings.java
+++ b/distribution/test/itests/test-itests-alliance/src/test/java/alliance/test/itests/TestBannerMarkings.java
@@ -62,7 +62,7 @@ import ddf.test.itests.AbstractIntegrationTest;
 @ExamReactorStrategy(PerClass.class)
 public class TestBannerMarkings extends AbstractIntegrationTest {
     private static final String[] REQUIRED_APPS =
-            {"catalog-app", "solr-app", "spatial-app", "alliance-security-app"};
+            {"catalog-app", "solr-app", "spatial-app", "security-app"};
 
     @Override
     protected Option[] configureDistribution() {


### PR DESCRIPTION
#### What does this PR do?
This PR removes the alliance prefix from alliance-security-app to match the app conventions of all other apps within Alliance
#### Who is reviewing it?
@coyotesqrl @jlcsmith @lcrosenbu @jrnorth 
#### How should this be tested?
Build and run Alliance Experimental, observe all apps start
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/CAL-100
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

