### PR TITLE
CAL-104 configure DefaultSecurityAttributeValuesPlugin to apply secur…

### DIFF
--- a/catalog/plugin/catalog-plugin-defaultsecurityattributevalues/pom.xml
+++ b/catalog/plugin/catalog-plugin-defaultsecurityattributevalues/pom.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.codice.alliance.catalog.plugin</groupId>
+        <artifactId>plugin</artifactId>
+        <version>0.2-SNAPSHOT</version>
+    </parent>
+    <name>Alliance :: Catalog :: Plugin :: Default Security Attribute Value Plugin</name>
+    <artifactId>catalog-plugin-defaultsecurityattributevalues</artifactId>
+    <packaging>bundle</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>ddf.security.core</groupId>
+            <artifactId>security-core-api</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.security</groupId>
+            <artifactId>ddf-security-common</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.alliance.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.alliance.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.servicemix.bundles</groupId>
+            <artifactId>org.apache.servicemix.bundles.opensaml</artifactId>
+            <version>3.1.1_3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>
+                            catalog-core-api-impl;groupId=org.codice.alliance.catalog.core;version=${project.version},
+                            catalog-core-api-impl;groupId=ddf.catalog.core;version=${ddf.version},
+                            platform-util,
+                            commons-lang3
+                        </Embed-Dependency>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>.87</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>.74</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>.50</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>.78</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/catalog/plugin/catalog-plugin-defaultsecurityattributevalues/src/main/java/org/codice/alliance/catalog/plugin/defaultsecurity/DefaultSecurityAttributeValuesPlugin.java
+++ b/catalog/plugin/catalog-plugin-defaultsecurityattributevalues/src/main/java/org/codice/alliance/catalog/plugin/defaultsecurity/DefaultSecurityAttributeValuesPlugin.java
@@ -1,0 +1,211 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.catalog.plugin.defaultsecurity;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.codice.alliance.catalog.core.api.impl.types.SecurityAttributes;
+import org.codice.alliance.catalog.core.api.types.Security;
+import org.opensaml.core.xml.schema.XSString;
+import org.opensaml.saml.saml2.core.AttributeStatement;
+
+import com.google.common.collect.ImmutableList;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.data.impl.MetacardTypeImpl;
+import ddf.catalog.operation.CreateRequest;
+import ddf.catalog.operation.DeleteRequest;
+import ddf.catalog.operation.UpdateRequest;
+import ddf.catalog.operation.impl.CreateRequestImpl;
+import ddf.catalog.plugin.PluginExecutionException;
+import ddf.catalog.plugin.PreIngestPlugin;
+import ddf.catalog.plugin.StopProcessingException;
+import ddf.security.Subject;
+import ddf.security.assertion.SecurityAssertion;
+
+public class DefaultSecurityAttributeValuesPlugin implements PreIngestPlugin {
+
+    private final SecurityAttributes securityAttributes;
+
+    public static final String DEFAULTMARKINGS = "defaultMarkings";
+
+    private static final Map<String, Set<String>> SYS_HIGH_TO_METACARD_ATTRIBUTE_MAPPING =
+            new HashMap<>();
+
+    public DefaultSecurityAttributeValuesPlugin(SecurityAttributes securityAttributes) {
+        this.securityAttributes = securityAttributes;
+    }
+
+    Subject getSystemSubject() {
+        return org.codice.ddf.security.common.Security.getInstance()
+                .getSystemSubject();
+    }
+
+    /**
+     * Retrieves the system high attributes and the mapping of the system attribute names to
+     * metacard security markings. Returns a hash map of the metacard markings
+     * to the value of its corresponding system attribute.
+     *
+     * @return Map of the metacard security markings to the value of their corresponding system high
+     * attribute.
+     */
+    private Map<String, Attribute> getHighwaterSecurityMarkings() {
+        Map<String, Attribute> securityMarkings = new HashMap<>();
+        Subject system = org.codice.ddf.security.common.Security.runAsAdmin(this::getSystemSubject);
+        SecurityAssertion assertion = system.getPrincipals()
+                .oneByType(SecurityAssertion.class);
+        List<AttributeStatement> attributeStatements = assertion.getAttributeStatements();
+        for (AttributeStatement curStatement : attributeStatements) {
+            for (org.opensaml.saml.saml2.core.Attribute attribute : curStatement.getAttributes()) {
+                Collection<String> attributeNames = SYS_HIGH_TO_METACARD_ATTRIBUTE_MAPPING.get(
+                        attribute.getName());
+
+                if (attributeNames == null || attributeNames.isEmpty()) {
+                    continue;
+                }
+                //if a user attribute is assigned to multiple metacard attributes add its values to each
+                for (String attributeName : attributeNames) {
+                    Collection<Serializable> values = attribute.getAttributeValues()
+                            .stream()
+                            .filter(curValue -> curValue instanceof XSString)
+                            .map(XSString.class::cast)
+                            .map(XSString::getValue)
+                            .collect(Collectors.toCollection(HashSet::new));
+                    if (securityMarkings.get(attributeName) != null) {
+                        values.addAll(securityMarkings.get(attributeName)
+                                .getValues());
+                    }
+                    securityMarkings.put(attributeName,
+                            new AttributeImpl(attributeName,
+                                    (List<Serializable>) ImmutableList.copyOf(values)));
+                }
+            }
+        }
+        return securityMarkings;
+    }
+
+    /**
+     * Adds default system high-water markings in the event that none of the policies were able to apply security markings to this metacard.
+     *
+     * @return Map of the metacard security markings to the value of their corresponding system high
+     * attribute.
+     */
+    public Metacard addDefaults(Metacard metacard) {
+
+        Map policyMap = (Map) metacard.getAttribute(Metacard.SECURITY)
+                .getValue();
+        if  (policyMap != null && !policyMap.isEmpty()) {
+            return metacard;
+        }
+
+        final Metacard extendedMetacard;
+        MetacardImpl metacardImpl;
+        if (!securityAttributes.getAttributeDescriptors()
+                .stream()
+                .anyMatch(ad -> metacard.getMetacardType()
+                        .getAttributeDescriptors()
+                        .contains(ad))) {
+            metacardImpl = new MetacardImpl(metacard,
+                    new MetacardTypeImpl(metacard.getMetacardType()
+                            .getName(),
+                            metacard.getMetacardType(),
+                            securityAttributes.getAttributeDescriptors()));
+        } else {
+            metacardImpl = new MetacardImpl(metacard);
+        }
+        Set<String> updatedTags = new HashSet<>(metacard.getTags());
+        updatedTags.add(DEFAULTMARKINGS);
+        metacardImpl.setTags(updatedTags);
+        extendedMetacard = metacardImpl;
+
+        Map<String, Attribute> securityMarkings = getHighwaterSecurityMarkings();
+        securityMarkings.keySet()
+                .stream()
+                .filter(securityMarking -> extendedMetacard.getMetacardType()
+                        .getAttributeDescriptor(securityMarking) != null)
+                .forEach(securityMarking -> {
+                    extendedMetacard.setAttribute(securityMarkings.get(securityMarking));
+                });
+        return extendedMetacard;
+    }
+
+    public void setClassification(String classification) {
+        addMapping(classification, Security.CLASSIFICATION);
+    }
+
+    private void addMapping(String userAttribute, String metacardAttribute) {
+        Set<String> metacardAttributes =
+                SYS_HIGH_TO_METACARD_ATTRIBUTE_MAPPING.get(userAttribute) != null ?
+                        SYS_HIGH_TO_METACARD_ATTRIBUTE_MAPPING.get(userAttribute) :
+                        new HashSet<>();
+        metacardAttributes.add(metacardAttribute);
+        SYS_HIGH_TO_METACARD_ATTRIBUTE_MAPPING.put(userAttribute, metacardAttributes);
+    }
+
+    public void setReleasability(String releasability) {
+        addMapping(releasability, Security.RELEASABILITY);
+    }
+
+    public void setCodewords(String codewords) {
+        addMapping(codewords, Security.CODEWORDS);
+    }
+
+    public void setDisseminationControls(String disseminationControls) {
+        addMapping(disseminationControls, Security.DISSEMINATION_CONTROLS);
+    }
+
+    public void setOtherDisseminationControls(String otherDisseminationControls) {
+        addMapping(otherDisseminationControls, Security.OTHER_DISSEMINATION_CONTROLS);
+    }
+
+    public void setOwnerProducer(String ownerProducer) {
+        addMapping(ownerProducer, Security.OWNER_PRODUCER);
+    }
+
+    @Override
+    public CreateRequest process(CreateRequest createRequest)
+            throws PluginExecutionException, StopProcessingException {
+        List<Metacard> updatedMetacards = createRequest.getMetacards()
+                .stream()
+                .filter(Objects::nonNull)
+                .map(this::addDefaults)
+                .collect(Collectors.toList());
+        return new CreateRequestImpl(updatedMetacards,
+                createRequest.getProperties(),
+                createRequest.getStoreIds());
+    }
+
+    @Override
+    public UpdateRequest process(UpdateRequest updateRequest)
+            throws PluginExecutionException, StopProcessingException {
+        return updateRequest;
+    }
+
+    @Override
+    public DeleteRequest process(DeleteRequest input)
+            throws PluginExecutionException, StopProcessingException {
+        return input;
+    }
+}

--- a/catalog/plugin/catalog-plugin-defaultsecurityattributevalues/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/plugin/catalog-plugin-defaultsecurityattributevalues/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<blueprint xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+           xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+
+    <bean id="securityAttributes" class="org.codice.alliance.catalog.core.api.impl.types.SecurityAttributes"/>
+
+    <bean id="defaultMarkingsPlugin"
+          class="org.codice.alliance.catalog.plugin.defaultsecurity.DefaultSecurityAttributeValuesPlugin">
+        <cm:managed-properties persistent-id="org.codice.alliance.catalog.plugin.defaultsecurity.DefaultSecurityAttributeValuesPlugin"
+                               update-strategy="container-managed"/>
+        <argument ref="securityAttributes"/>
+        <property name="classification" value="Clearance"/>
+        <property name="releasability" value="CountryOfAffiliation"/>
+        <property name="codewords" value="FineAccessControls"/>
+        <property name="disseminationControls" value="disseminationControls"/>
+        <property name="otherDisseminationControls" value="otherDisseminationControls"/>
+        <property name="ownerProducer" value="ownerProducer" />
+    </bean>
+
+    <service ranking="99" ref="defaultMarkingsPlugin" interface="ddf.catalog.plugin.PreIngestPlugin"/>
+
+</blueprint>

--- a/catalog/plugin/catalog-plugin-defaultsecurityattributevalues/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/plugin/catalog-plugin-defaultsecurityattributevalues/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
+
+	<OCD  name="Default Security Attribute Values Plugin" id="org.codice.alliance.catalog.plugin.defaultsecurity.DefaultSecurityAttributeValuesPlugin" description="Mapping of System High-Water attributes to use in case metacards are ingested without any security marking.">
+		<AD name="Classification" id="classification"
+			required="true"
+			type="String"
+			default="Clearance"
+			description="Mappings of system attributes to Classification metacard marking.">
+		</AD>
+		<AD name="Codewords" id="codewords"
+			required="true"
+			type="String" 
+			default="FineAccessControls"
+			description="Mappings of system attributes to Codewords metacard marking.">
+		</AD>
+		<AD name="Releasabilty" id="releasability"
+			required="true"
+			type="String"
+			default="CountryOfAffiliation"
+			description="Mappings of system attributes to Releasabilty metacard marking.">
+		</AD>
+		<AD name="Dissemination Controls" id="disseminationControls"
+			required="true"
+			type="String" 
+			default="disseminationControls"
+			description="Mappings of system attributes to Dissemination Controls metacard marking.">
+		</AD>
+
+		<AD name="Other Dissemination Controls" id="otherdisseminationControls"
+			required="true"
+			type="String" 
+			default="otherdisseminationControls"
+			description="Mappings of system attributes to Other Dissemination Controls metacard marking.">
+		</AD>
+		<AD name="Owner Producer" id="ownerProducer"
+			required="true"
+			type="String" 
+			default="ownerProducer"
+			description="Mappings of system attributes to Owner Producer metacard marking.">
+		</AD>
+
+	</OCD>
+
+	<Designate pid="org.codice.alliance.catalog.plugin.defaultsecurity.DefaultSecurityAttributeValuesPlugin">
+	    <Object ocdref="org.codice.alliance.catalog.plugin.defaultsecurity.DefaultSecurityAttributeValuesPlugin" />
+  	</Designate>
+
+
+</metatype:MetaData>

--- a/catalog/plugin/catalog-plugin-defaultsecurityattributevalues/src/test/java/org/codice/alliance/catalog/plugin/defaultsecurity/DefaultSecurityAttributeValuesPluginTest.java
+++ b/catalog/plugin/catalog-plugin-defaultsecurityattributevalues/src/test/java/org/codice/alliance/catalog/plugin/defaultsecurity/DefaultSecurityAttributeValuesPluginTest.java
@@ -1,0 +1,226 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.catalog.plugin.defaultsecurity;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Set;
+
+import org.apache.shiro.subject.PrincipalCollection;
+import org.codice.alliance.catalog.core.api.impl.types.SecurityAttributes;
+import org.codice.alliance.catalog.core.api.types.Security;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.opensaml.core.xml.schema.XSString;
+import org.opensaml.saml.saml2.core.AttributeStatement;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+import com.google.common.collect.Maps;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.Result;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.operation.CreateRequest;
+import ddf.catalog.operation.UpdateRequest;
+import ddf.security.Subject;
+import ddf.security.assertion.SecurityAssertion;
+
+public class DefaultSecurityAttributeValuesPluginTest {
+
+    public static final String USER_ATTRIB_1 = "UserAttrib1";
+
+    public static final String USER_ATTRIB_2 = "UserAttrib2";
+
+    public static final String CLASSIFICATION_ATTRIB_VAL = "1";
+
+    public static final String CODEWORD_ATTRIB_VAL = "2";
+
+    private DefaultSecurityAttributeValuesPlugin defaultSecurityAttributeValuesPlugin;
+
+    @Mock
+    private Metacard unmarkedMetacard;
+
+    @Mock
+    private Metacard markedMetacard;
+
+    @Mock
+    private Result unmarkedResult;
+
+    @Mock
+    private Result markedResult;
+
+    @Mock
+    private Attribute emptySecurityAttributeList;
+
+    @Mock
+    private Attribute securityAttributeList;
+
+    @Mock
+    private HashMap<String, Object> mockedEmptyAttributeMap;
+
+    @Mock
+    private HashMap<String, Object> mockedFilledAttributeMap;
+
+    @Mock
+    private Subject mockedSubject;
+
+    @Mock
+    private ConfigurationAdmin configurationAdmin;
+
+    @Mock
+    private PrincipalCollection mockedPrincipalCollection;
+
+    @Mock
+    private SecurityAssertion mockedAssertion;
+
+    @Mock
+    private AttributeStatement mockedAttributeStatement1;
+
+    @Mock
+    private org.opensaml.saml.saml2.core.Attribute mockedAttribute1;
+
+    @Mock
+    private AttributeStatement mockedAttributeStatement2;
+
+    @Mock
+    private org.opensaml.saml.saml2.core.Attribute mockedAttribute2;
+
+    @Mock
+    private XSString mockedXss1;
+
+    @Mock
+    private XSString mockedXss2;
+
+    @Mock
+    private MetacardType metacardType;
+
+    @Mock
+    private AttributeDescriptor attributeDescriptor;
+
+    @Mock
+    private CreateRequest createRequest;
+
+    @Mock
+    private UpdateRequest updateRequest;
+
+    @Before
+    public void setup() {
+        initMocks(this);
+        defaultSecurityAttributeValuesPlugin = Mockito.spy(new DefaultSecurityAttributeValuesPlugin(
+                new SecurityAttributes()));
+        doReturn(mockedSubject).when(defaultSecurityAttributeValuesPlugin)
+                .getSystemSubject();
+        when(mockedSubject.getPrincipals()).thenReturn(mockedPrincipalCollection);
+        when(mockedPrincipalCollection.oneByType(anyObject())).thenReturn(mockedAssertion);
+        when(mockedAssertion.getAttributeStatements()).thenReturn(Arrays.asList(
+                mockedAttributeStatement1,
+                mockedAttributeStatement2));
+        when(mockedAttributeStatement1.getAttributes()).thenReturn(Arrays.asList(mockedAttribute1));
+        when(mockedAttributeStatement2.getAttributes()).thenReturn(Arrays.asList(mockedAttribute2));
+        when(mockedXss1.getValue()).thenReturn(CLASSIFICATION_ATTRIB_VAL);
+        when(mockedXss2.getValue()).thenReturn(CODEWORD_ATTRIB_VAL);
+        when(mockedAttribute1.getAttributeValues()).thenReturn(Arrays.asList(mockedXss1));
+        when(mockedAttribute2.getAttributeValues()).thenReturn(Arrays.asList(mockedXss2));
+        when(mockedAttribute1.getName()).thenReturn(USER_ATTRIB_1);
+        when(mockedAttribute2.getName()).thenReturn(USER_ATTRIB_2);
+        defaultSecurityAttributeValuesPlugin.setClassification(USER_ATTRIB_1);
+        defaultSecurityAttributeValuesPlugin.setCodewords(USER_ATTRIB_2);
+
+        when(markedMetacard.getAttribute(eq(Metacard.SECURITY))).thenReturn(securityAttributeList);
+        when(unmarkedMetacard.getAttribute(eq(Metacard.SECURITY))).thenReturn(securityAttributeList);
+        when(securityAttributeList.getValue()).thenReturn((Serializable) Collections.EMPTY_MAP);
+        when(unmarkedMetacard.getMetacardType()).thenReturn(metacardType);
+        when(metacardType.getAttributeDescriptor(any(String.class))).thenReturn(attributeDescriptor);
+        when(createRequest.getMetacards()).thenReturn(Collections.singletonList(unmarkedMetacard));
+        when(updateRequest.getUpdates()).thenReturn(Collections.singletonList(Maps.immutableEntry(
+                "key",
+                unmarkedMetacard)));
+        when(unmarkedMetacard.getMetacardType()).thenReturn(metacardType);
+        when(markedMetacard.getMetacardType()).thenReturn(metacardType);
+        when(emptySecurityAttributeList.getValue()).thenReturn(mockedEmptyAttributeMap);
+        when(mockedEmptyAttributeMap.isEmpty()).thenReturn(true);
+    }
+
+    @Test
+    public void testProcessUnmarkedMetacard() throws Exception {
+        Metacard modifiedMetacard = defaultSecurityAttributeValuesPlugin.addDefaults(
+                unmarkedMetacard);
+        assertThat(unmarkedMetacard, not(modifiedMetacard));
+        assertThat(CODEWORD_ATTRIB_VAL,
+                is(modifiedMetacard.getAttribute(Security.CODEWORDS)
+                        .getValue()));
+        assertThat(CLASSIFICATION_ATTRIB_VAL,
+                is(modifiedMetacard.getAttribute(Security.CLASSIFICATION)
+                        .getValue()));
+        assertThat(modifiedMetacard.getTags(),
+                contains(DefaultSecurityAttributeValuesPlugin.DEFAULTMARKINGS));
+    }
+
+    @Test
+    public void testProcessUnmarkedMetacardWtihSecurityAttributeDescriptors() throws Exception {
+        Set<AttributeDescriptor> attributeDescriptors = mock(Set.class);
+        when(metacardType.getAttributeDescriptors()).thenReturn(attributeDescriptors);
+        when(attributeDescriptors.contains(any(AttributeDescriptor.class))).thenReturn(true);
+
+        Metacard modifiedMetacard = defaultSecurityAttributeValuesPlugin.addDefaults(
+                unmarkedMetacard);
+        assertThat(unmarkedMetacard, not(modifiedMetacard));
+        verify(unmarkedMetacard, times(3)).setAttribute(any(Attribute.class));
+    }
+
+    @Test
+    public void testProcessMarkedMetacard() throws Exception {
+        when(securityAttributeList.getValue()).thenReturn((Serializable) Collections.singletonMap(
+                "blah",
+                "blah"));
+        Metacard modifiedMetacard =
+                defaultSecurityAttributeValuesPlugin.addDefaults(markedMetacard);
+        verify(markedMetacard, times(0)).setAttribute(any(AttributeImpl.class));
+        assertThat(markedMetacard, is(modifiedMetacard));
+    }
+
+    @Test
+    public void testProcessCreateRequest() throws Exception {
+        CreateRequest modifiedRequest = defaultSecurityAttributeValuesPlugin.process(createRequest);
+        assertThat(createRequest, not(modifiedRequest));
+    }
+
+    @Test
+    public void testProcessUpdateRequest() throws Exception {
+        UpdateRequest modifiedRequest = defaultSecurityAttributeValuesPlugin.process(updateRequest);
+        assertThat(updateRequest, is(modifiedRequest));
+    }
+
+}

--- a/catalog/plugin/pom.xml
+++ b/catalog/plugin/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <groupId>org.codice.alliance</groupId>
+        <artifactId>catalog</artifactId>
+        <version>0.2-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.codice.alliance.catalog.plugin</groupId>
+    <artifactId>plugin</artifactId>
+    <packaging>pom</packaging>
+    <name>Alliance :: Catalog :: Plugin</name>
+
+    <modules>
+        <module>catalog-plugin-defaultsecurityattributevalues</module>
+    </modules>
+
+</project>

--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -62,6 +62,7 @@
         <module>core</module>
         <module>nsili</module>
         <module>imaging</module>
+        <module>plugin</module>
         <module>video</module>
         <module>security</module>
     </modules>

--- a/catalog/security/security-app/pom.xml
+++ b/catalog/security/security-app/pom.xml
@@ -29,8 +29,18 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.codice.alliance.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.codice.alliance.security</groupId>
             <artifactId>banner-marking</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.alliance.catalog.plugin</groupId>
+            <artifactId>catalog-plugin-defaultsecurityattributevalues</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>
@@ -58,23 +68,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
-                <artifactId>karaf-maven-plugin</artifactId>
-                <version>${karaf.version}</version>
-                <executions>
-                    <execution>
-                        <id>kar</id>
-                        <goals>
-                            <goal>kar</goal>
-                        </goals>
-                        <configuration>
-                            <resourcesDir>${project.build.directory}/resources</resourcesDir>
-                            <featuresFile>${basedir}/target/classes/features.xml</featuresFile>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <!-- Puts the features XML file for this app into the maven repo. -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -95,6 +88,23 @@
                                     <classifier>features</classifier>
                                 </artifact>
                             </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.karaf.tooling</groupId>
+                <artifactId>karaf-maven-plugin</artifactId>
+                <version>${karaf.version}</version>
+                <executions>
+                    <execution>
+                        <id>kar</id>
+                        <goals>
+                            <goal>kar</goal>
+                        </goals>
+                        <configuration>
+                            <resourcesDir>${project.build.directory}/resources</resourcesDir>
+                            <featuresFile>${basedir}/target/classes/features.xml</featuresFile>
                         </configuration>
                     </execution>
                 </executions>

--- a/catalog/security/security-app/src/main/resources/features.xml
+++ b/catalog/security/security-app/src/main/resources/features.xml
@@ -16,14 +16,24 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
 
-    <feature name="banner-marking" install="manual" version="${project.version}"
+    <feature name="alliance-catalog-core-api" install="manual" version="${project.version" description="Alliance catalog extension APIs">
+        <bundle>mvn:org.codice.alliance.catalog.core/catalog-core-api/${project.version}</bundle>
+    </feature>
+
+    <feature name="banner-marking" install="auto" version="${project.version}"
              description="Alliance Banner Security Markings Extractor">
+        <feature prerequisite="true">security-app</feature>
         <bundle>mvn:org.codice.alliance.security/banner-marking/${project.version}</bundle>
+    </feature>
+
+    <feature name="security-defaultsecurityattributevalues" install="auto" version="${project.version}"
+             description="Plugin to mark unmarked metacards with the system high security markings.">
+        <feature prerequisite="true">alliance-catalog-core-api</feature>
+        <bundle>mvn:org.codice.alliance.catalog.plugin/catalog-plugin-defaultsecurityattributevalues/${project.version}</bundle>
     </feature>
 
     <feature name="security-app" install="auto" version="${project.version}"
              description="The Alliance Security App provides features to enhance security. ::Alliance Security">
         <feature prerequisite="true">catalog-app</feature>
-        <feature>banner-marking</feature>
     </feature>
 </features>

--- a/distribution/install-profiles/src/main/resources/features.xml
+++ b/distribution/install-profiles/src/main/resources/features.xml
@@ -31,6 +31,7 @@
         <!-- Alliance Apps -->
         <feature>nsili-app</feature>
         <feature>imaging-app</feature>
+        <feature>security-app</feature>
     </feature>
 
     <feature name="profile-alliance-experimental" install="manual" version="${project.version}"


### PR DESCRIPTION
#### What does this PR do?
 if no security attributes are present this plugin adds security attributes to metacards based on the system users attributes.
#### Who is reviewing it?
@bcwaters @coyotesqrl @tbatie @adimka @bdeining @jaymcnallie  @stustison 
#### How should this be tested
deploy a standard profile alliance build
#### Any background context you want to provide?
#### What are the relevant tickets?
DDF-2291
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

…ity defaults to metacards based on the system high-water mark