### PR TITLE
CAL-109: Docs fail to build using Oracle JDK on Linux

### DIFF
--- a/distribution/docs/pom.xml
+++ b/distribution/docs/pom.xml
@@ -56,7 +56,8 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <asciidoctor.maven.plugin.version>1.5.2</asciidoctor.maven.plugin.version>
+                <asciidoctor.maven.plugin.version>1.5.2.1</asciidoctor.maven.plugin.version>
+                <asciidoctorj.version>1.5.3.2</asciidoctorj.version>
                 <packaging>pom</packaging>
                 <module>docs</module>
                 <skipTests>false</skipTests>
@@ -230,6 +231,16 @@
                                 <groupId>org.asciidoctor</groupId>
                                 <artifactId>asciidoctorj-pdf</artifactId>
                                 <version>${asciidoctorj-pdf.version}</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.asciidoctor</groupId>
+                                <artifactId>asciidoctorj</artifactId>
+                                <version>${asciidoctorj.version}</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.jruby</groupId>
+                                <artifactId>jruby-complete</artifactId>
+                                <version>${jruby.version}</version>
                             </dependency>
                         </dependencies>
                         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -48,10 +48,10 @@
         <guava.version>18.0</guava.version>
         <slf4j.version>1.7.1</slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jruby.version>1.7.25</jruby.version>
+        <jruby.version>9.1.2.0</jruby.version>
         <asciidoctor-diagram.version>1.2.1</asciidoctor-diagram.version>
         <gem-maven-plugin.version>1.0.5</gem-maven-plugin.version>
-        <asciidoctorj-pdf.version>1.5.0-alpha.6</asciidoctorj-pdf.version>
+        <asciidoctorj-pdf.version>1.5.0-alpha.11</asciidoctorj-pdf.version>
         <asciidoctor.source.highlighter>coderay</asciidoctor.source.highlighter>
         <!-- output directory for reports -->
         <project.report.output.directory>project-info</project.report.output.directory>


### PR DESCRIPTION
#### What does this PR do?
Changes dependency version so docs can build on Oracle JDK on Linux
#### Who is reviewing it?
@ricklarsen @shaundmorris @coyotesqrl 
#### How should this be tested?
Docs build successfully 
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

