### PR TITLE
CAL-110: Unit test TestCatalogOutputAdapter#testGetBinaryContent fail…

### DIFF
--- a/catalog/imaging/imaging-transformer-chipping/src/test/java/org/codice/alliance/imaging/chip/transformer/TestCatalogOutputAdapter.java
+++ b/catalog/imaging/imaging-transformer-chipping/src/test/java/org/codice/alliance/imaging/chip/transformer/TestCatalogOutputAdapter.java
@@ -86,6 +86,7 @@ public class TestCatalogOutputAdapter {
     @Test
     public void testGetBinaryContent() throws IOException, MimeTypeParseException {
         BufferedImage suppliedImage = ImageIO.read(getInputStream(I_3001A));
+        suppliedImage = new BufferedImage(suppliedImage.getWidth(), suppliedImage.getHeight(), BufferedImage.TYPE_3BYTE_BGR);
         BinaryContent binaryContent = catalogOutputAdapter.getBinaryContent(suppliedImage);
         assertThat(binaryContent, is(notNullValue()));
         assertThat(binaryContent.getInputStream(), is(notNullValue()));


### PR DESCRIPTION
#### What does this PR do?
Adds support to TestCatalogOutputAdapter#testGetBinaryContent for OpenJDK
#### Who is reviewing it?
@coyotesqrl @shaundmorris
#### How should this be tested?
TestCatalogOutputAdapter passes
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

…s on OpenJDK