### PR TITLE
CAL-111: Add support for JPEG2000 images.

### DIFF
--- a/catalog/imaging/imaging-transformer-nitf/pom.xml
+++ b/catalog/imaging/imaging-transformer-nitf/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>net.coobird</groupId>
             <artifactId>thumbnailator</artifactId>
-            <version>0.4.8</version>
+            <version>${thumbnailator.version}</version>
         </dependency>
 
         <dependency>
@@ -84,6 +84,18 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core</artifactId>
             <version>${camel.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.jai-imageio</groupId>
+            <artifactId>jai-imageio-core</artifactId>
+            <version>${jai-imageio-core.version}</version>
+        </dependency>
+            
+        <dependency>
+            <groupId>com.github.jai-imageio</groupId>
+            <artifactId>jai-imageio-jpeg2000</artifactId>
+            <version>${jpeg2000.version}</version>
         </dependency>
     </dependencies>
 
@@ -102,9 +114,12 @@
                             platform-util,
                             codice-imaging-nitf-core,
                             codice-imaging-nitf-render,
-                            codice-imaging-nitf-fluent-api
+                            codice-imaging-nitf-fluent-api,
+                            jai-imageio-core,
+                            jai-imageio-jpeg2000
                         </Embed-Dependency>
                         <Export-Package/>
+                        <Import-Package>!sun.security.action,*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/gmti/NitfGmtiTransformer.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/gmti/NitfGmtiTransformer.java
@@ -65,7 +65,8 @@ public class NitfGmtiTransformer extends SegmentHandler {
             throw new IllegalArgumentException("argument 'metacard' may not be null.");
         }
 
-        nitfSegmentsFlow.fileHeader(header -> handleHeader(header, metacard));
+        nitfSegmentsFlow.fileHeader(header -> handleHeader(header, metacard))
+                .end();
 
         String locationString = setLocation(metacard);
 

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/ImageMetacardType.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/ImageMetacardType.java
@@ -18,8 +18,12 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javax.imageio.spi.IIORegistry;
+
 import org.codice.alliance.transformer.nitf.common.NitfAttribute;
 import org.codice.alliance.transformer.nitf.common.NitfHeaderAttribute;
+
+import com.github.jaiimageio.jpeg2000.impl.J2KImageReaderSpi;
 
 import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.impl.BasicTypes;
@@ -37,6 +41,8 @@ public class ImageMetacardType extends MetacardTypeImpl {
     public ImageMetacardType() {
         super(NITF, (Set<AttributeDescriptor>) null);
         getDescriptors();
+        IIORegistry.getDefaultInstance()
+                .registerServiceProvider(new J2KImageReaderSpi());
     }
 
     private void getDescriptors() {

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/NitfImageTransformer.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/NitfImageTransformer.java
@@ -77,7 +77,8 @@ public class NitfImageTransformer extends SegmentHandler {
                         SymbolAttribute.values()))
                 .forEachLabelSegment(segment -> handleSegmentHeader(metacard,
                         segment,
-                        LabelAttribute.values()));
+                        LabelAttribute.values()))
+                .end();
 
         // Set GEOGRAPHY from discovered polygons
         if (polygonList.size() == 1) {

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/NitfPreStoragePlugin.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/NitfPreStoragePlugin.java
@@ -128,7 +128,7 @@ public class NitfPreStoragePlugin implements PreCreateStoragePlugin, PreUpdateSt
 
                 return Optional.ofNullable(overviewContentItem);
             }
-        } catch (IOException | ParseException | NitfFormatException e) {
+        } catch (IOException | ParseException | NitfFormatException | UnsupportedOperationException e) {
             LOGGER.warn(e.getMessage(), e);
         }
 
@@ -153,7 +153,8 @@ public class NitfPreStoragePlugin implements PreCreateStoragePlugin, PreUpdateSt
                                 LOGGER.error(e.getMessage(), e);
                             }
                         }
-                    });
+                    })
+                    .end();
         }
 
         return bufferedImage.get();

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/TreTestUtility.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/TreTestUtility.java
@@ -221,8 +221,8 @@ public class TreTestUtility {
         when(imageSegment.getImageMode()).thenReturn(ImageMode.BANDSEQUENTIAL);
         when(imageSegment.getNumberOfBlocksPerRow()).thenReturn(4);
         when(imageSegment.getNumberOfBlocksPerColumn()).thenReturn(4);
-        when(imageSegment.getNumberOfPixelsPerBlockHorizontal()).thenReturn(512);
-        when(imageSegment.getNumberOfPixelsPerBlockVertical()).thenReturn(512);
+        when(imageSegment.getNumberOfPixelsPerBlockHorizontal()).thenReturn(512l);
+        when(imageSegment.getNumberOfPixelsPerBlockVertical()).thenReturn(512l);
         when(imageSegment.getImageDisplayLevel()).thenReturn(1);
         when(imageSegment.getAttachmentLevel()).thenReturn(2);
         when(imageSegment.getImageLocationRow()).thenReturn(0);

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/TestImageInputTransformer.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/TestImageInputTransformer.java
@@ -253,10 +253,10 @@ public class TestImageInputTransformer {
                 .getValue(), is(1));
         assertThat(metacard.getAttribute(
                 "nitf.image." + ImageAttribute.NUMBER_OF_PIXELS_PER_BLOCK_HORIZONTAL)
-                .getValue(), is(1024));
+                .getValue(), is(1024l));
         assertThat(metacard.getAttribute(
                 "nitf.image." + ImageAttribute.NUMBER_OF_PIXELS_PER_BLOCK_VERTICAL)
-                .getValue(), is(1024));
+                .getValue(), is(1024l));
         assertThat(metacard.getAttribute("nitf.image." + ImageAttribute.NUMBER_OF_BITS_PER_PIXEL)
                 .getValue(), is(8));
         assertThat(metacard.getAttribute("nitf.image." + ImageAttribute.IMAGE_DISPLAY_LEVEL)

--- a/catalog/imaging/pom.xml
+++ b/catalog/imaging/pom.xml
@@ -12,7 +12,9 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>catalog</artifactId>
@@ -26,8 +28,11 @@
     <name>Alliance :: Imaging</name>
 
     <properties>
-        <nitf-imaging.version>0.3</nitf-imaging.version>
+        <nitf-imaging.version>0.4</nitf-imaging.version>
         <camel.version>2.16.1</camel.version>
+        <jai-imageio-core.version>1.3.1</jai-imageio-core.version>
+        <jpeg2000.version>1.3.1_CODICE_1</jpeg2000.version>
+        <thumbnailator.version>0.4.8</thumbnailator.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
#### What does this PR do?
- adds support for JPEG2000 images using the Codice fork of the jai-imageio-jpeg2000 library. 
- fixes a bug where the transformer was leaving behind temporary files
- fixes a bug that caused the ingest to fail when the imaging-nitf library couldn't handle the image encoding.

#### Who is reviewing it?
@lcrosenbu 
@roelens8 
@kcwire 
@jlcsmith 

#### How should this be tested?
Starting with a clean DDF instance, install the alliance imaging app.  Ingest a JPEG2000 NITF file.  Verify that the thumbnail, overview and original images are generated.

#### Any background context you want to provide?

#### What are the relevant tickets?
CAL-111

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [x ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

