### PR TITLE
CAL-114: Fix for itests breaking with invalid geowebcache-app reference

### DIFF
--- a/distribution/alliance/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
+++ b/distribution/alliance/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
@@ -34,7 +34,6 @@ featuresRepositories= \
  mvn:org.codice.ddf.spatial/spatial-app/${ddf.version}/xml/features, \
  mvn:ddf.ui.search/search-ui-app/${ddf.version}/xml/features, \
  mvn:org.codice.ddf.spatial/geowebcache-app/${ddf.version}/xml/features, \
- mvn:org.codice.ddf/geowebcache-app/${ddf.version}/xml/features, \
  mvn:org.codice.ddf.resourcemanagement/resourcemanagement-app/${ddf.version}/xml/features, \
  mvn:ddf.admin/admin-app/${ddf.version}/xml/features
 


### PR DESCRIPTION
#### What does this PR do?
Fix for itests breaking with invalid geowebcache-app reference

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@bdeining 
@peterhuffer 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@pklinef

#### How should this be tested?
Run the full build for Alliance including itests.

#### Any background context you want to provide?

#### What are the relevant tickets?
https://codice.atlassian.net/browse/CAL-114

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

