### PR TITLE
CAL-112: Fix for standing queries not correctly handling start times …

### DIFF
--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/LibraryImpl.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/LibraryImpl.java
@@ -96,6 +96,8 @@ public class LibraryImpl extends LibraryPOA {
 
     private SecurityManager securityManager;
 
+    private long maxWaitToStartTimeMsecs;
+
     private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(LibraryImpl.class);
 
     public LibraryImpl(POA poa) {
@@ -143,6 +145,10 @@ public class LibraryImpl extends LibraryPOA {
 
     public void setOutgoingValidationEnabled(boolean outgoingValidationEnabled) {
         this.outgoingValidationEnabled = outgoingValidationEnabled;
+    }
+
+    public void setMaxWaitToStartTimeMsecs(long maxWaitToStartTimeMsecs) {
+        this.maxWaitToStartTimeMsecs = maxWaitToStartTimeMsecs;
     }
 
     @Override
@@ -250,6 +256,7 @@ public class LibraryImpl extends LibraryPOA {
             standingQueryMgr.setMaxPendingResults(maxPendingResults);
             standingQueryMgr.setRemoveSourceLibrary(removeSourceLibrary);
             standingQueryMgr.setOutgoingValidationEnabled(outgoingValidationEnabled);
+            standingQueryMgr.setMaxWaitToStartTimeMsecs(maxWaitToStartTimeMsecs);
             if (!CorbaUtils.isIdActive(poa,
                     managerId.getBytes(Charset.forName(NsiliEndpoint.ENCODING)))) {
                 try {

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/NsiliEndpoint.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/NsiliEndpoint.java
@@ -20,6 +20,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.codice.alliance.nsili.common.NsilCorbaExceptionUtil;
 import org.codice.alliance.nsili.orb.api.CorbaOrb;
@@ -74,6 +77,8 @@ public class NsiliEndpoint implements CorbaServiceListener, QuerySources {
     private FilterBuilder filterBuilder;
 
     private int defaultUpdateFrequencySec = 60;
+
+    private long maxWaitToStartTimeSec = TimeUnit.MINUTES.toSeconds(5);
 
     private int maxPendingResults = 10000;
 
@@ -168,7 +173,14 @@ public class NsiliEndpoint implements CorbaServiceListener, QuerySources {
     public void setDefaultUpdateFrequencySec(int defaultUpdateFrequencySec) {
         this.defaultUpdateFrequencySec = defaultUpdateFrequencySec;
         if (library != null) {
-            library.setDefaultUpdateFrequencyMsec(defaultUpdateFrequencySec * 1000);
+            library.setDefaultUpdateFrequencyMsec(TimeUnit.SECONDS.toMillis(defaultUpdateFrequencySec));
+        }
+    }
+
+    public void setMaxWaitToStartTimeMinutes(long maxWaitToStartTimeMinutes) {
+        this.maxWaitToStartTimeSec = TimeUnit.MINUTES.toSeconds(maxWaitToStartTimeMinutes);
+        if (library != null) {
+            library.setMaxWaitToStartTimeMsecs(TimeUnit.MINUTES.toMillis(maxWaitToStartTimeMinutes));
         }
     }
 
@@ -312,12 +324,13 @@ public class NsiliEndpoint implements CorbaServiceListener, QuerySources {
         library = new LibraryImpl(rootPOA);
         library.setCatalogFramework(framework);
         library.setFilterBuilder(filterBuilder);
-        library.setDefaultUpdateFrequencyMsec(defaultUpdateFrequencySec * 1000);
+        library.setDefaultUpdateFrequencyMsec(TimeUnit.SECONDS.toMillis(defaultUpdateFrequencySec));
         library.setMaxPendingResults(maxPendingResults);
         library.setQuerySources(querySources);
         library.setLibraryVersion(libraryVersion);
         library.setRemoveSourceLibrary(removeSourceLibrary);
         library.setOutgoingValidationEnabled(outgoingValidationEnabled);
+        library.setMaxWaitToStartTimeMsecs(TimeUnit.SECONDS.toMillis(maxWaitToStartTimeSec));
 
         libraryRef = rootPOA.servant_to_reference(library);
 

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/managers/StandingQueryMgrImpl.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/managers/StandingQueryMgrImpl.java
@@ -65,6 +65,8 @@ public class StandingQueryMgrImpl extends StandingQueryMgrPOA {
 
     private boolean outgoingValidationEnabled;
 
+    private long maxWaitToStartTimeMsecs;
+
     private long defaultTimeout = AccessManagerImpl.DEFAULT_TIMEOUT;
 
     public StandingQueryMgrImpl(Set<String> querySources) {
@@ -96,6 +98,10 @@ public class StandingQueryMgrImpl extends StandingQueryMgrPOA {
 
     public void setOutgoingValidationEnabled(boolean outgoingValidationEnabled) {
         this.outgoingValidationEnabled = outgoingValidationEnabled;
+    }
+
+    public void setMaxWaitToStartTimeMsecs(long maxWaitToStartTimeMsecs) {
+        this.maxWaitToStartTimeMsecs = maxWaitToStartTimeMsecs;
     }
 
     protected void init() {
@@ -142,7 +148,8 @@ public class StandingQueryMgrImpl extends StandingQueryMgrPOA {
                 querySources,
                 maxPendingResults,
                 removeSourceLibrary,
-                outgoingValidationEnabled);
+                outgoingValidationEnabled,
+                maxWaitToStartTimeMsecs);
 
         String id = UUID.randomUUID()
                 .toString();

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -39,6 +39,7 @@
         <property name="securityHandler" ref="securityHandler" />
         <property name="securityManager" ref="securityManager" />
         <property name="defaultUpdateFrequencySec" value="60" />
+        <property name="maxWaitToStartTimeMinutes" value="60" />
         <property name="maxPendingResults" value="10000" />
         <property name="outgoingValidationEnabled" value="false" />
         <property name="libraryVersion" value="NSILI|3.2" />

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -27,6 +27,11 @@
                 default="60"
         />
         <AD
+                description="Maximum time to wait before starting a standing query (minutes)"
+                name="Standing Query Max Wait To Start Time" id="maxWaitToStartTimeMinutes" required="true" type="Integer"
+                default="60"
+        />
+        <AD
                 description="Maximum Number of results to cache for each client."
                 name="Maximum Number Pending Results" id="maxPendingResults" required="true" type="Integer"
                 default="10000"

--- a/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/NsiliEndpointTest.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/NsiliEndpointTest.java
@@ -261,6 +261,7 @@ public class NsiliEndpointTest extends NsiliCommonTest {
         nsiliEndpoint.setCorbaOrb(mockCorbaOrb);
         nsiliEndpoint.setSecurityManager(securityManager);
         nsiliEndpoint.setDefaultUpdateFrequencySec(1);
+        nsiliEndpoint.setMaxWaitToStartTimeMinutes(1);
         nsiliEndpoint.setOutgoingValidationEnabled(true);
         nsiliEndpoint.setRemoveSourceLibrary(true);
         nsiliEndpoint.setLibraryVersion("NSILI|3.2");

--- a/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/StandingQueryMgrImplTest.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/StandingQueryMgrImplTest.java
@@ -25,6 +25,7 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import org.codice.alliance.nsili.common.CorbaUtils;
 import org.codice.alliance.nsili.common.GIAS.Event;
@@ -108,6 +109,7 @@ public class StandingQueryMgrImplTest extends NsiliCommonTest {
         standingQueryMgr.setFilterBuilder(new GeotoolsFilterBuilder());
         standingQueryMgr.setCatalogFramework(mockCatalogFramework);
         standingQueryMgr.setDefaultUpdateFrequencyMsec(60000);
+        standingQueryMgr.setMaxWaitToStartTimeMsecs(TimeUnit.MINUTES.toMillis(5));
         standingQueryMgr.setMaxPendingResults(10000);
 
         if (!CorbaUtils.isIdActive(rootPOA,

--- a/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/SubmitStandingQueryRequestImplTest.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/SubmitStandingQueryRequestImplTest.java
@@ -26,6 +26,8 @@ import java.nio.charset.Charset;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.codice.alliance.nsili.common.BqsConverter;
 import org.codice.alliance.nsili.common.CB.Callback;
@@ -380,6 +382,7 @@ public class SubmitStandingQueryRequestImplTest extends NsiliCommonTest {
         //Set artificially low for for test cases.
         long defaultUpdateFrequencyMsec = 2000;
         int maxPendingResults = 10000;
+        long maxWaitToStartTimeMsecs = TimeUnit.MINUTES.toMillis(5);
         standingQueryRequest = new SubmitStandingQueryRequestImpl(query,
                 resultAttributes,
                 sortAttributes,
@@ -391,7 +394,8 @@ public class SubmitStandingQueryRequestImplTest extends NsiliCommonTest {
                 null,
                 maxPendingResults,
                 true,
-                false);
+                false,
+                maxWaitToStartTimeMsecs);
         standingQueryRequest.register_callback(mockCallback2);
 
         String managerId = UUID.randomUUID().toString();

--- a/distribution/docs/src/main/resources/_contents/_nsili/managing-nsili-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_nsili/managing-nsili-contents.adoc
@@ -9,7 +9,9 @@ The following apps must be installed with/before ${alliance-nsili}:
 
 === Installing ${alliance-nsili}
 
-The *${alliance-nsili}* app is installed by default with standard installation.
+The *${alliance-nsili}* app is not installed by default, and requires manual installation. This application
+uses unencrypted connections for the STANAG-4559 endpoint, which affects the security of the system.
+This should only be enabled if required.
 
 === Configuring ${alliance-nsili}
 

--- a/distribution/install-profiles/src/main/resources/features.xml
+++ b/distribution/install-profiles/src/main/resources/features.xml
@@ -29,7 +29,6 @@
         <feature>solr-app</feature>
 
         <!-- Alliance Apps -->
-        <feature>nsili-app</feature>
         <feature>imaging-app</feature>
         <feature>security-app</feature>
         <feature>alliance-app</feature>
@@ -48,7 +47,6 @@
         <feature>solr-app</feature>
 
         <!-- Alliance Apps -->
-        <feature>nsili-app</feature>
         <feature>imaging-app</feature>
         <feature>security-app</feature>
         <feature>video-app</feature>


### PR DESCRIPTION
#### What does this PR do?
Fix for standing queries not correctly handling start times in the future.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@bdeining 
@harrison-tarr 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@beyelerb
@jlcsmith

#### How should this be tested?
Full test requires testing with a NSILI source, and to configure their synchronization to start in the future.

#### Any background context you want to provide?

#### What are the relevant tickets?
https://codice.atlassian.net/browse/CAL-112

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests