### PR TITLE
CAL-93: Updated Alliance Taxonomy to include isr.tdl-platform

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/org/codice/alliance/catalog/core/api/impl/types/IsrAttributes.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/org/codice/alliance/catalog/core/api/impl/types/IsrAttributes.java
@@ -326,6 +326,12 @@ public class IsrAttributes implements Isr, MetacardType {
                 true /* tokenized */,
                 false /* multivalued */,
                 BasicTypes.STRING_TYPE));
+        DESCRIPTORS.add(new AttributeDescriptorImpl(TACTICAL_DATA_LINK_PLATFORM,
+                true /* indexed */,
+                true /* stored */,
+                false /* tokenized */,
+                false /* multivalued */,
+                BasicTypes.SHORT_TYPE));
         DESCRIPTORS.add(new AttributeDescriptorImpl(VIDEO_MOTION_IMAGERY_SYSTEMS_MATRIX_LEVEL,
                 true /* indexed */,
                 true /* stored */,

--- a/catalog/core/catalog-core-api/src/main/java/org/codice/alliance/catalog/core/api/types/Isr.java
+++ b/catalog/core/catalog-core-api/src/main/java/org/codice/alliance/catalog/core/api/types/Isr.java
@@ -249,6 +249,11 @@ public interface Isr {
     String CHEMICAL_BIOLOGICAL_RADIOLOGICAL_NUCLEAR_SUBSTANCE = "isr.cbrn-substance";
 
     /**
+     * Attribute name for accessing the TDL platform number for this Metacard. <br/>
+     */
+    String TACTICAL_DATA_LINK_PLATFORM = "isr.tdl-platform-number";
+
+    /**
      * Attribute name for accessing the TDL activity number for this Metacard. <br/>
      */
     String TACTICAL_DATA_LINK_ACTIVITY = "isr.tdl-activity";


### PR DESCRIPTION
#### What does this PR do?
Adds the tdl-platform attribute to the normalized taxonomy.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@bdeining 
@brendan-hofmann 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire 

#### How should this be tested?

#### Any background context you want to provide?
Isr.platform-id is a string being used by other transformers for tail numbers, etc. This attribute is intended to map the platform ID from the data link.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/CAL-93

#### Screenshots (if appropriate)

#### Checklist:
- [X] Documentation Updated (taxonomy wiki page)
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

