### PR TITLE
CAL-117 Refactored the NSILI endpoint default port to be configurable in system.properties

### DIFF
--- a/catalog/nsili/catalog-nsili-orb-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/nsili/catalog-nsili-orb-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -22,7 +22,7 @@
           destroy-method="shutdown">
         <cm:managed-properties persistent-id="org.codice.alliance.nsili.orb.impl.corbaorb" update-strategy="component-managed"
                                update-method="refresh"/>
-        <property name="corbaPort" value="2809"/>
+        <property name="corbaPort" value="${org.codice.alliance.corba_default_port}"/>
         <property name="corbaTimeout" value="60"/>
     </bean>
 

--- a/catalog/nsili/catalog-nsili-orb-impl/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/nsili/catalog-nsili-orb-impl/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -18,8 +18,8 @@
          description="NSILI Corba ORB Configuration">
 
         <AD description="Corba Listen Port."
-            name="Corba Listen Port" id="corbaPort" required="true" type="Integer"
-            default="2809"/>
+            name="Corba Listen Port" id="corbaPort" required="true" type="String"
+            default="${org.codice.alliance.corba_default_port}"/>
 
         <AD description="The timeout (seconds) associated with CORBA reads."
             name="CORBA Timeout" id="corbaTimeout"

--- a/catalog/nsili/catalog-nsili-orb-impl/src/test/java/org/codice/alliance/nsili/orb/impl/TestCorbaOrbImpl.java
+++ b/catalog/nsili/catalog-nsili-orb-impl/src/test/java/org/codice/alliance/nsili/orb/impl/TestCorbaOrbImpl.java
@@ -52,7 +52,7 @@ public class TestCorbaOrbImpl {
         assertThat(port, is(20000));
 
         Map<String, Object> props = new HashMap<>();
-        props.put(CorbaOrbImpl.CORBA_PORT, 20001);
+        props.put(CorbaOrbImpl.CORBA_PORT, "20001");
         props.put(CorbaOrbImpl.CORBA_TIMEOUT, 61);
         corbaOrb.refresh(props);
         orb = corbaOrb.getOrb();

--- a/distribution/alliance/pom.xml
+++ b/distribution/alliance/pom.xml
@@ -351,6 +351,23 @@
                 </configuration>
             </plugin>
             <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <concat destfile="${project.basedir}/target/dependencies/ddf-kernel-${ddf.version}/etc/system.properties" append="true">&#10;# Set the default port number for the catalog-ftp feature FTP endpoint&#10;org.codice.alliance.corba_default_port=2809</concat>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>

--- a/distribution/docs/src/main/resources/_contents/_tables/org.codice.alliance.nsili.orb.impl.corbaorb-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_tables/org.codice.alliance.nsili.orb.impl.corbaorb-table-contents.adoc
@@ -13,7 +13,7 @@
 |corbaPort
 |Integer
 |Corba Listen Port.
-|2809
+|${org.codice.alliance.corba_default_port}
 |true
 
 | CORBA Timeout


### PR DESCRIPTION
#### What does this PR do?
This PR refactors the default port for the NSILI endpoint so that it is configurable in system.properties. The NSILI endpoint default port in TestNsili itest is now set to a DynamicPort.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@lcrosenbu @mweser @peterhuffer @glenhein @troymohl 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@stustison 
@kcwire 
#### How should this be tested?
1. Ensure that the TestCorbaOrbImpl and TestNsili tests pass.
2. Confirm that the NSILI endpoint port number is configurable in system.properties:
   1. Build Alliance.
   2. Change ` org.codice.alliance.corba_default_port ` in $ALLIANCE_HOME/etc/system.properties file to a new port.
   3. Start DDF.
   4. Confirm that the default port number for the NSILI endpoint is now the new port that you set in the system.properties file, indicated by the debug log entry "Successfully initialized CORBA orb on port: [port number]".
   5. Confirm that "${org.codice.alliance.corba_default_port}" appears in the modal to configure the NSILI endpoint on the Admin UI. You should be able to `Save changes` with "${org.codice.alliance.corba_default_port}" as the port number.
   6. Confirm that the NSILI endpoint port number is still configurable from the Admin UI.

#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/CAL-117
#### Screenshots (if appropriate)
#### Checklist:
- [x] Documentation Updated
- [x] Update / Add Unit Tests
- [x] Update / Add Integration Tests
