### PR TITLE
CAL-104 fix embedded dependency not always being embedded

### DIFF
--- a/catalog/plugin/catalog-plugin-defaultsecurityattributevalues/pom.xml
+++ b/catalog/plugin/catalog-plugin-defaultsecurityattributevalues/pom.xml
@@ -85,8 +85,8 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Embed-Dependency>
-                            catalog-core-api-impl;groupId=org.codice.alliance.catalog.core;version=${project.version},
-                            catalog-core-api-impl;groupId=ddf.catalog.core;version=${ddf.version},
+                            catalog-core-api-impl;groupId=org.codice.alliance.catalog.core,
+                            catalog-core-api-impl;groupId=ddf.catalog.core,
                             platform-util,
                             commons-lang3
                         </Embed-Dependency>


### PR DESCRIPTION
#### What does this PR do?
fix an issue with catalog-core-api-impl not getting embedded when a snapshot was downloaded from nexus
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@adimka @tbatie 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@jlcsmith

#### How should this be tested?
build alliance with a new .m2  mvn clean install -Dmaven.repo.local=/tmp/.m2 then jar -tvf catalog-plugin-defaultsecurityattributevalues.jar and verify two catalog-core-api-impl jars are embedded
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

