### PR TITLE
CAL-121 Create a Point instead of a LineString when there is only one…

### DIFF
--- a/libs/klv/pom.xml
+++ b/libs/klv/pom.xml
@@ -165,7 +165,7 @@
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.60</minimum>
+                                            <minimum>0.65</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>

--- a/libs/klv/src/main/java/org/codice/alliance/libs/klv/FrameCenterKlvProcessor.java
+++ b/libs/klv/src/main/java/org/codice/alliance/libs/klv/FrameCenterKlvProcessor.java
@@ -25,7 +25,6 @@ import org.codice.alliance.libs.stanag4609.Stanag4609TransportStreamParser;
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.LineString;
 import com.vividsolutions.jts.io.WKTReader;
 import com.vividsolutions.jts.io.WKTWriter;
 
@@ -71,9 +70,9 @@ public class FrameCenterKlvProcessor extends MultipleFieldKlvProcessor {
 
         Coordinate[] coordinates = listToArray(convertWktToCoordinates(points));
 
-        LineString lineString = convertCoordinatesToLineString(coordinates);
+        Geometry geometry = convertCoordinatesToGeometry(coordinates);
 
-        String wkt = convertLineStringToWkt(geometryOperator.apply(lineString));
+        String wkt = convertGeometryToWkt(geometryOperator.apply(geometry));
 
         setAttribute(metacard, wkt);
     }
@@ -86,13 +85,17 @@ public class FrameCenterKlvProcessor extends MultipleFieldKlvProcessor {
         return coordinateList.toArray(new Coordinate[coordinateList.size()]);
     }
 
-    private String convertLineStringToWkt(Geometry lineString) {
+    private String convertGeometryToWkt(Geometry geometry) {
         WKTWriter wktWriter = new WKTWriter();
-        return wktWriter.write(lineString);
+        return wktWriter.write(geometry);
     }
 
-    private LineString convertCoordinatesToLineString(Coordinate[] coordinates) {
-        return new GeometryFactory().createLineString(coordinates);
+    private Geometry convertCoordinatesToGeometry(Coordinate[] coordinates) {
+        if (coordinates.length == 1) {
+            return new GeometryFactory().createPoint(coordinates[0]);
+        } else {
+            return new GeometryFactory().createLineString(coordinates);
+        }
     }
 
     private List<Coordinate> convertWktToCoordinates(List<String> points) {


### PR DESCRIPTION
#### What does this PR do?
Updates `FrameCenterKlvProcessor` so it will create a `Point` geometry if it has only one frame center coordinate pair. Currently, it creates a `LineString` regardless of how many coordinates pairs it has. The number of coordinate pairs in a `LineString` must be 0 or >= 2.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@glenhein 
@bdeining 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire

#### How should this be tested?
Ingest [this file](https://github.com/codice/alliance/blob/master/libs/stanag4609/src/test/resources/dayflight.mpg) using the MPEG TS Input Transformer. It only has one KLV packet and thus only one frame center coordinate. Verify that the created metacard has a frame center of the form `POINT (A B)`.

#### What are the relevant tickets?
[CAL-121](https://codice.atlassian.net/browse/CAL-121)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests