### PR TITLE
CAL-42 Fix the admin stream monitor rollover tooltips

### DIFF
--- a/catalog/video/video-admin-plugin/src/main/webapp/js/view/StreamMonitor.view.js
+++ b/catalog/video/video-admin-plugin/src/main/webapp/js/view/StreamMonitor.view.js
@@ -108,8 +108,8 @@ define([
             onRender: function() {
                 this.setupPopOver('[data-toggle="feed-name-popover"]', 'Title of the parent metacard.');
                 this.setupPopOver('[data-toggle="url-popover"]', 'Specifies the network address (e.g. udp://localhost:50000) to be monitored. The address must be resolvable.');
-                this.setupPopOver('[data-toggle="max-dur-popover"]', 'Maximum file size (MB) before rollover. Must be >=1.');
-                this.setupPopOver('[data-toggle="max-size-popover"]', 'Maximum elapsed time in minutes before rollover. Must be >=1.');
+                this.setupPopOver('[data-toggle="max-dur-popover"]', 'Maximum elapsed time in minutes before rollover. Must be >=1.');
+                this.setupPopOver('[data-toggle="max-size-popover"]', 'Maximum file size (MB) before rollover. Must be >=1.');
                 this.setupPopOver('[data-toggle="file-templ-popover"]', 'Filename template for each chunk. The template may contain any number of the sequence "%{date=FORMAT}" where FORMAT is a Java SimpleDateFormat. Must be non-blank.');
                 this.setupPopOver('[data-toggle="delay-popover"]', 'Delay updates when creating metacards to avoid retries. Slower systems require a longer delay. The minimum value is 0 seconds and the maximum value is 60 seconds. (seconds)');
                 this.setupPopOver('[data-toggle="distance-tolerance-popover"]', 'Distance tolerance used to simplify geospatial metadata during video stream processing. The tolerance must be non-negative and the units are degrees.');

--- a/catalog/video/video-mpegts-transformer/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/video/video-mpegts-transformer/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -18,7 +18,7 @@
          name="MPEG-TS Input Transformer"
          id="org.codice.alliance.transformer.video.MpegTsInputTransformer">
 
-        <AD description="Location polygon subsample count used to reduce the number the total number of polygons."
+        <AD description="Location polygon subsample count used to reduce the total number of polygons."
             name="Subsample Count" id="subsampleCount" required="true" type="Integer"
             default="50"/>
 


### PR DESCRIPTION
#### What does this PR do?
Corrects the tooltips for the maximum clip duration and maximum clip size fields in the admin stream monitor UI.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@glenhein 
@bdeining 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire

#### How should this be tested?
Install the video app, configure a new stream monitor, and verify that the tooltips for the maximum clip duration and maximum clip size are correct.

#### What are the relevant tickets?
[CAL-42](https://codice.atlassian.net/browse/CAL-42)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

