### PR TITLE
CAL-129: Added javadoc and source jars to release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,16 +8,24 @@
 *.DS_Store
 node_modules/
 node/
-target/
 bin/
 atlassian-ide-plugin.xml
 *.sonar-ide.properties
 **/webapp/css/styles.css
 platform/solr/**/overlays
-dependency-reduced-pom.xml
 
 # JMeter Related files to ignore
 jmeter.log
 *.jmx.log
 *.jtl
 
+# Maven Ignores (https://raw.githubusercontent.com/github/gitignore/master/Maven.gitignore)
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties

--- a/pom.xml
+++ b/pom.xml
@@ -203,8 +203,9 @@
                     <version>${maven.release.plugin.version}</version>
                     <configuration>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
-                        <preparationGoals>clean verify install</preparationGoals>
+                        <preparationGoals>clean install</preparationGoals>
                         <pushChanges>false</pushChanges>
+                        <arguments>-Prelease ${arguments}</arguments>
                     </configuration>
                 </plugin>
 
@@ -417,6 +418,41 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <repositories>
         <repository>


### PR DESCRIPTION
#### What does this PR do?

* Adds javadocs to release profile
* Adds sources to the release profile
* Ensures release profile is triggered during release
* Adds additional gitignores for maven

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@codice/continuous-integration 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@pklinef
@shaundmorris

#### How should this be tested?

* Run `mvn release:prepare -Dmaven.repo.local=/tmp/m2` this should create javadoc and source jars for all artifacts

#### Any background context you want to provide?

Previously javadoc and source jars were not created automatically during a release

#### What are the relevant tickets?

[CAL-129](https://codice.atlassian.net/browse/CAL-129)

#### Checklist:
- [ ] Documentation Updated
