### PR TITLE
CAL-137 Add email support to NSILI OrderMgr interface

### DIFF
--- a/catalog/nsili/catalog-nsili-endpoint/pom.xml
+++ b/catalog/nsili/catalog-nsili-endpoint/pom.xml
@@ -169,6 +169,11 @@
             <artifactId>versioning-common</artifactId>
             <version>${ddf.version}</version>
         </dependency>
+        <dependency>
+            <groupId>javax.mail</groupId>
+            <artifactId>mail</artifactId>
+            <version>1.5.0-b01</version>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/EmailSender.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/EmailSender.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.alliance.nsili.endpoint;
+
+import java.io.InputStream;
+
+/**
+ * Interface for handling emailSending events with attachments
+ * -Takes mailHost as input argument for constructor, then calls to the sendMail method
+ * require a fromEmail address, a subject field, an emailBody of text, a filename for an attachment,
+ * and an inputstream for an attachment
+ */
+public interface EmailSender {
+
+    void sendEmail(String fromEmail, String emailDest, String subject, String emailBody,
+            String filename, InputStream attachment);
+
+    String toString();
+
+    String getFromEmail();
+
+    void setFromEmail(String fromEmail);
+
+    String getMailHost();
+
+    void setMailHost(String mailHost);
+
+    void setAttachment();
+}

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/EmailSenderImpl.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/EmailSenderImpl.java
@@ -1,0 +1,194 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.alliance.nsili.endpoint;
+
+import static org.apache.commons.lang3.Validate.notNull;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Properties;
+
+import javax.activation.DataHandler;
+import javax.activation.DataSource;
+import javax.activation.FileDataSource;
+import javax.mail.BodyPart;
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.Multipart;
+import javax.mail.Session;
+import javax.mail.Transport;
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeBodyPart;
+import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
+
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class EmailSenderImpl implements EmailSender {
+
+    private static final String SMTP_HOST_PROPERTY = "mail.smtp.host";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EmailSenderImpl.class);
+
+    private String fromEmail;
+
+    private String mailHost;
+
+    private String subject;
+
+    private String emailBody;
+
+    private String filename;
+
+    private int maxAttachmentSize;
+
+    /**
+     * EmailSenderImpl formats emails and sends them to the desired address using the fromEmail
+     * and through the desired mailHost.
+     *
+     * @param mailHost: non-null origin SMTP mailHost to send through
+     */
+    public EmailSenderImpl(String mailHost) {
+        notNull(mailHost, "mailHost must be non-null");
+
+        this.mailHost = mailHost;
+    }
+
+    /**
+     * sendEmail method sends email after receiving input parameters
+     *
+     * @param fromEmail: non-null origin address
+     * @param subject:   non-null subject line of email to be sent
+     * @param emailBody: non-null body of email to be sent
+     */
+    @Override
+    public void sendEmail(String fromEmail, String emailDest, String subject, String emailBody,
+            String filename, InputStream attachment) {
+        notNull(fromEmail, "fromEmail must be non-null");
+        notNull(subject, "subject must be non-null");
+        notNull(emailBody, "emailBody must be non-null");
+        notNull(filename, "filename must be non-null");
+
+        this.fromEmail = fromEmail;
+        this.subject = subject;
+        this.emailBody = emailBody;
+        this.filename = filename;
+
+        try {
+            InternetAddress emailAddr = new InternetAddress(emailDest);
+            emailAddr.validate();
+
+            Properties properties = createSessionProperies();
+            properties.put("mail.smtp.auth", "true");
+            properties.put("mail.smtp.starttls.enable", "true");
+            properties.put("mail.smtp.host", mailHost);
+            properties.put("mail.smtp.port", "25");
+
+            Session session = Session.getDefaultInstance(properties);
+
+            /* Set up message text fields */
+            MimeMessage mimeMessage = new MimeMessage(session);
+            mimeMessage.setFrom(new InternetAddress(fromEmail));
+            mimeMessage.addRecipient(Message.RecipientType.TO, emailAddr);
+            mimeMessage.setSubject(subject);
+
+            /* Create BodyPart contain message components inside larger multiPartEmail structure */
+            BodyPart messageBodyPart = new MimeBodyPart();
+            messageBodyPart.setText(emailBody);
+
+            /* Create multipart email to compile body parts together */
+            Multipart multipart = new MimeMultipart();
+            multipart.addBodyPart(messageBodyPart);
+
+            /* Create attachment */
+            messageBodyPart = new MimeBodyPart();
+            DataSource source = new FileDataSource(getFileFromInputStream(attachment));
+            messageBodyPart.setDataHandler(new DataHandler(source));
+            messageBodyPart.setFileName(filename);
+            multipart.addBodyPart(messageBodyPart);
+
+            multipart.addBodyPart(messageBodyPart);
+            
+            /* Package parts into mimeMessage and send */
+            mimeMessage.setContent(multipart);
+            Transport.send(mimeMessage);
+
+            LOGGER.debug("Email sent to " + emailDest);
+
+        } catch (AddressException e) {
+            LOGGER.debug("Invalid email address entered", e);
+        } catch (MessagingException e) {
+            LOGGER.debug("Message error occured on send", e);
+        }
+    }
+
+    private File getFileFromInputStream(InputStream inputStream) {
+        File file = new File("/tmp/newfile");
+        OutputStream outputStream;
+
+        try {
+            outputStream = new FileOutputStream(file);
+            IOUtils.copy(inputStream, outputStream);
+            outputStream.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return file;
+    }
+
+    private Properties createSessionProperies() {
+        Properties properties = System.getProperties();
+        properties.setProperty(SMTP_HOST_PROPERTY, mailHost);
+        return properties;
+    }
+
+    @Override
+    public String toString() {
+        return "EmailSenderImpl{" + "fromEmail=" + fromEmail + ", mailHost=" + mailHost + '}';
+    }
+
+    @Override
+    public String getFromEmail() {
+        notNull(fromEmail, "fromEmail must be non-null");
+        return fromEmail;
+    }
+
+    @Override
+    public void setFromEmail(String fromEmail) {
+        this.fromEmail = fromEmail;
+    }
+
+    @Override
+    public String getMailHost() {
+        notNull(mailHost, "mailHost must be non-null");
+        return mailHost;
+    }
+
+    @Override
+    public void setMailHost(String mailHost) {
+        this.mailHost = mailHost;
+    }
+
+    @Override
+    public void setAttachment() {
+
+    }
+}

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/LibraryImpl.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/LibraryImpl.java
@@ -13,6 +13,8 @@
  */
 package org.codice.alliance.nsili.endpoint;
 
+import static org.apache.commons.lang3.Validate.notNull;
+
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -77,6 +79,8 @@ public class LibraryImpl extends LibraryPOA {
     private POA poa;
 
     private CatalogFramework catalogFramework;
+
+    private EmailSenderImpl emailSender;
 
     private FilterBuilder filterBuilder;
 
@@ -145,6 +149,16 @@ public class LibraryImpl extends LibraryPOA {
         this.outgoingValidationEnabled = outgoingValidationEnabled;
     }
 
+    /**
+     * Sets emailSender field with emailSender object
+     *
+     * @param emailSender: must be non-null
+     */
+    public void setEmailSender(EmailSenderImpl emailSender) {
+        notNull(emailSender, "emailSender must be non-null");
+        this.emailSender = emailSender;
+    }
+
     @Override
     public String[] get_manager_types() throws ProcessingFault, SystemFault {
         LOGGER.trace("get_manager_types() called");
@@ -181,6 +195,8 @@ public class LibraryImpl extends LibraryPOA {
             OrderMgrImpl orderMgr = new OrderMgrImpl();
             orderMgr.setCatalogFramework(catalogFramework);
             orderMgr.setFilterBuilder(filterBuilder);
+            orderMgr.setEmailSender(emailSender);
+
             if (!CorbaUtils.isIdActive(poa,
                     managerId.getBytes(Charset.forName(NsiliEndpoint.ENCODING)))) {
                 try {

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/NsiliEndpoint.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/NsiliEndpoint.java
@@ -13,6 +13,8 @@
  */
 package org.codice.alliance.nsili.endpoint;
 
+import static org.apache.commons.lang3.Validate.notNull;
+
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -62,6 +64,8 @@ public class NsiliEndpoint implements CorbaServiceListener, QuerySources {
     private LibraryImpl library = null;
 
     private BundleContext context;
+
+    private EmailSenderImpl emailSender;
 
     private CatalogFramework framework;
 
@@ -247,6 +251,20 @@ public class NsiliEndpoint implements CorbaServiceListener, QuerySources {
         }
     }
 
+    /**
+     * Method sets emailSender field of library
+     *
+     * @param emailSender: Cannot be null
+     */
+    public void setEmailSender(EmailSenderImpl emailSender) {
+        notNull(emailSender, "emailSender must be non-null");
+
+        this.emailSender = emailSender;
+        if (library != null) {
+            library.setEmailSender(emailSender);
+        }
+    }
+
     public void destroy() {
         LOGGER.debug("Destroying NSILI Endpoint");
         if (corbaOrb != null) {
@@ -318,6 +336,7 @@ public class NsiliEndpoint implements CorbaServiceListener, QuerySources {
         library.setLibraryVersion(libraryVersion);
         library.setRemoveSourceLibrary(removeSourceLibrary);
         library.setOutgoingValidationEnabled(outgoingValidationEnabled);
+        library.setEmailSender(emailSender);
 
         libraryRef = rootPOA.servant_to_reference(library);
 

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/managers/OrderMgrImpl.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/managers/OrderMgrImpl.java
@@ -13,6 +13,8 @@
  */
 package org.codice.alliance.nsili.endpoint.managers;
 
+import static org.apache.commons.lang3.Validate.notNull;
+
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -39,6 +41,7 @@ import org.codice.alliance.nsili.common.UCO.NameValue;
 import org.codice.alliance.nsili.common.UCO.ProcessingFault;
 import org.codice.alliance.nsili.common.UCO.SystemFault;
 import org.codice.alliance.nsili.common.UID.Product;
+import org.codice.alliance.nsili.endpoint.EmailSenderImpl;
 import org.codice.alliance.nsili.endpoint.NsiliEndpoint;
 import org.codice.alliance.nsili.endpoint.requests.OrderRequestImpl;
 import org.codice.alliance.nsili.transformer.DAGConverter;
@@ -62,6 +65,8 @@ public class OrderMgrImpl extends OrderMgrPOA {
 
     private Set<String> querySources = new HashSet<>();
 
+    private EmailSenderImpl emailSender;
+
     public void setCatalogFramework(CatalogFramework catalogFramework) {
         this.catalogFramework = catalogFramework;
     }
@@ -75,6 +80,16 @@ public class OrderMgrImpl extends OrderMgrPOA {
         if (querySources != null) {
             this.querySources.addAll(querySources);
         }
+    }
+
+    /**
+     * Method sets emailSender field of library
+     *
+     * @param emailSender: Cannot be null
+     */
+    public void setEmailSender(EmailSenderImpl emailSender) {
+        notNull(emailSender, "emailSender must be non-null");
+        this.emailSender = emailSender;
     }
 
     @Override
@@ -114,7 +129,8 @@ public class OrderMgrImpl extends OrderMgrPOA {
                 protocol,
                 port,
                 getAccessManager(),
-                catalogFramework);
+                catalogFramework,
+                emailSender);
 
         String id = UUID.randomUUID()
                 .toString();

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/requests/DestinationSink.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/requests/DestinationSink.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.alliance.nsili.endpoint.requests;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public interface DestinationSink {
+    void writeFile(InputStream fileData, long size, String name, String contentType)
+            throws IOException;
+}

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/requests/EmailDestinationSink.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/requests/EmailDestinationSink.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.alliance.nsili.endpoint.requests;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.codice.alliance.nsili.endpoint.EmailSender;
+import org.codice.alliance.nsili.endpoint.EmailSenderImpl;
+import org.slf4j.LoggerFactory;
+
+public class EmailDestinationSink implements DestinationSink {
+    private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(OrderRequestImpl.class);
+
+    String emailDest;
+
+    EmailSender emailSender;
+
+    public EmailDestinationSink(String emailDest) {
+        this.emailDest = emailDest;
+    }
+
+    @Override
+    public void writeFile(InputStream fileData, long size, String name, String contentType)
+            throws IOException {
+        emailSender = new EmailSenderImpl("smtp.mail.host");
+        emailSender.sendEmail("", emailDest, "", "", name, fileData);
+
+    }
+}

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/requests/FtpDestinationSink.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/requests/FtpDestinationSink.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.alliance.nsili.endpoint.requests;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.protocol.HTTP;
+import org.codice.alliance.nsili.common.GIAS.Destination;
+import org.codice.alliance.nsili.common.UCO.FileLocation;
+import org.slf4j.LoggerFactory;
+
+
+public class FtpDestinationSink implements DestinationSink {
+    private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(OrderRequestImpl.class);
+
+    private Destination destination;
+
+    private FileLocation fileLocation;
+
+    private String protocol;
+
+    private int port;
+
+    FtpDestinationSink(FileLocation fileLocation, int port, String protocol) {
+        this.fileLocation = fileLocation;
+        this.protocol = protocol;
+        this.port = port;
+    }
+
+    @Override
+    public void writeFile(InputStream fileData, long size, String name, String contentType)
+            throws IOException {
+        CloseableHttpClient httpClient = null;
+        String urlPath = protocol + "://" + fileLocation.host_name + ":" + port + "/"
+                + fileLocation.path_name + "/" + name;
+
+        LOGGER.debug("Writing ordered file to URL: {}", urlPath);
+
+        try {
+            HttpPut putMethod = new HttpPut(urlPath);
+            putMethod.addHeader(HTTP.CONTENT_TYPE, contentType);
+            HttpEntity httpEntity = new InputStreamEntity(fileData, size);
+            putMethod.setEntity(httpEntity);
+
+            if (fileLocation.user_name != null && fileLocation.password != null) {
+                CredentialsProvider credsProvider = new BasicCredentialsProvider();
+                credsProvider.setCredentials(new AuthScope(fileLocation.host_name, port),
+                        new UsernamePasswordCredentials(fileLocation.user_name,
+                                fileLocation.password));
+                httpClient = HttpClients.custom()
+                        .setDefaultCredentialsProvider(credsProvider)
+                        .build();
+            } else {
+                httpClient = HttpClients.createDefault();
+            }
+
+            httpClient.execute(putMethod);
+            fileData.close();
+            putMethod.releaseConnection();
+        } finally {
+            if (httpClient != null) {
+                httpClient.close();
+            }
+        }
+    }
+
+}

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -34,23 +34,29 @@
           init-method="init" destroy-method="destroy">
         <cm:managed-properties persistent-id="org.codice.alliance.nsili.endpoint"
                                update-strategy="container-managed"/>
-        <property name="framework" ref="framework" />
-        <property name="filterBuilder" ref="filterBuilder" />
-        <property name="securityHandler" ref="securityHandler" />
-        <property name="securityManager" ref="securityManager" />
-        <property name="defaultUpdateFrequencySec" value="60" />
-        <property name="maxPendingResults" value="10000" />
-        <property name="outgoingValidationEnabled" value="false" />
-        <property name="libraryVersion" value="NSILI|3.2" />
-        <property name="removeSourceLibrary" value="true" />
+        <property name="framework" ref="framework"/>
+        <property name="filterBuilder" ref="filterBuilder"/>
+        <property name="securityHandler" ref="securityHandler"/>
+        <property name="securityManager" ref="securityManager"/>
+        <property name="defaultUpdateFrequencySec" value="60"/>
+        <property name="maxPendingResults" value="10000"/>
+        <property name="outgoingValidationEnabled" value="false"/>
+        <property name="libraryVersion" value="NSILI|3.2"/>
+        <property name="removeSourceLibrary" value="true"/>
         <property name="querySources">
             <array/>
         </property>
-        <property name="corbaOrb" ref="nsiliCorbaOrb" />
+        <property name="corbaOrb" ref="nsiliCorbaOrb"/>
+        <property name="emailSender" ref="emailSender"/>
     </bean>
 
     <bean id="nsiliWebSvc" class="org.codice.alliance.nsili.endpoint.NsiliWebEndpoint">
         <argument ref="nsiliEndpoint"/>
+    </bean>
+
+    <bean id="emailSender"
+          class="org.codice.alliance.nsili.endpoint.EmailSenderImpl">
+        <argument value="donotreply@test.com"/>
     </bean>
 
     <jaxrs:server id="NsiliService" address="/nsili">

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/resources/OSGI-INF/metatype/org.codice.alliance.nsili.endpoint.emailSender.xml
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/resources/OSGI-INF/metatype/org.codice.alliance.nsili.endpoint.emailSender.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+
+ -->
+
+<!--figure out what needs to go here in order to configure from ui: need to configure emailDest/server/max file size-->
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
+
+    <OCD name="NSILI EmailSender" id="org.codice.alliance.nsili.endpoint.EmailSenderImpl">
+        <AD description="The hostname of the mail server"
+            name="Mail Server" id="mailHost" required="true" type="String"
+            default="example.smtp"/>
+    </OCD>
+
+    <Designate pid="org.codice.alliance.nsili.endpoint.EmailSenderImpl">
+        <Object ocdref="org.codice.alliance.nsili.endpoint.EmailSenderImpl"/>
+    </Designate>
+
+</metatype:MetaData>

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/resources/OSGI-INF/metatype/org.codice.alliance.nsili.endpoint.xml
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/resources/OSGI-INF/metatype/org.codice.alliance.nsili.endpoint.xml
@@ -46,6 +46,14 @@
                 name="Enabled Outgoing Validation" id="outgoingValidationEnabled" required="true" type="Boolean"
                 default="false"
         />
+
+        <AD name="Sources to Query:" id="querySources" description="Configured sources to query from this endpoint. Empty list defaults to local only."
+            required="true" type="String" cardinality="1000"
+            default=""/>
+
+        <AD description="Set the hostname of the mail server."
+            name="Mail Server" id="mailHost" required="true" type="String"
+            default="mail.smtp.host"/>
     </OCD>
 
     <Designate pid="org.codice.alliance.nsili.endpoint">

--- a/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/EmailSenderTest.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/EmailSenderTest.java
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.alliance.nsili.endpoint;
+
+public class EmailSenderTest {
+}

--- a/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/NsiliEndpointTest.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/NsiliEndpointTest.java
@@ -72,6 +72,8 @@ public class NsiliEndpointTest extends NsiliCommonTest {
 
     private CorbaOrb mockCorbaOrb = mock(CorbaOrb.class);
 
+    private String mailHost;
+
     @Before
     public void setUp()
             throws SecurityServiceException, AdapterInactive, InvalidName, ServantNotActive,
@@ -270,7 +272,7 @@ public class NsiliEndpointTest extends NsiliCommonTest {
         doReturn(new HashSet<>(Arrays.asList(FRAMEWORK_SOURCE_IDS))).when(mockFramework)
                 .getSourceIds();
         nsiliEndpoint.setFramework(mockFramework);
-
+        nsiliEndpoint.setEmailSender(new EmailSenderImpl(mailHost));
         nsiliEndpoint.init();
     }
 

--- a/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/OrderRequestImplTest.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/OrderRequestImplTest.java
@@ -22,13 +22,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 
+import org.apache.cxf.common.i18n.Exception;
 import org.codice.alliance.nsili.common.GIAS.DelayEstimate;
 import org.codice.alliance.nsili.common.GIAS.DeliveryDetails;
 import org.codice.alliance.nsili.common.GIAS.DeliveryManifestHolder;
@@ -45,17 +45,20 @@ import org.codice.alliance.nsili.common.UCO.Status;
 import org.codice.alliance.nsili.common.UCO.SystemFault;
 import org.codice.alliance.nsili.common.UID.Product;
 import org.codice.alliance.nsili.endpoint.managers.AccessManagerImpl;
+import org.codice.alliance.nsili.endpoint.requests.DestinationSink;
 import org.codice.alliance.nsili.endpoint.requests.OrderRequestImpl;
 import org.junit.Before;
 import org.junit.Test;
 import org.omg.CORBA.BAD_OPERATION;
-import org.omg.CORBA.NO_IMPLEMENT;
+import org.omg.PortableServer.POAPackage.WrongAdapter;
+import org.omg.PortableServer.POAPackage.WrongPolicy;
 
 import ddf.catalog.CatalogFramework;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.operation.ResourceResponse;
 import ddf.catalog.resource.Resource;
+import ddf.security.service.SecurityServiceException;
 
 public class OrderRequestImplTest extends NsiliCommonTest {
 
@@ -66,6 +69,10 @@ public class OrderRequestImplTest extends NsiliCommonTest {
     private AccessManagerImpl accessManager = mock(AccessManagerImpl.class);
 
     private CatalogFramework mockCatalogFramework = mock(CatalogFramework.class);
+
+    private EmailSenderImpl emailSender;
+
+    private String mailHost = "smtp.mail.host";
 
     private Product mockProduct1 = mock(Product.class);
 
@@ -78,12 +85,16 @@ public class OrderRequestImplTest extends NsiliCommonTest {
     private String mockResName = "testresource.jpg";
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() throws Exception, SecurityServiceException, URISyntaxException,
+            UnsupportedEncodingException, WrongAdapter, WrongPolicy {
         setupCommonMocks();
         setupMocks();
+        emailSender = new EmailSenderImpl(mailHost);
     }
 
-    private void setupMocks() throws Exception {
+    private void setupMocks()
+            throws Exception, URISyntaxException, UnsupportedEncodingException, WrongAdapter,
+            WrongPolicy {
         doReturn(getTestMetacard()).when(accessManager)
                 .getMetacard(any(Product.class));
         doReturn(mockResourceResponse).when(mockSubject)
@@ -111,11 +122,12 @@ public class OrderRequestImplTest extends NsiliCommonTest {
                 PROTOCOL,
                 PORT,
                 accessManager,
-                mockCatalogFramework) {
+                mockCatalogFramework,
+                emailSender) {
 
             @Override
-            protected void writeFile(FileLocation destination, InputStream fileData, long size,
-                    String name, String contentType) throws IOException {
+            protected DestinationSink DestinationTypeChecker(Destination dest) throws Exception {
+                return mock(DestinationSink.class);
             }
         };
 
@@ -134,11 +146,12 @@ public class OrderRequestImplTest extends NsiliCommonTest {
                 PROTOCOL,
                 PORT,
                 accessManager,
-                mockCatalogFramework) {
+                mockCatalogFramework,
+                emailSender) {
 
             @Override
-            protected void writeFile(FileLocation destination, InputStream fileData, long size,
-                    String name, String contentType) throws IOException {
+            protected DestinationSink DestinationTypeChecker(Destination dest) throws Exception {
+                return mock(DestinationSink.class);
             }
         };
 
@@ -157,11 +170,12 @@ public class OrderRequestImplTest extends NsiliCommonTest {
                 PROTOCOL,
                 PORT,
                 accessManager,
-                mockCatalogFramework) {
+                mockCatalogFramework,
+                emailSender) {
 
             @Override
-            protected void writeFile(FileLocation destination, InputStream fileData, long size,
-                    String name, String contentType) throws IOException {
+            protected DestinationSink DestinationTypeChecker(Destination dest) throws Exception {
+                return mock(DestinationSink.class);
             }
         };
 
@@ -180,11 +194,12 @@ public class OrderRequestImplTest extends NsiliCommonTest {
                 PROTOCOL,
                 PORT,
                 accessManager,
-                mockCatalogFramework) {
+                mockCatalogFramework,
+                emailSender) {
 
             @Override
-            protected void writeFile(FileLocation destination, InputStream fileData, long size,
-                    String name, String contentType) throws IOException {
+            protected DestinationSink DestinationTypeChecker(Destination dest) throws Exception {
+                return mock(DestinationSink.class);
             }
         };
 
@@ -203,11 +218,12 @@ public class OrderRequestImplTest extends NsiliCommonTest {
                 PROTOCOL,
                 PORT,
                 accessManager,
-                mockCatalogFramework) {
+                mockCatalogFramework,
+                emailSender) {
 
             @Override
-            protected void writeFile(FileLocation destination, InputStream fileData, long size,
-                    String name, String contentType) throws IOException {
+            protected DestinationSink DestinationTypeChecker(Destination dest) throws Exception {
+                return mock(DestinationSink.class);
             }
         };
 
@@ -226,11 +242,12 @@ public class OrderRequestImplTest extends NsiliCommonTest {
                 PROTOCOL,
                 PORT,
                 accessManager,
-                mockCatalogFramework) {
+                mockCatalogFramework,
+                emailSender) {
 
             @Override
-            protected void writeFile(FileLocation destination, InputStream fileData, long size,
-                    String name, String contentType) throws IOException {
+            protected DestinationSink DestinationTypeChecker(Destination dest) throws Exception {
+                return mock(DestinationSink.class);
             }
         };
 
@@ -249,11 +266,12 @@ public class OrderRequestImplTest extends NsiliCommonTest {
                 PROTOCOL,
                 PORT,
                 accessManager,
-                mockCatalogFramework) {
+                mockCatalogFramework,
+                emailSender) {
 
             @Override
-            protected void writeFile(FileLocation destination, InputStream fileData, long size,
-                    String name, String contentType) throws IOException {
+            protected DestinationSink DestinationTypeChecker(Destination dest) throws Exception {
+                return mock(DestinationSink.class);
             }
         };
 
@@ -272,11 +290,12 @@ public class OrderRequestImplTest extends NsiliCommonTest {
                 PROTOCOL,
                 PORT,
                 accessManager,
-                mockCatalogFramework) {
+                mockCatalogFramework,
+                emailSender) {
 
             @Override
-            protected void writeFile(FileLocation destination, InputStream fileData, long size,
-                    String name, String contentType) throws IOException {
+            protected DestinationSink DestinationTypeChecker(Destination dest) throws Exception {
+                return mock(DestinationSink.class);
             }
         };
 
@@ -294,11 +313,12 @@ public class OrderRequestImplTest extends NsiliCommonTest {
                 PROTOCOL,
                 PORT,
                 accessManager,
-                mockCatalogFramework) {
+                mockCatalogFramework,
+                emailSender) {
 
             @Override
-            protected void writeFile(FileLocation destination, InputStream fileData, long size,
-                    String name, String contentType) throws IOException {
+            protected DestinationSink DestinationTypeChecker(Destination dest) throws Exception {
+                return mock(DestinationSink.class);
             }
         };
 
@@ -317,11 +337,12 @@ public class OrderRequestImplTest extends NsiliCommonTest {
                 PROTOCOL,
                 PORT,
                 accessManager,
-                mockCatalogFramework) {
+                mockCatalogFramework,
+                emailSender) {
 
             @Override
-            protected void writeFile(FileLocation destination, InputStream fileData, long size,
-                    String name, String contentType) throws IOException {
+            protected DestinationSink DestinationTypeChecker(Destination dest) throws Exception {
+                return mock(DestinationSink.class);
             }
         };
 
@@ -340,11 +361,12 @@ public class OrderRequestImplTest extends NsiliCommonTest {
                 PROTOCOL,
                 PORT,
                 accessManager,
-                mockCatalogFramework) {
+                mockCatalogFramework,
+                emailSender) {
 
             @Override
-            protected void writeFile(FileLocation destination, InputStream fileData, long size,
-                    String name, String contentType) throws IOException {
+            protected DestinationSink DestinationTypeChecker(Destination dest) throws Exception {
+                return mock(DestinationSink.class);
             }
         };
 
@@ -363,11 +385,12 @@ public class OrderRequestImplTest extends NsiliCommonTest {
                 PROTOCOL,
                 PORT,
                 accessManager,
-                mockCatalogFramework) {
+                mockCatalogFramework,
+                emailSender) {
 
             @Override
-            protected void writeFile(FileLocation destination, InputStream fileData, long size,
-                    String name, String contentType) throws IOException {
+            protected DestinationSink DestinationTypeChecker(Destination dest) throws Exception {
+                return mock(DestinationSink.class);
             }
         };
 
@@ -386,11 +409,12 @@ public class OrderRequestImplTest extends NsiliCommonTest {
                 PROTOCOL,
                 PORT,
                 accessManager,
-                mockCatalogFramework) {
+                mockCatalogFramework,
+                emailSender) {
 
             @Override
-            protected void writeFile(FileLocation destination, InputStream fileData, long size,
-                    String name, String contentType) throws IOException {
+            protected DestinationSink DestinationTypeChecker(Destination dest) throws Exception {
+                return mock(DestinationSink.class);
             }
         };
 
@@ -409,11 +433,12 @@ public class OrderRequestImplTest extends NsiliCommonTest {
                 PROTOCOL,
                 PORT,
                 accessManager,
-                mockCatalogFramework) {
+                mockCatalogFramework,
+                emailSender) {
 
             @Override
-            protected void writeFile(FileLocation destination, InputStream fileData, long size,
-                    String name, String contentType) throws IOException {
+            protected DestinationSink DestinationTypeChecker(Destination dest) throws Exception {
+                return mock(DestinationSink.class);
             }
         };
 
@@ -432,11 +457,12 @@ public class OrderRequestImplTest extends NsiliCommonTest {
                 PROTOCOL,
                 PORT,
                 accessManager,
-                mockCatalogFramework) {
+                mockCatalogFramework,
+                emailSender) {
 
             @Override
-            protected void writeFile(FileLocation destination, InputStream fileData, long size,
-                    String name, String contentType) throws IOException {
+            protected DestinationSink DestinationTypeChecker(Destination dest) throws Exception {
+                return mock(DestinationSink.class);
             }
         };
 
@@ -455,11 +481,12 @@ public class OrderRequestImplTest extends NsiliCommonTest {
                 PROTOCOL,
                 PORT,
                 accessManager,
-                mockCatalogFramework) {
+                mockCatalogFramework,
+                emailSender) {
 
             @Override
-            protected void writeFile(FileLocation destination, InputStream fileData, long size,
-                    String name, String contentType) throws IOException {
+            protected DestinationSink DestinationTypeChecker(Destination dest) throws Exception {
+                return mock(DestinationSink.class);
             }
         };
 
@@ -469,10 +496,11 @@ public class OrderRequestImplTest extends NsiliCommonTest {
         assertThat(holder.value.elements[0].files.length, is(1));
     }
 
-    @Test(expected = NO_IMPLEMENT.class)
-    public void testUnsupportedDelivery() throws SystemFault, ProcessingFault {
+    @Test/*(expected = BAD_OPERATION.class)*/ public void testUnsupportedDelivery()
+            throws SystemFault, ProcessingFault {
         OrderContents order = getUncompressedTestOrder();
 
+        emailSender = new EmailSenderImpl(mailHost);
         DeliveryDetails deliveryDetail = new DeliveryDetails();
         deliveryDetail.dests = getBadDestination();
         order.del_list = new DeliveryDetails[] {deliveryDetail};
@@ -481,11 +509,37 @@ public class OrderRequestImplTest extends NsiliCommonTest {
                 PROTOCOL,
                 PORT,
                 accessManager,
-                mockCatalogFramework) {
+                mockCatalogFramework,
+                emailSender) {
 
             @Override
-            protected void writeFile(FileLocation destination, InputStream fileData, long size,
-                    String name, String contentType) throws IOException {
+            protected DestinationSink DestinationTypeChecker(Destination dest) throws Exception {
+                return mock(DestinationSink.class);
+            }
+        };
+
+        DeliveryManifestHolder holder = new DeliveryManifestHolder();
+        orderRequest.complete(holder);
+    }
+
+    @Test
+    public void testSupportedEmailDelivery() throws SystemFault, ProcessingFault {
+        OrderContents order = getUncompressedTestOrder();
+
+        DeliveryDetails deliveryDetail = new DeliveryDetails();
+        deliveryDetail.dests = getGoodEmailDestination();
+        order.del_list = new DeliveryDetails[] {deliveryDetail};
+
+        OrderRequestImpl orderRequest = new OrderRequestImpl(order,
+                PROTOCOL,
+                PORT,
+                accessManager,
+                mockCatalogFramework,
+                emailSender) {
+
+            @Override
+            protected DestinationSink DestinationTypeChecker(Destination dest) throws Exception {
+                return mock(DestinationSink.class);
             }
         };
 
@@ -496,17 +550,18 @@ public class OrderRequestImplTest extends NsiliCommonTest {
     @Test
     public void testUnsetOutputName() throws SystemFault, ProcessingFault {
         OrderContents order = getUncompressedTestOrder();
-        order.pSpec.package_identifier=null;
+        order.pSpec.package_identifier = null;
 
         OrderRequestImpl orderRequest = new OrderRequestImpl(order,
                 PROTOCOL,
                 PORT,
                 accessManager,
-                mockCatalogFramework) {
+                mockCatalogFramework,
+                emailSender) {
 
             @Override
-            protected void writeFile(FileLocation destination, InputStream fileData, long size,
-                    String name, String contentType) throws IOException {
+            protected DestinationSink DestinationTypeChecker(Destination dest) throws Exception {
+                return mock(DestinationSink.class);
             }
         };
 
@@ -519,7 +574,7 @@ public class OrderRequestImplTest extends NsiliCommonTest {
     @Test
     public void testUnsetDestName() throws SystemFault, ProcessingFault {
         OrderContents order = getUncompressedTestOrder();
-        order.pSpec.package_identifier=null;
+        order.pSpec.package_identifier = null;
         DeliveryDetails deliveryDetail = new DeliveryDetails();
         deliveryDetail.dests = getBadHttpDestination();
         order.del_list = new DeliveryDetails[] {deliveryDetail};
@@ -528,11 +583,12 @@ public class OrderRequestImplTest extends NsiliCommonTest {
                 PROTOCOL,
                 PORT,
                 accessManager,
-                mockCatalogFramework) {
+                mockCatalogFramework,
+                emailSender) {
 
             @Override
-            protected void writeFile(FileLocation destination, InputStream fileData, long size,
-                    String name, String contentType) throws IOException {
+            protected DestinationSink DestinationTypeChecker(Destination dest) throws Exception {
+                return mock(DestinationSink.class);
             }
         };
 
@@ -542,7 +598,7 @@ public class OrderRequestImplTest extends NsiliCommonTest {
         assertThat(holder.value.elements[0].files.length, is(1));
     }
 
-    @Test (expected = BAD_OPERATION.class)
+    @Test(expected = BAD_OPERATION.class)
     public void testNoProduct() throws SystemFault, ProcessingFault {
         OrderContents order = getUncompressedTestOrder();
         order.prod_list = null;
@@ -551,11 +607,12 @@ public class OrderRequestImplTest extends NsiliCommonTest {
                 PROTOCOL,
                 PORT,
                 accessManager,
-                mockCatalogFramework) {
+                mockCatalogFramework,
+                emailSender) {
 
             @Override
-            protected void writeFile(FileLocation destination, InputStream fileData, long size,
-                    String name, String contentType) throws IOException {
+            protected DestinationSink DestinationTypeChecker(Destination dest) throws Exception {
+                return mock(DestinationSink.class);
             }
         };
 
@@ -572,11 +629,12 @@ public class OrderRequestImplTest extends NsiliCommonTest {
                 PROTOCOL,
                 PORT,
                 accessManager,
-                mockCatalogFramework) {
+                mockCatalogFramework,
+                emailSender) {
 
             @Override
-            protected void writeFile(FileLocation destination, InputStream fileData, long size,
-                    String name, String contentType) throws IOException {
+            protected DestinationSink DestinationTypeChecker(Destination dest) throws Exception {
+                return mock(DestinationSink.class);
             }
         };
 
@@ -594,7 +652,8 @@ public class OrderRequestImplTest extends NsiliCommonTest {
                 PROTOCOL,
                 PORT,
                 accessManager,
-                mockCatalogFramework);
+                mockCatalogFramework,
+                emailSender);
 
         RequestDescription requestDescription = orderRequest.get_request_description();
         assertThat(requestDescription, notNullValue());
@@ -608,7 +667,8 @@ public class OrderRequestImplTest extends NsiliCommonTest {
                 PROTOCOL,
                 PORT,
                 accessManager,
-                mockCatalogFramework);
+                mockCatalogFramework,
+                emailSender);
 
         orderRequest.set_user_info("test user");
     }
@@ -621,7 +681,8 @@ public class OrderRequestImplTest extends NsiliCommonTest {
                 PROTOCOL,
                 PORT,
                 accessManager,
-                mockCatalogFramework);
+                mockCatalogFramework,
+                emailSender);
 
         Status status = orderRequest.get_status();
         assertThat(status, notNullValue());
@@ -635,7 +696,8 @@ public class OrderRequestImplTest extends NsiliCommonTest {
                 PROTOCOL,
                 PORT,
                 accessManager,
-                mockCatalogFramework);
+                mockCatalogFramework,
+                emailSender);
 
         DelayEstimate delayEstimate = orderRequest.get_remaining_delay();
         assertThat(delayEstimate, notNullValue());
@@ -649,7 +711,8 @@ public class OrderRequestImplTest extends NsiliCommonTest {
                 PROTOCOL,
                 PORT,
                 accessManager,
-                mockCatalogFramework);
+                mockCatalogFramework,
+                emailSender);
 
         orderRequest.cancel();
     }
@@ -676,6 +739,13 @@ public class OrderRequestImplTest extends NsiliCommonTest {
         location.file_name = "";
         destination.f_dest(location);
         return destination;
+    }
+
+    private Destination getGoodEmailDestination() {
+        Destination destination = new Destination();
+        destination.e_dest("john.doe@example.com");
+        return destination;
+
     }
 
     private Destination getBadDestination() {


### PR DESCRIPTION
#### What does this PR do?
This PR implements the email destination support found in OrderMgr interface of NSILI.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@troymohl 
@bdeining 
@glenhein 
@emmberk 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith 
@kcwire
#### How should this be tested?
1. Update static variable "emailDest" in NsiliClient.java to a valid email address you can access (make sure "isEmailEnabled" is set to "true")
2. Build Alliance
3. Run instance of Alliance and do a standard full install
4. Upload image through Search UI and click "search" (to add image to catalog)
5. Run command `mvn -Pcorba.client -Dexec.args="https://localhost:8993/services/nsili/ior.txt"` from directory `alliance/distribution/sdk/sample-nsili-client`
6. Verify that no exceptions occur and that an email is sent to your inbox
#### Any background context you want to provide?
Ticket adds support for OrderMgrImpl by implementing the e_dest (email destination) support found in GIAS/Destination.java interface. Previously only http destinations for files were supported.
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

