### PR TITLE
CAL-140 Added missing org.codice.ddf.admin.applicationlist.properties

### DIFF
--- a/distribution/alliance/src/main/filtered-resources/etc/org.codice.ddf.admin.applicationlist.properties
+++ b/distribution/alliance/src/main/filtered-resources/etc/org.codice.ddf.admin.applicationlist.properties
@@ -1,0 +1,18 @@
+# List of applications that should be automatically installed and started on first load.
+# Applications should be defined by <name>=<location> where location may be empty if the application is located within DDF by default.
+# NOTE: If an application is listed in here, DDF will AUTOMATICALLY install all application it depends on.
+# Examples:
+#
+# Local application:
+# opendj-embedded=
+#
+# Application installed into a local maven repository:
+# opendj-embedded=mvn:org.codice.opendj.embedded/opendj-embedded-app/1.0.1-SNAPSHOT/xml/features
+#
+# Application located on the file system:
+# opendj-embedded=file:/location/to/opendj-embedded-app-1.0.1-SNAPSHOT.kar
+
+#catalog-app=
+#solr-app=
+#spatial-app=
+#opendj-embedded=


### PR DESCRIPTION
#### What does this PR do?
This PR adds a missing file to the Alliance distribution that was causing warnings when using the configuration export functionality.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@lcrosenbu @jrnorth 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@stustison 
#### How should this be tested?
Build and install Alliance, export the configurations and observe no warnings
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/CAL-140
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

