### PR TITLE
CAL-129: Cleaned up javadoc formatting

### DIFF
--- a/catalog/core/catalog-core-api/src/main/java/org/codice/alliance/catalog/core/api/types/Isr.java
+++ b/catalog/core/catalog-core-api/src/main/java/org/codice/alliance/catalog/core/api/types/Isr.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * 
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * 
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -14,275 +14,275 @@
 package org.codice.alliance.catalog.core.api.types;
 
 /**
- * <p>
+ * 
  * <b> This code is experimental. While this interface is functional and tested, it may change or be
  * removed in a future version of the library. </b>
- * </p>
+ * 
  */
 public interface Isr {
 
     /**
-     * Attribute name for accessing the Cloud Cover percentage for this Metacard. <br/>
+     *  Attribute name for accessing the Cloud Cover percentage for this Metacard. 
      */
     String CLOUD_COVER = "isr.cloud-cover";
 
     /**
-     * Attribute name for accessing whether the imagery has been processed for VMTI for this Metacard. <br/>
+     *  Attribute name for accessing whether the imagery has been processed for VMTI for this Metacard. 
      */
     String VIDEO_MOVING_TARGET_INDICATOR_PROCESSED = "isr.vmti-processed";
 
     /**
-     * Attribute name for accessing the ISR comment for this Metacard. <br/>
+     *  Attribute name for accessing the ISR comment for this Metacard. 
      */
     String COMMENTS = "isr.comments";
 
     /**
-     * Attribute name for accessing the dwell location for this Metacard. <br/>
+     *  Attribute name for accessing the dwell location for this Metacard. 
      */
     String DWELL_LOCATION = "isr.dwell-location";
 
     /**
-     * Attribute name for accessing whether the exploitation was automatically generated for this Metacard. <br/>
+     *  Attribute name for accessing whether the exploitation was automatically generated for this Metacard. 
      */
     String EXPLOTATION_AUTO_GENERATED = "isr.exploitation-auto-generated";
 
     /**
-     * Attribute name for accessing the exploitation level for this Metacard. <br/>
+     *  Attribute name for accessing the exploitation level for this Metacard. 
      */
     String EXPLOITATION_LEVEL = "isr.exploitation-level";
 
     /**
-     * Attribute name for accessing the exploitation subjective quality code for this Metacard. <br/>
+     *  Attribute name for accessing the exploitation subjective quality code for this Metacard. 
      */
     String EXPLOITATION_SUBJECTIVE_QUALITY_CODE = "isr.exploitation-subjective-quality-code";
 
     /**
-     * Attribute name for accessing the MTI Job ID for this Metacard. <br/>
+     *  Attribute name for accessing the MTI Job ID for this Metacard. 
      */
     String MOVING_TARGET_INDICATOR_JOB_ID = "isr.mti-job-id";
 
     /**
-     * Attribute name for accessing the frequency in hertz for this Metacard. <br/>
+     *  Attribute name for accessing the frequency in hertz for this Metacard. 
      */
     String FREQUENCY_HERTZ = "isr.frequency-hertz";
 
     /**
-     * Attribute name for accessing the Image ID for this Metacard. <br/>
+     *  Attribute name for accessing the Image ID for this Metacard. 
      */
     String IMAGE_ID = "isr.image-id";
 
     /**
      * Attribute name for accessing the JC3IEDM (Joint Consultation,
-     * Command and Control Information Exchange Data Model) ID for this Metacard. <br/>
+     *  Command and Control Information Exchange Data Model) ID for this Metacard. 
      */
     String JC3IEDM_ID = "isr.jc3iedm-id";
 
     /**
-     * Attribute name for accessing the Mission ID for this Metacard. <br/>
+     *  Attribute name for accessing the Mission ID for this Metacard. 
      */
     String MISSION_ID = "isr.mission-id";
 
     /**
-     * Attribute name for accessing the Nato Reporting Code for this Metacard. <br/>
+     *  Attribute name for accessing the Nato Reporting Code for this Metacard. 
      */
     String NATO_REPORTING_CODE = "isr.nato-reporting-code";
 
     /**
-     * Attribute name for accessing the NIIRS rating for this Metacard. <br/>
+     *  Attribute name for accessing the NIIRS rating for this Metacard. 
      */
     String NATIONAL_IMAGERY_INTERPRETABILITY_RATING_SCALE = "isr.niirs";
 
     /**
-     * Attribute name for accessing the organizational unit for this Metacard. <br/>
+     *  Attribute name for accessing the organizational unit for this Metacard. 
      */
     String ORGANIZATIONAL_UNIT = "isr.organizational-unit";
 
     /**
-     * Attribute name for accessing the original source for the metadata for this Metacard. <br/>
+     *  Attribute name for accessing the original source for the metadata for this Metacard. 
      */
     String ORIGINAL_SOURCE = "isr.original-source";
 
     /**
-     * Attribute name for accessing the platform ID for this Metacard. <br/>
+     *  Attribute name for accessing the platform ID for this Metacard. 
      */
     String PLATFORM_ID = "isr.platform-id";
 
     /**
-     * Attribute name for accessing the platform name for this Metacard. <br/>
+     *  Attribute name for accessing the platform name for this Metacard. 
      */
     String PLATFORM_NAME = "isr.platform-name";
 
     /**
-     * Attribute name for accessing the report entity alias for this Metacard. <br/>
+     *  Attribute name for accessing the report entity alias for this Metacard. 
      */
     String REPORT_ENTITY_ALIAS = "isr.report-entity-alias";
 
     /**
-     * Attribute name for accessing the report entity name for this Metacard. <br/>
+     *  Attribute name for accessing the report entity name for this Metacard. 
      */
     String REPORT_ENTITY_NAME = "isr.report-entity-name";
 
     /**
-     * Attribute name for accessing the report entity type for this Metacard. <br/>
+     *  Attribute name for accessing the report entity type for this Metacard. 
      */
     String REPORT_ENTITY_TYPE = "isr.report-entity-type";
 
     /**
-     * Attribute name for accessing the report info rating for this Metacard. <br/>
+     *  Attribute name for accessing the report info rating for this Metacard. 
      */
     String REPORT_INFO_RATING = "isr.report-info-rating";
 
     /**
-     * Attribute name for accessing the report situation type for this Metacard. <br/>
+     *  Attribute name for accessing the report situation type for this Metacard. 
      */
     String REPORT_SITUATION_TYPE = "isr.report-situation-type";
 
     /**
-     * Attribute name for accessing the report serial number for this Metacard. <br/>
+     *  Attribute name for accessing the report serial number for this Metacard. 
      */
     String REPORT_SERIAL_NUMBER = "isr.report-serial-number";
 
     /**
-     * Attribute name for accessing the report type for this Metacard. <br/>
+     *  Attribute name for accessing the report type for this Metacard. 
      */
     String REPORT_TYPE = "isr.report-type";
 
     /**
-     * Attribute name for accessing the report priority for this Metacard. <br/>
+     *  Attribute name for accessing the report priority for this Metacard. 
      */
     String REPORT_PRIORITY = "isr.report-priority";
 
     /**
-     * Attribute name for accessing the entity requesting action for the metadata of this Metacard. <br/>
+     *  Attribute name for accessing the entity requesting action for the metadata of this Metacard. 
      */
     String REQUEST_FOR_INFORMATION_FOR_ACTION = "isr.rfi-for-action";
 
     /**
-     * Attribute name for accessing the entity requesting that has interest in the metadata
-     * of this Metacard. <br/>
+     *  Attribute name for accessing the entity requesting that has interest in the metadata
+     * of this Metacard. 
      */
     String REQUEST_FOR_INFORMATION_FOR_INFORMATION = "isr.rfi-for-information";
 
     /**
-     * Attribute name for accessing the RFI serial number for this Metacard. <br/>
+     *  Attribute name for accessing the RFI serial number for this Metacard. 
      */
     String REQUEST_FOR_INFORMATION_SERIAL_NUMBER = "isr.rfi-serial-number";
 
     /**
-     * Attribute name for accessing the RFI status for this Metacard. <br/>
+     *  Attribute name for accessing the RFI status for this Metacard. 
      */
     String REQUEST_FOR_INFORMATION_STATUS = "isr.rfi-status";
 
     /**
-     * Attribute name for accessing the RFI workflow status for this Metacard. <br/>
+     *  Attribute name for accessing the RFI workflow status for this Metacard. 
      */
     String REQUEST_FOR_INFORMATION_WORKFLOW_STATUS = "isr.rfi-workflow-status";
 
     /**
-     * Attribute name for accessing the sensor ID for this Metacard. <br/>
+     *  Attribute name for accessing the sensor ID for this Metacard. 
      */
     String SENSOR_ID = "isr.sensor-id";
 
     /**
-     * Attribute name for accessing the sensor type for this Metacard. <br/>
+     *  Attribute name for accessing the sensor type for this Metacard. 
      */
     String SENSOR_TYPE = "isr.sensor-type";
 
     /**
-     * Attribute name for accessing the target category code for this Metacard. <br/>
+     *  Attribute name for accessing the target category code for this Metacard. 
      */
     String TARGET_CATEGORY_CODE = "isr.target-category-code";
 
     /**
-     * Attribute name for accessing the target ID for this Metacard. <br/>
+     *  Attribute name for accessing the target ID for this Metacard. 
      */
     String TARGET_ID = "isr.target-id";
 
     /**
-     * Attribute name for accessing the target report count for this Metacard. <br/>
+     *  Attribute name for accessing the target report count for this Metacard. 
      */
     String TARGET_REPORT_COUNT = "isr.target-report-count";
 
     /**
-     * Attribute name for accessing the task comments for this Metacard. <br/>
+     *  Attribute name for accessing the task comments for this Metacard. 
      */
     String TASK_COMMENTS = "isr.task-comments";
 
     /**
-     * Attribute name for accessing the task ID for this Metacard. <br/>
+     *  Attribute name for accessing the task ID for this Metacard. 
      */
     String TASK_ID = "isr.task-id";
 
     /**
-     * Attribute name for accessing the task status for this Metacard. <br/>
+     *  Attribute name for accessing the task status for this Metacard. 
      */
     String TASK_STATUS = "isr.task-status";
 
     /**
-     * Attribute name for accessing the CBRN alarm classification for this Metacard. <br/>
+     *  Attribute name for accessing the CBRN alarm classification for this Metacard. 
      */
     String CHEMICAL_BIOLOGICAL_RADIOLOGICAL_NUCLEAR_ALARM_CLASSIFICATION =
             "isr.cbrn-alarm-classification";
 
     /**
-     * Attribute name for accessing the CBRN category for this Metacard. <br/>
+     *  Attribute name for accessing the CBRN category for this Metacard. 
      */
     String CHEMICAL_BIOLOGICAL_RADIOLOGICAL_NUCLEAR_CATEGORY = "isr.cbrn-category";
 
     /**
-     * Attribute name for accessing the CBRN incident number for this Metacard. <br/>
+     *  Attribute name for accessing the CBRN incident number for this Metacard. 
      */
     String CHEMICAL_BIOLOGICAL_RADIOLOGICAL_NUCLEAR_INCIDENT_NUMBER = "isr.cbrn-incident-number";
 
     /**
-     * Attribute name for accessing the CBRN operation name for this Metacard. <br/>
+     *  Attribute name for accessing the CBRN operation name for this Metacard. 
      */
     String CHEMICAL_BIOLOGICAL_RADIOLOGICAL_NUCLEAR_OPERATION_NAME = "isr.cbrn-operation-name";
 
     /**
-     * Attribute name for accessing the CBRN type for this Metacard. <br/>
+     *  Attribute name for accessing the CBRN type for this Metacard. 
      */
     String CHEMICAL_BIOLOGICAL_RADIOLOGICAL_NUCLEAR_TYPE = "isr.cbrn-type";
 
     /**
-     * Attribute name for accessing the CBRN substance for this Metacard. <br/>
+     *  Attribute name for accessing the CBRN substance for this Metacard. 
      */
     String CHEMICAL_BIOLOGICAL_RADIOLOGICAL_NUCLEAR_SUBSTANCE = "isr.cbrn-substance";
 
     /**
-     * Attribute name for accessing the TDL platform number for this Metacard. <br/>
+     *  Attribute name for accessing the TDL platform number for this Metacard. 
      */
     String TACTICAL_DATA_LINK_PLATFORM = "isr.tdl-platform-number";
 
     /**
-     * Attribute name for accessing the TDL activity number for this Metacard. <br/>
+     *  Attribute name for accessing the TDL activity number for this Metacard. 
      */
     String TACTICAL_DATA_LINK_ACTIVITY = "isr.tdl-activity";
 
     /**
-     * Attribute name for accessing the TDL track number for this Metacard. <br/>
+     *  Attribute name for accessing the TDL track number for this Metacard. 
      */
     String TACTICAL_DATA_LINK_TRACK_NUMBER = "isr.tdl-track-number";
 
     /**
-     * Attribute name for accessing the TDL message number for this Metacard. <br/>
+     *  Attribute name for accessing the TDL message number for this Metacard. 
      */
     String TACTICAL_DATA_LINK_MESSAGE_NUMBER = "isr.tdl-message-number";
 
     /**
-     * Attribute name for accessing the MISM level for this Metacard. <br/>
+     *  Attribute name for accessing the MISM level for this Metacard. 
      */
     String VIDEO_MOTION_IMAGERY_SYSTEMS_MATRIX_LEVEL = "isr.video-mism-level";
 
     /**
-     * Attribute name for accessing the ISR category for this Metacard. <br/>
+     *  Attribute name for accessing the ISR category for this Metacard. 
      */
     String CATEGORY = "isr.category";
 
     /*  The following attribute names are experimental and may change. */
 
     /**
-     * Attribute name for accessing the ISR data quality for this Metacard. <br/>
+     *  Attribute name for accessing the ISR data quality for this Metacard. 
      */
     String DATA_QUALITY = "ext.isr.data-quality";
 }

--- a/catalog/core/catalog-core-api/src/main/java/org/codice/alliance/catalog/core/api/types/Security.java
+++ b/catalog/core/catalog-core-api/src/main/java/org/codice/alliance/catalog/core/api/types/Security.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * 
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * 
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -14,99 +14,99 @@
 package org.codice.alliance.catalog.core.api.types;
 
 /**
- * <p>
+ * 
  * <b> This code is experimental. While this interface is functional and tested, it may change or be
- * removed in a future version of the library. </b>
- * </p>
+ * removed in a future version of the library.</b>
+ * 
  */
 public interface Security {
 
     /**
-     * Attribute name for accessing the security classification for this Metacard. <br/>
+     *  Attribute name for accessing the security classification for this Metacard. 
      */
     String CLASSIFICATION = "security.classification";
 
     /**
-     * Attribute name for accessing the security classification system for this Metacard. <br/>
+     *  Attribute name for accessing the security classification system for this Metacard. 
      */
     String CLASSIFICATION_SYSTEM = "security.classification-system";
 
     /**
-     * Attribute name for accessing the security code words for this Metacard. <br/>
+     *  Attribute name for accessing the security code words for this Metacard. 
      */
     String CODEWORDS = "security.codewords";
 
     /**
-     * Attribute name for accessing the security dissemination controls for this Metacard. <br/>
+     *  Attribute name for accessing the security dissemination controls for this Metacard. 
      */
     String DISSEMINATION_CONTROLS = "security.dissemination-controls";
 
     /**
-     * Attribute name for accessing other security dissemination controls for this Metacard. <br/>
+     *  Attribute name for accessing other security dissemination controls for this Metacard. 
      */
     String OTHER_DISSEMINATION_CONTROLS = "security.other-dissemination-controls";
 
     /**
-     * Attribute name for accessing the country codes of owners and producers for this Metacard. <br/>
+     *  Attribute name for accessing the country codes of owners and producers for this Metacard. 
      */
     String OWNER_PRODUCER = "security.owner-producer";
 
     /**
-     * Attribute name for accessing the releasability for this Metacard. <br/>
+     *  Attribute name for accessing the releasability for this Metacard. 
      */
     String RELEASABILITY = "security.releasability";
 
     /*  The following attribute names are experimental and may change. */
 
     /**
-     * Attribute name for accessing the metadata originator classification for this Metacard. <br/>
+     *  Attribute name for accessing the metadata originator classification for this Metacard. 
      */
     String METADATA_ORIGINATOR_CLASSIFICATION =
             "ext.metadata-originator-classification";
 
     /**
-     * Attribute name for accessing the metadata classification for this Metacard. <br/>
+     *  Attribute name for accessing the metadata classification for this Metacard. 
      */
     String METADATA_CLASSIFICATION = "ext.metadata-classification";
 
     /**
-     * Attribute name for accessing the security classification system for the metadata for this Metacard. <br/>
+     *  Attribute name for accessing the security classification system for the metadata for this Metacard. 
      */
     String METADATA_CLASSIFICATION_SYSTEM = "ext.metadata-classification-system";
 
     /**
-     * Attribute name for accessing the metadata dissemination controls for this Metacard. <br/>
+     *  Attribute name for accessing the metadata dissemination controls for this Metacard. 
      */
     String METADATA_DISSEMINATION = "ext.metadata-dissemination-controls";
 
     /**
-     * Attribute name for accessing the metadata releasability for this Metacard. <br/>
+     *  Attribute name for accessing the metadata releasability for this Metacard. 
      */
     String METADATA_RELEASABILITY = "ext.metadata-releasability";
 
     /**
-     * Attribute name for accessing the resource originator classification for this Metacard. <br/>
+     *  Attribute name for accessing the resource originator classification for this Metacard. 
      */
     String RESOURCE_ORIGINATOR_CLASSIFICATION =
             "ext.resource-originator-classification";
 
     /**
-     * Attribute name for accessing the resource classification for this Metacard. <br/>
+     *  Attribute name for accessing the resource classification for this Metacard. 
      */
     String RESOURCE_CLASSIFICATION = "ext.resource-classification";
 
     /**
-     * Attribute name for accessing the security classification system for the resource for this Metacard. <br/>
+     *  Attribute name for accessing the security classification system for the resource for this Metacard. 
      */
     String RESOURCE_CLASSIFICATION_SYSTEM = "ext.resource-classification-system";
 
     /**
-     * Attribute name for accessing the resource releasability for this Metacard. <br/>
+     *  Attribute name for accessing the resource releasability for this Metacard. 
      */
     String RESOURCE_RELEASABILITY = "ext.resource-releasability";
 
     /**
-     * Attribute name for accessing the resource dissemination controls for this Metacard. <br/>
+     *  Attribute name for accessing the resource dissemination controls for this Metacard. 
      */
     String RESOURCE_DISSEMINATION = "ext.resource-dissemination-controls";
 }

--- a/catalog/imaging/imaging-service-api/src/main/java/org/codice/alliance/imaging/chip/service/api/ChipService.java
+++ b/catalog/imaging/imaging-service-api/src/main/java/org/codice/alliance/imaging/chip/service/api/ChipService.java
@@ -48,7 +48,7 @@ public interface ChipService {
      *                      the image then h will be adjusted down such that y + w will equal the
      *                      image height.
      * @return              The portion of the image inside the crop area.
-     * @throws ChipOutOfBoundsException when x > image width, y > image height, w < 0 or h < 0.
+     * @throws ChipOutOfBoundsException when x &gt; image width, y &gt; image height, w &lt; 0 or h &lt; 0.
      */
     BufferedImage crop(BufferedImage inputImage, int x, int y, int w, int h) throws ChipOutOfBoundsException;
 }

--- a/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/UdpStreamMonitor.java
+++ b/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/UdpStreamMonitor.java
@@ -182,7 +182,7 @@ public class UdpStreamMonitor implements StreamMonitor {
     }
 
     /**
-     * @param metacardUpdateInitialDelay must be non-null and >=0 and <={@link UdpStreamProcessor#MAX_METACARD_UPDATE_INITIAL_DELAY}
+     * @param metacardUpdateInitialDelay must be non-null and &gt;=0 and &lt;={@link UdpStreamProcessor#MAX_METACARD_UPDATE_INITIAL_DELAY}
      */
     public void setMetacardUpdateInitialDelay(Long metacardUpdateInitialDelay) {
         udpStreamProcessor.setMetacardUpdateInitialDelay(metacardUpdateInitialDelay);
@@ -479,7 +479,7 @@ public class UdpStreamMonitor implements StreamMonitor {
     }
 
     /**
-     * @param milliseconds must be non-null and >= {@link #ELAPSED_TIME_MIN}
+     * @param milliseconds must be non-null and &gt;= {@link #ELAPSED_TIME_MIN}
      */
     public void setElapsedTimeRolloverCondition(Long milliseconds) {
         notNull(milliseconds, "milliseconds must be non-null");

--- a/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/netty/PacketBuffer.java
+++ b/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/netty/PacketBuffer.java
@@ -44,8 +44,8 @@ import org.slf4j.LoggerFactory;
  * written is on a clean IDR boundary. If an IDR boundary cannot be found, the data will be
  * eventually flush on a arbitrary point to avoid memory exhaustion. This implementation
  * is thread-safe.
- * <p/>
- * NOTE: This implementation could probably be improved by using some kind of circular buffer with read and write pointers
+ *
+ *  NOTE: This implementation could probably be improved by using some kind of circular buffer with read and write pointers 
  */
 public class PacketBuffer {
 

--- a/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/netty/UdpStreamProcessor.java
+++ b/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/netty/UdpStreamProcessor.java
@@ -216,7 +216,7 @@ public class UdpStreamProcessor implements StreamProcessor {
     }
 
     /**
-     * @param metacardUpdateInitialDelay must be non-null and >=0 and <={@link #MAX_METACARD_UPDATE_INITIAL_DELAY}
+     * @param metacardUpdateInitialDelay must be non-null and &gt;=0 and &lt;={@link #MAX_METACARD_UPDATE_INITIAL_DELAY}
      */
     public void setMetacardUpdateInitialDelay(Long metacardUpdateInitialDelay) {
         notNull(metacardUpdateInitialDelay, "metacardUpdateInitialDelay must be non-null");

--- a/libs/klv/src/main/java/org/codice/alliance/libs/klv/LocationKlvProcessor.java
+++ b/libs/klv/src/main/java/org/codice/alliance/libs/klv/LocationKlvProcessor.java
@@ -30,7 +30,7 @@ import ddf.catalog.data.impl.AttributeImpl;
 
 /**
  * Generate the location metadata based on the klv corner data. Callers must supply a
- * {@link Configuration} that contains a postive (>0)
+ * {@link Configuration} that contains a postive (&gt;0)
  * Integer for {@link Configuration#SUBSAMPLE_COUNT}.
  */
 public class LocationKlvProcessor implements KlvProcessor {

--- a/pom.xml
+++ b/pom.xml
@@ -277,6 +277,14 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>2.10.3</version>
+                    <configuration>
+                      <failOnError>false</failOnError>
+                      <show>protected</show>
+                      <skip>false</skip>
+                      <additionalParams>
+                        -Xdoclint:all,-missing
+                      </additionalParams>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.jacoco</groupId>


### PR DESCRIPTION
#### What does this PR do?

Javadoc was failing due to invalid javadoc markup which was causing the release process to fail

* Fixed invalid html formatting
* Fixed invalid usage of greater-than and less-than
* Disabled doclint for missing annotations

#### Who is reviewing it 
@codice/continuous-integration 
@troymohl 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@lessarderic 
#### How should this be tested?

Run `mvn javadoc:javadoc` and ensure it completes successfully

#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-129](https://codice.atlassian.net/browse/CAL-129)