### PR TITLE
CAL-131: Add all Nitf attributes into Nitf metacard types

### DIFF
--- a/catalog/imaging/imaging-transformer-nitf/pom.xml
+++ b/catalog/imaging/imaging-transformer-nitf/pom.xml
@@ -161,12 +161,12 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.87</minimum>
+                                            <minimum>0.85</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.60</minimum>
+                                            <minimum>0.65</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/AbstractNitfMetacardType.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/AbstractNitfMetacardType.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.transformer.nitf;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.codice.alliance.transformer.nitf.common.NitfAttribute;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.impl.MetacardTypeImpl;
+
+public abstract class AbstractNitfMetacardType extends MetacardTypeImpl {
+
+    public AbstractNitfMetacardType(String name, Set<AttributeDescriptor> descriptors) {
+        super(name, descriptors);
+    }
+
+    public abstract void initDescriptors();
+
+    protected Set<AttributeDescriptor> getDescriptors(NitfAttribute[] attributes) {
+        Set<AttributeDescriptor> descriptors = new HashSet<>();
+        for (NitfAttribute attribute : attributes) {
+            descriptors.addAll(attribute.getAttributeDescriptors());
+        }
+        return descriptors;
+    }
+}

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/ExtNitfUtility.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/ExtNitfUtility.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.transformer.nitf;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.impl.AttributeDescriptorImpl;
+
+/**
+ * Utility class for holding common elements and creating NITF {@link AttributeDescriptor}s that do
+ * not map to the taxonomy.
+ */
+public class ExtNitfUtility {
+    public static final String EXT_NITF_PREFIX = "ext.nitf.";
+
+    public static AttributeDescriptor createDuplicateDescriptorAndRename(String newName,
+            AttributeDescriptor duplicatedDescriptor) {
+        return new AttributeDescriptorImpl(EXT_NITF_PREFIX + newName,
+                duplicatedDescriptor.isIndexed(),
+                duplicatedDescriptor.isStored(),
+                duplicatedDescriptor.isTokenized(),
+                duplicatedDescriptor.isMultiValued(),
+                duplicatedDescriptor.getType());
+    }
+}

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/AcftbAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/AcftbAttribute.java
@@ -14,32 +14,65 @@
 package org.codice.alliance.transformer.nitf.common;
 
 import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.Function;
 
+import org.apache.commons.lang.StringUtils;
 import org.codice.alliance.catalog.core.api.impl.types.IsrAttributes;
 import org.codice.alliance.catalog.core.api.types.Isr;
+import org.codice.alliance.transformer.nitf.ExtNitfUtility;
 import org.codice.imaging.nitf.core.tre.Tre;
 
 import ddf.catalog.data.AttributeDescriptor;
-import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.impl.AttributeDescriptorImpl;
+import ddf.catalog.data.impl.BasicTypes;
 
 public enum AcftbAttribute implements NitfAttribute<Tre> {
+
+    /*
+     * Normalized attributes. These taxonomy terms will be duplicated by `ext.nitf.acftb.*` when
+     * appropriate
+     */
+
     AIRCRAFT_MISSION_ID(Isr.MISSION_ID,
             "AC_MSN_ID",
             tre -> TreUtility.getTreValue(tre, "AC_MSN_ID"),
-            new IsrAttributes()),
+            new IsrAttributes().getAttributeDescriptor(Isr.MISSION_ID),
+            "aircraftMissionId"),
     AIRCRAFT_TAIL_NUMBER(Isr.PLATFORM_ID,
             "AC_TAIL_NO",
             tre -> TreUtility.getTreValue(tre, "AC_TAIL_NO"),
-            new IsrAttributes()),
+            new IsrAttributes().getAttributeDescriptor(Isr.PLATFORM_ID),
+            "aircraftTailNumber"),
     SENSOR_ID_TYPE(Isr.SENSOR_TYPE,
             "SENSOR_ID_TYPE",
             tre -> TreUtility.getTreValue(tre, "SENSOR_ID_TYPE"),
-            new IsrAttributes()),
+            new IsrAttributes().getAttributeDescriptor(Isr.SENSOR_TYPE),
+            "sensorIdType"),
     SENSOR_ID(Isr.SENSOR_ID,
             "SENSOR_ID",
             tre -> TreUtility.getTreValue(tre, "SENSOR_ID"),
-            new IsrAttributes());
+            new IsrAttributes().getAttributeDescriptor(Isr.SENSOR_ID),
+            "sensorId"),
+
+    /*
+     * Non-normalized attributes
+     */
+
+    AIRCRAFT_TAKEOFF("aircraftTakeOff", "AC_TO", tre -> TreUtility.getTreValue(tre, "AC_TO")),
+    SCENE_SOURCE("sceneSource", "SCENE_SOURCE", tre -> TreUtility.getTreValue(tre, "SCENE_SOURCE")),
+    SCENE_NUMBER("sceneNumber", "SCNUM", tre -> TreUtility.getTreValue(tre, "SCNUM")),
+    PROCESSING_DATE("processingDate", "PDATE", tre -> TreUtility.getTreValue(tre, "PDATE")),
+    IMMEDIATE_SCENE_HOST("immediateSceneHost",
+            "IMHOSTNO",
+            tre -> TreUtility.getTreValue(tre, "IMHOSTNO")),
+    IMMEDIATE_SCENE_REQUEST_ID("immediateSceneRequestId",
+            "IMREQID",
+            tre -> TreUtility.getTreValue(tre, "IMREQID")),
+    MISSION_PLAN_MODE("missionPlanMode", "MPLAN", tre -> TreUtility.getTreValue(tre, "MPLAN"));
+
+    private static final String ATTRIBUTE_NAME_PREFIX = "acftb.";
 
     private String shortName;
 
@@ -47,15 +80,37 @@ public enum AcftbAttribute implements NitfAttribute<Tre> {
 
     private Function<Tre, Serializable> accessorFunction;
 
-    private AttributeDescriptor attributeDescriptor;
+    private Set<AttributeDescriptor> attributeDescriptors;
 
-    AcftbAttribute(String longName, String shortName, Function<Tre, Serializable> accessorFunction,
-            MetacardType metacardType) {
+    AcftbAttribute(final String longName, final String shortName,
+            final Function<Tre, Serializable> accessorFunction) {
         this.longName = longName;
         this.shortName = shortName;
         this.accessorFunction = accessorFunction;
-        // retrieving metacard attribute descriptor for this attribute to prevent later lookups
-        this.attributeDescriptor = metacardType.getAttributeDescriptor(longName);
+        // retrieving metacard attribute descriptors for this attribute to prevent later lookups
+        this.attributeDescriptors = new HashSet<>();
+        this.attributeDescriptors.add(new AttributeDescriptorImpl(
+                ExtNitfUtility.EXT_NITF_PREFIX + ATTRIBUTE_NAME_PREFIX + longName,
+                true, /* indexed */
+                true, /* stored */
+                false, /* tokenized */
+                true, /* multivalued */
+                BasicTypes.STRING_TYPE));
+    }
+
+    AcftbAttribute(String longName, String shortName, Function<Tre, Serializable> accessorFunction,
+            AttributeDescriptor attributeDescriptor, String extNitfName) {
+        this.longName = longName;
+        this.shortName = shortName;
+        this.accessorFunction = accessorFunction;
+        // retrieving metacard attribute descriptors for this attribute to prevent later lookups
+        this.attributeDescriptors = new HashSet<>();
+        this.attributeDescriptors.add(attributeDescriptor);
+        if (StringUtils.isNotEmpty(extNitfName)) {
+            this.attributeDescriptors.add(ExtNitfUtility.createDuplicateDescriptorAndRename(
+                    ATTRIBUTE_NAME_PREFIX + extNitfName,
+                    attributeDescriptor));
+        }
     }
 
     @Override
@@ -74,7 +129,7 @@ public enum AcftbAttribute implements NitfAttribute<Tre> {
     }
 
     @Override
-    public AttributeDescriptor getAttributeDescriptor() {
-        return this.attributeDescriptor;
+    public Set<AttributeDescriptor> getAttributeDescriptors() {
+        return this.attributeDescriptors;
     }
 }

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/NitfAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/NitfAttribute.java
@@ -14,6 +14,7 @@
 package org.codice.alliance.transformer.nitf.common;
 
 import java.io.Serializable;
+import java.util.Set;
 import java.util.function.Function;
 
 import ddf.catalog.data.AttributeDescriptor;
@@ -44,7 +45,7 @@ public interface NitfAttribute<T> {
     Function<T, Serializable> getAccessorFunction();
 
     /**
-     * @return an AttributeDescriptor for this attribute.
+     * @return AttributeDescriptors for this attribute.
      */
-    AttributeDescriptor getAttributeDescriptor();
+    Set<AttributeDescriptor> getAttributeDescriptors();
 }

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/NitfHeaderAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/NitfHeaderAttribute.java
@@ -17,16 +17,21 @@ import java.io.Serializable;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.Function;
 
+import org.apache.commons.lang.StringUtils;
 import org.codice.alliance.catalog.core.api.impl.types.IsrAttributes;
 import org.codice.alliance.catalog.core.api.impl.types.SecurityAttributes;
 import org.codice.alliance.catalog.core.api.types.Isr;
 import org.codice.alliance.catalog.core.api.types.Security;
+import org.codice.alliance.transformer.nitf.ExtNitfUtility;
 import org.codice.imaging.nitf.core.common.DateTime;
 import org.codice.imaging.nitf.core.header.NitfHeader;
 
 import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.AttributeType;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.AttributeDescriptorImpl;
 import ddf.catalog.data.impl.BasicTypes;
@@ -41,70 +46,180 @@ import ddf.catalog.data.types.Media;
  * NitfAttributes to represent the properties of a NitfFileHeader.
  */
 public enum NitfHeaderAttribute implements NitfAttribute<NitfHeader> {
+
+    /*
+     * Normalized attributes. These taxonomy terms will be duplicated by `ext.nitf.*` when
+     * appropriate
+     */
+
     FILE_PROFILE_NAME(Media.FORMAT,
             "FHDR",
             header -> header.getFileType()
                     .name(),
-            new MediaAttributes().getAttributeDescriptor(Media.FORMAT)),
+            new MediaAttributes().getAttributeDescriptor(Media.FORMAT),
+            "fileProfileName"),
     FILE_VERSION(Media.FORMAT_VERSION,
             "FVER",
             header -> header.getFileType()
                     .name(),
-            new MediaAttributes().getAttributeDescriptor(Media.FORMAT_VERSION)),
+            new MediaAttributes().getAttributeDescriptor(Media.FORMAT),
+            "fileVersion"),
     ORIGINATING_STATION_ID(Isr.ORGANIZATIONAL_UNIT,
             "OSTAID",
             NitfHeader::getOriginatingStationId,
-            new IsrAttributes().getAttributeDescriptor(Isr.ORGANIZATIONAL_UNIT)),
+            new IsrAttributes().getAttributeDescriptor(Isr.ORGANIZATIONAL_UNIT),
+            "originatingStationId"),
     FILE_TITLE(Core.TITLE,
             "FTITLE",
             NitfHeader::getFileTitle,
-            new CoreAttributes().getAttributeDescriptor(Core.TITLE)),
+            new CoreAttributes().getAttributeDescriptor(Core.TITLE),
+            "fileTitle"),
     FILE_DATE_AND_TIME_CREATED(Core.CREATED,
             "FDT",
             header -> convertNitfDate(header.getFileDateTime()),
-            new CoreAttributes().getAttributeDescriptor(Core.CREATED)),
+            new CoreAttributes().getAttributeDescriptor(Core.CREATED),
+            "fileDateAndTime"),
     FILE_DATE_AND_TIME_MODIFIED(Core.MODIFIED,
             "FDT",
             header -> convertNitfDate(header.getFileDateTime()),
-            new CoreAttributes().getAttributeDescriptor(Core.MODIFIED)),
+            new CoreAttributes().getAttributeDescriptor(Core.MODIFIED),
+            ""),
     FILE_DATE_AND_TIME_EFFECTIVE(Metacard.EFFECTIVE,
             "FDT",
             header -> convertNitfDate(header.getFileDateTime()),
-            new AttributeDescriptorImpl(Metacard.EFFECTIVE, true, true, false, false, BasicTypes.DATE_TYPE)),
+            new AttributeDescriptorImpl(Metacard.EFFECTIVE, true, /* indexed */
+                    true, /* stored */
+                    false, /* tokenized */
+                    false, /* multivalued */
+                    BasicTypes.DATE_TYPE),
+            ""),
     FILE_SECURITY_CLASSIFICATION(Security.CLASSIFICATION,
             "FSCLAS",
             header -> header.getFileSecurityMetadata()
                     .getSecurityClassification()
                     .name(),
-            new SecurityAttributes().getAttributeDescriptor(Security.CLASSIFICATION)),
+            new SecurityAttributes().getAttributeDescriptor(Security.CLASSIFICATION),
+            "fileSecurityClassification"),
     FILE_CLASSIFICATION_SECURITY_SYSTEM(Security.CLASSIFICATION_SYSTEM,
             "FSCLSY",
             header -> header.getFileSecurityMetadata()
                     .getSecurityClassificationSystem(),
-            new SecurityAttributes().getAttributeDescriptor(Security.CLASSIFICATION_SYSTEM)),
+            new SecurityAttributes().getAttributeDescriptor(Security.CLASSIFICATION_SYSTEM),
+            "fileClassificationSecuritySystem"),
     FILE_CODE_WORDS(Security.CODEWORDS,
             "FSCODE",
             header -> header.getFileSecurityMetadata()
                     .getCodewords(),
-            new SecurityAttributes().getAttributeDescriptor(Security.CODEWORDS)),
+            new SecurityAttributes().getAttributeDescriptor(Security.CODEWORDS),
+            "fileCodewords"),
     FILE_CONTROL_AND_HANDLING(Security.DISSEMINATION_CONTROLS,
             "FSCTLH",
             header -> header.getFileSecurityMetadata()
                     .getControlAndHandling(),
-            new SecurityAttributes().getAttributeDescriptor(Security.DISSEMINATION_CONTROLS)),
+            new SecurityAttributes().getAttributeDescriptor(Security.DISSEMINATION_CONTROLS),
+            "fileControlAndHandling"),
     FILE_RELEASING_INSTRUCTIONS(Security.RELEASABILITY,
             "FSREL",
             header -> header.getFileSecurityMetadata()
                     .getReleaseInstructions(),
-            new SecurityAttributes().getAttributeDescriptor(Security.RELEASABILITY)),
+            new SecurityAttributes().getAttributeDescriptor(Security.RELEASABILITY),
+            "fileReleasingInstructions"),
     ORIGINATORS_NAME(Contact.CREATOR_NAME,
             "ONAME",
             NitfHeader::getOriginatorsName,
-            new ContactAttributes().getAttributeDescriptor(Contact.CREATOR_NAME)),
+            new ContactAttributes().getAttributeDescriptor(Contact.CREATOR_NAME),
+            "originatorsName"),
     ORIGINATORS_PHONE_NUMBER(Contact.CREATOR_PHONE,
             "OPHONE",
             NitfHeader::getOriginatorsPhoneNumber,
-            new ContactAttributes().getAttributeDescriptor(Contact.CREATOR_PHONE));
+            new ContactAttributes().getAttributeDescriptor(Contact.CREATOR_PHONE),
+            "originatorsPhoneNumber"),
+
+    /*
+     * Non normalized attributes
+     */
+
+    COMPLEXITY_LEVEL("complexityLevel",
+            "CLEVEL",
+            NitfHeader::getComplexityLevel,
+            BasicTypes.INTEGER_TYPE),
+    FILE_DATE_AND_TIME("fileDateAndTime",
+            "FDT",
+            header -> convertNitfDate(header.getFileDateTime()),
+            BasicTypes.DATE_TYPE),
+    STANDARD_TYPE("standardType", "STYPE", NitfHeader::getStandardType, BasicTypes.STRING_TYPE),
+    FILE_DECLASSIFICATION_EXEMPTION("fileDeclassificationExemption",
+            "FSDCXM",
+            header -> header.getFileSecurityMetadata()
+                    .getDeclassificationExemption(),
+            BasicTypes.STRING_TYPE),
+    FILE_DECLASSIFICATION_TYPE("fileDeclassificationType",
+            "FSDCTP",
+            header -> header.getFileSecurityMetadata()
+                    .getDeclassificationType(),
+            BasicTypes.STRING_TYPE),
+    FILE_DECLASSIFICATION_DATE("fileDeclassificationDate",
+            "FSDCDT",
+            header -> header.getFileSecurityMetadata()
+                    .getDeclassificationDate(),
+            BasicTypes.STRING_TYPE),
+    FILE_DOWNGRADE("fileDowngrade",
+            "FSDG",
+            header -> header.getFileSecurityMetadata()
+                    .getDowngrade(),
+            BasicTypes.STRING_TYPE),
+    FILE_DOWNGRADE_DATE("fileDowngradeDate",
+            "FSDGDT",
+            header -> header.getFileSecurityMetadata()
+                    .getDowngradeDate(),
+            BasicTypes.STRING_TYPE),
+    FILE_CLASSIFICATION_TEXT("fileClassificationText",
+            "FSCLTX",
+            header -> header.getFileSecurityMetadata()
+                    .getClassificationText(),
+            BasicTypes.STRING_TYPE),
+    FILE_CLASSIFICATION_AUTHORITY_TYPE("fileClassificationAuthorityType",
+            "FSCATP",
+            header -> header.getFileSecurityMetadata()
+                    .getClassificationAuthorityType(),
+            BasicTypes.STRING_TYPE),
+    FILE_CLASSIFICATION_AUTHORITY("fileClassificationAuthority",
+            "FSCAUT",
+            header -> header.getFileSecurityMetadata()
+                    .getClassificationAuthority(),
+            BasicTypes.STRING_TYPE),
+    FILE_CLASSIFICATION_REASON("fileClassificationReason",
+            "FSCRSN",
+            header -> header.getFileSecurityMetadata()
+                    .getClassificationReason(),
+            BasicTypes.STRING_TYPE),
+    FILE_SECURITY_SOURCE_DATE("fileSecuritySourceDate",
+            "FSSRDT",
+            header -> header.getFileSecurityMetadata()
+                    .getSecuritySourceDate(),
+            BasicTypes.STRING_TYPE),
+    FILE_SECURITY_CONTROL_NUMBER("fileSecurityControlNumber",
+            "FSCTLN",
+            header -> header.getFileSecurityMetadata()
+                    .getSecurityControlNumber(),
+            BasicTypes.STRING_TYPE),
+    FILE_COPY_NUMBER("fileCopyNumber",
+            "FSCOP",
+            header -> header.getFileSecurityMetadata()
+                    .getFileCopyNumber(),
+            BasicTypes.STRING_TYPE),
+    FILE_NUMBER_OF_COPIES("fileNumberOfCopies",
+            "FSCPYS",
+            header -> header.getFileSecurityMetadata()
+                    .getFileNumberOfCopies(),
+            BasicTypes.STRING_TYPE),
+    FILE_BACKGROUND_COLOR("fileBackgroundColor",
+            "FBKGC",
+            header -> header.getFileBackgroundColour() != null ?
+                    header.getFileBackgroundColour()
+                            .toString() :
+                    "",
+            BasicTypes.STRING_TYPE);
 
     private String shortName;
 
@@ -112,17 +227,39 @@ public enum NitfHeaderAttribute implements NitfAttribute<NitfHeader> {
 
     private Function<NitfHeader, Serializable> accessorFunction;
 
-    private AttributeDescriptor attributeDescriptor;
+    private Set<AttributeDescriptor> attributeDescriptors;
 
-    NitfHeaderAttribute(final String lName,
-                        final String sName,
-                        final Function<NitfHeader, Serializable> function,
-                        AttributeDescriptor attributeDescriptor) {
+    /*
+     * Used only for Nitf attributes that do not map to the taxonomy.
+     */
+    private NitfHeaderAttribute(final String lName, final String sName,
+            final Function<NitfHeader, Serializable> function, AttributeType attributeType) {
+        this(lName,
+                sName,
+                function,
+                new AttributeDescriptorImpl(ExtNitfUtility.EXT_NITF_PREFIX + lName,
+                        true, /* indexed */
+                        true, /* stored */
+                        false, /* tokenized */
+                        false, /* multivalued */
+                        attributeType),
+                "");
+    }
+
+    NitfHeaderAttribute(final String lName, final String sName,
+            final Function<NitfHeader, Serializable> function,
+            AttributeDescriptor attributeDescriptor, String extNitfName) {
         this.shortName = sName;
         this.longName = lName;
         this.accessorFunction = function;
         // retrieving metacard attribute descriptor for this attribute to prevent later lookups
-        this.attributeDescriptor = attributeDescriptor;
+        this.attributeDescriptors = new HashSet<>();
+        this.attributeDescriptors.add(attributeDescriptor);
+        if (StringUtils.isNotEmpty(extNitfName)) {
+            this.attributeDescriptors.add(ExtNitfUtility.createDuplicateDescriptorAndRename(
+                    extNitfName,
+                    attributeDescriptor));
+        }
     }
 
     /**
@@ -153,8 +290,8 @@ public enum NitfHeaderAttribute implements NitfAttribute<NitfHeader> {
      * {@inheritDoc}
      */
     @Override
-    public AttributeDescriptor getAttributeDescriptor() {
-        return this.attributeDescriptor;
+    public Set<AttributeDescriptor> getAttributeDescriptors() {
+        return this.attributeDescriptors;
     }
 
     /**

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/SegmentHandler.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/SegmentHandler.java
@@ -16,12 +16,12 @@ package org.codice.alliance.transformer.nitf.common;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.codice.imaging.nitf.core.common.TaggedRecordExtensionHandler;
 import org.codice.imaging.nitf.core.tre.Tre;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,23 +58,32 @@ public class SegmentHandler {
         Function<T, Serializable> accessor = attribute.getAccessorFunction();
         Serializable value = accessor.apply(segment);
 
-        AttributeDescriptor descriptor = attribute.getAttributeDescriptor();
+        Set<AttributeDescriptor> descriptors = attribute.getAttributeDescriptors();
 
-        if (descriptor == null) {
+        if (descriptors == null) {
             LOGGER.debug("Could not set metacard attribute " + attribute.getLongName()
                     + " since it does not belong to this metacard type");
             return;
         }
 
-        if (descriptor.getType().equals(BasicTypes.STRING_TYPE) && value != null
-                && ((String) value).length() == 0) {
-            value = null;
+        for (AttributeDescriptor descriptor : descriptors) {
+            if (descriptor.getType()
+                    .equals(BasicTypes.STRING_TYPE) && value != null && value.toString()
+                    .length() == 0) {
+                value = null;
+            }
         }
 
-        if (value != null) {
-            Attribute catalogAttribute = populateAttribute(metacard, descriptor.getName(), value);
-            LOGGER.trace("Setting the metacard attribute [{}, {}]", descriptor.getName(), value);
-            metacard.setAttribute(catalogAttribute);
+        for (AttributeDescriptor descriptor : descriptors) {
+            if (value != null) {
+                Attribute catalogAttribute = populateAttribute(metacard,
+                        descriptor.getName(),
+                        value);
+                LOGGER.trace("Setting the metacard attribute [{}, {}]",
+                        descriptor.getName(),
+                        value);
+                metacard.setAttribute(catalogAttribute);
+            }
         }
     }
 

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/gmti/GmtiMetacardType.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/gmti/GmtiMetacardType.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.transformer.nitf.gmti;
+
+import org.codice.alliance.catalog.core.api.impl.types.IsrAttributes;
+import org.codice.alliance.catalog.core.api.impl.types.SecurityAttributes;
+import org.codice.alliance.transformer.nitf.AbstractNitfMetacardType;
+import org.codice.alliance.transformer.nitf.common.AcftbAttribute;
+import org.codice.alliance.transformer.nitf.common.NitfHeaderAttribute;
+
+import ddf.catalog.data.impl.types.AssociationsAttributes;
+import ddf.catalog.data.impl.types.ContactAttributes;
+import ddf.catalog.data.impl.types.CoreAttributes;
+import ddf.catalog.data.impl.types.DateTimeAttributes;
+import ddf.catalog.data.impl.types.LocationAttributes;
+import ddf.catalog.data.impl.types.MediaAttributes;
+import ddf.catalog.data.impl.types.ValidationAttributes;
+
+public class GmtiMetacardType extends AbstractNitfMetacardType {
+    private static final String NAME = "isr.gmti";
+
+    public GmtiMetacardType() {
+        super(NAME, null);
+        this.initDescriptors();
+    }
+
+    @Override
+    public void initDescriptors() {
+        descriptors.addAll(getDescriptors(NitfHeaderAttribute.values()));
+        descriptors.addAll(getDescriptors(AcftbAttribute.values()));
+        descriptors.addAll(getDescriptors(IndexedMtirpbAttribute.values()));
+        descriptors.addAll(getDescriptors(MtirpbAttribute.values()));
+        descriptors.addAll(new CoreAttributes().getAttributeDescriptors());
+        descriptors.addAll(new AssociationsAttributes().getAttributeDescriptors());
+        descriptors.addAll(new ContactAttributes().getAttributeDescriptors());
+        descriptors.addAll(new MediaAttributes().getAttributeDescriptors());
+        descriptors.addAll(new DateTimeAttributes().getAttributeDescriptors());
+        descriptors.addAll(new LocationAttributes().getAttributeDescriptors());
+        descriptors.addAll(new ValidationAttributes().getAttributeDescriptors());
+        descriptors.addAll(new IsrAttributes().getAttributeDescriptors());
+        descriptors.addAll(new SecurityAttributes().getAttributeDescriptors());
+    }
+}

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/gmti/MtirpbAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/gmti/MtirpbAttribute.java
@@ -14,10 +14,14 @@
 package org.codice.alliance.transformer.nitf.gmti;
 
 import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.Function;
 
+import org.apache.commons.lang.StringUtils;
 import org.codice.alliance.catalog.core.api.impl.types.IsrAttributes;
 import org.codice.alliance.catalog.core.api.types.Isr;
+import org.codice.alliance.transformer.nitf.ExtNitfUtility;
 import org.codice.alliance.transformer.nitf.common.NitfAttribute;
 import org.codice.alliance.transformer.nitf.common.TreUtility;
 import org.codice.imaging.nitf.core.tre.Tre;
@@ -25,19 +29,56 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import ddf.catalog.data.AttributeDescriptor;
-import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.impl.AttributeDescriptorImpl;
+import ddf.catalog.data.impl.BasicTypes;
 
 public enum MtirpbAttribute implements NitfAttribute<Tre> {
-    AIRCRAFT_LOCATION(Isr.DWELL_LOCATION,
-            "ACFT_LOC",
-            tre -> TreUtility.getTreValue(tre, "ACFT_LOC"),
-            new IsrAttributes()),
+
+    /*
+     * Normalized attributes. These taxonomy terms will be duplicated by `ext.nitf.mtirpb.*` when
+     * appropriate
+     */
+
     NUMBER_OF_VALID_TARGETS(Isr.TARGET_REPORT_COUNT,
             "NO_VALID_TARGETS",
             tre -> TreUtility.getTreValue(tre, "NO_VALID_TARGETS"),
-            new IsrAttributes());
+            new IsrAttributes().getAttributeDescriptor(Isr.TARGET_REPORT_COUNT),
+            "numberOfValidTargets"),
+
+    /*
+     * Non-normalized attributes
+     */
+
+    AIRCRAFT_LOCATION("aircraftLocation",
+            "ACFT_LOC",
+            tre -> TreUtility.getTreValue(tre, "ACFT_LOC")),
+    AIRCRAFT_ALTITUDE("aircraftAltitude",
+            "ACFT_ALT",
+            tre -> TreUtility.getTreValue(tre, "ACFT_ALT")),
+    AIRCRAFT_ALTITUDE_UNITS("aircraftAltitudeUnitOfMeasure",
+            "ACFT_ALT_UNIT",
+            tre -> TreUtility.getTreValue(tre, "ACFT_ALT_UNIT")),
+    AIRCRAFT_HEADING("aircraftHeading",
+            "ACFT_HEADING",
+            tre -> TreUtility.getTreValue(tre, "ACFT_HEADING")),
+    COSINE_OF_GRAZE_ANGLE("cosineOfGrazeAngle",
+            "COSGRZ",
+            tre -> TreUtility.getTreValue(tre, "COSGRZ")),
+    DESTINATION_POINT("destinationPoint", "MTI_DP", tre -> TreUtility.getTreValue(tre, "MTI_DP")),
+    MTI_LR("mtiLeftOrRight", "MTI_LR", tre -> TreUtility.getTreValue(tre, "MTI_LR")),
+    PATCH_NUMBER("patchNumber", "PATCH_NO", tre -> TreUtility.getTreValue(tre, "PATCH_NO")),
+    SCAN_DATE_AND_TIME("scanDateAndTime", "DATIME", tre -> TreUtility.getTreValue(tre, "DATIME")),
+    SQUINT_ANGLE("squintAngle", "SQUINT_ANGLE", tre -> TreUtility.getTreValue(tre, "SQUINT_ANGLE")),
+    WIDE_AREA_MTI_FRAME_NUMBER("wideAreaMtiFrameNumber",
+            "WAMTI_FRAME_NO",
+            tre -> TreUtility.getTreValue(tre, "WAMTI_FRAME_NO")),
+    WIDE_AREA_MTI_BAR_NUMBER("wideAreaMtiBarNumber",
+            "WAMTI_BAR_NO",
+            tre -> TreUtility.getTreValue(tre, "WAMTI_BAR_NO"));
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MtirpbAttribute.class);
+
+    private static final String ATTRIBUTE_NAME_PREFIX = "mtirpb.";
 
     private String shortName;
 
@@ -45,15 +86,37 @@ public enum MtirpbAttribute implements NitfAttribute<Tre> {
 
     private Function<Tre, Serializable> accessorFunction;
 
-    private AttributeDescriptor attributeDescriptor;
+    private Set<AttributeDescriptor> attributeDescriptors;
 
-    MtirpbAttribute(String longName, String shortName, Function<Tre, Serializable> accessorFunction,
-            MetacardType metacardType) {
+    MtirpbAttribute(String longName, String shortName,
+            Function<Tre, Serializable> accessorFunction) {
         this.longName = longName;
         this.shortName = shortName;
         this.accessorFunction = accessorFunction;
         // retrieving metacard attribute descriptor for this attribute to prevent later lookups
-        this.attributeDescriptor = metacardType.getAttributeDescriptor(longName);
+        this.attributeDescriptors = new HashSet<>();
+        this.attributeDescriptors.add(new AttributeDescriptorImpl(
+                ExtNitfUtility.EXT_NITF_PREFIX + ATTRIBUTE_NAME_PREFIX + longName,
+                true, /* indexed */
+                true, /* stored */
+                false, /* tokenized */
+                true, /* multivalued */
+                BasicTypes.STRING_TYPE));
+    }
+
+    MtirpbAttribute(String longName, String shortName, Function<Tre, Serializable> accessorFunction,
+            AttributeDescriptor attributeDescriptor, String extNitfName) {
+        this.longName = longName;
+        this.shortName = shortName;
+        this.accessorFunction = accessorFunction;
+        // retrieving metacard attribute descriptor for this attribute to prevent later lookups
+        this.attributeDescriptors = new HashSet<>();
+        this.attributeDescriptors.add(attributeDescriptor);
+        if (StringUtils.isNotEmpty(extNitfName)) {
+            this.attributeDescriptors.add(ExtNitfUtility.createDuplicateDescriptorAndRename(
+                    ATTRIBUTE_NAME_PREFIX + extNitfName,
+                    attributeDescriptor));
+        }
     }
 
     @Override
@@ -72,7 +135,7 @@ public enum MtirpbAttribute implements NitfAttribute<Tre> {
     }
 
     @Override
-    public AttributeDescriptor getAttributeDescriptor() {
-        return this.attributeDescriptor;
+    public Set<AttributeDescriptor> getAttributeDescriptors() {
+        return this.attributeDescriptors;
     }
 }

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/GraphicAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/GraphicAttribute.java
@@ -1,0 +1,208 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.transformer.nitf.image;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+import org.codice.alliance.transformer.nitf.ExtNitfUtility;
+import org.codice.alliance.transformer.nitf.common.NitfAttribute;
+import org.codice.imaging.nitf.core.graphic.GraphicSegment;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.AttributeType;
+import ddf.catalog.data.impl.AttributeDescriptorImpl;
+import ddf.catalog.data.impl.BasicTypes;
+
+/**
+ * NitfAttributes to represent the properties of a GraphicSegment.
+ */
+public enum GraphicAttribute implements NitfAttribute<GraphicSegment> {
+    FILE_PART_TYPE("filePartType", "SY", segment -> "SY"),
+    GRAPHIC_IDENTIFIER("graphicIdentifier", "SID", GraphicSegment::getIdentifier),
+    GRAPHIC_NAME("graphicName", "SNAME", GraphicSegment::getGraphicName),
+    GRAPHIC_SECURITY_CLASSIFICATION("graphicSecurityClassification",
+            "SSCLAS",
+            segment -> segment.getSecurityMetadata()
+                    .getSecurityClassification()
+                    .name()),
+    GRAPHIC_CLASSIFICATION_SECURITY_SYSTEM("graphicClassificationSecuritySystem",
+            "SSCLSY",
+            segment -> segment.getSecurityMetadata()
+                    .getSecurityClassificationSystem()),
+    GRAPHIC_CODEWORDS("graphicCodewords",
+            "SSCODE",
+            segment -> segment.getSecurityMetadata()
+                    .getCodewords()),
+    GRAPHIC_CONTROL_AND_HANDLING("graphicControlAndHandling",
+            "SSCTLH",
+            segment -> segment.getSecurityMetadata()
+                    .getControlAndHandling()),
+    GRAPHIC_RELEASING_INSTRUCTIONS("graphicReleasingInstructions",
+            "SSREL",
+            segment -> segment.getSecurityMetadata()
+                    .getReleaseInstructions()),
+    GRAPHIC_DECLASSIFICATION_TYPE("graphicDeclassificationType",
+            "SSDCTP",
+            segment -> segment.getSecurityMetadata()
+                    .getDeclassificationType()),
+    GRAPHIC_DECLASSIFICATION_DATE("graphicDeclassificationDate",
+            "SSDCDT",
+            segment -> segment.getSecurityMetadata()
+                    .getDeclassificationDate()),
+    GRAPHIC_DECLASSIFICATION_EXEMPTION("graphicDeclassificationExemption",
+            "SSDCXM",
+            segment -> segment.getSecurityMetadata()
+                    .getDeclassificationExemption()),
+    GRAPHIC_DOWNGRADE("graphicDowngrade",
+            "SSDG",
+            segment -> segment.getSecurityMetadata()
+                    .getDowngrade()),
+    GRAPHIC_DOWNGRADE_DATE("graphicDowngradeDate",
+            "SSDGDT",
+            segment -> segment.getSecurityMetadata()
+                    .getDowngradeDate()),
+    GRAPHIC_CLASSIFICATION_TEXT("graphicClassificationText",
+            "SSCLTX",
+            segment -> segment.getSecurityMetadata()
+                    .getClassificationText()),
+    GRAPHIC_CLASSIFICATION_AUTHORITY_TYPE("graphicClassificationAuthorityType",
+            "SSCATP",
+            segment -> segment.getSecurityMetadata()
+                    .getClassificationAuthorityType()),
+    GRAPHIC_CLASSIFICATION_AUTHORITY("graphicClassificationAuthority",
+            "SSCAUT",
+            segment -> segment.getSecurityMetadata()
+                    .getClassificationAuthority()),
+    GRAPHIC_CLASSIFICATION_REASON("graphicClassificationReason",
+            "SSCRSN",
+            segment -> segment.getSecurityMetadata()
+                    .getClassificationReason()),
+    GRAPHIC_SECURITY_SOURCE_DATE("graphicSecuritySourceDate",
+            "SSSRDT",
+            segment -> segment.getSecurityMetadata()
+                    .getSecuritySourceDate()),
+    GRAPHIC_SECURITY_CONTROL_NUMBER("graphicSecurityControlNumber",
+            "SSCTLN",
+            segment -> segment.getSecurityMetadata()
+                    .getSecurityControlNumber()),
+    GRAPHIC_DISPLAY_LEVEL("graphicDisplayLevel",
+            "SDLVL",
+            GraphicSegment::getGraphicDisplayLevel,
+            Collections.singletonList(BasicTypes.INTEGER_TYPE)),
+    GRAPHIC_ATTACHMENT_LEVEL("graphicAttachmentLevel",
+            "SALVL",
+            GraphicSegment::getAttachmentLevel,
+            Collections.singletonList(BasicTypes.INTEGER_TYPE)),
+    GRAPHIC_LOCATION("graphicLocation",
+            "SLOC",
+            segment -> segment.getGraphicLocationRow() + "," + segment.getGraphicLocationColumn()),
+    GRAPHIC_COLOR("graphicColor",
+            "SCOLOR",
+            segment -> segment.getGraphicColour()
+                    .toString()),
+    GRAPHIC_EXTENDED_SUBHEADER_DATA_LENGTH("graphicExtendedSubheaderDataLength",
+            "SXSHDL",
+            GraphicSegment::getExtendedHeaderDataOverflow,
+            Collections.singletonList(BasicTypes.INTEGER_TYPE));
+
+    public static final String ATTRIBUTE_NAME_PREFIX = "graphic.";
+
+    private String shortName;
+
+    private String longName;
+
+    private Function<GraphicSegment, Serializable> accessorFunction;
+
+    private Set<AttributeDescriptor> attributeDescriptors;
+
+    GraphicAttribute(final String lName, final String sName,
+            final Function<GraphicSegment, Serializable> accessor) {
+        this(lName, sName, accessor, Collections.singletonList(BasicTypes.STRING_TYPE));
+    }
+
+    GraphicAttribute(final String lName, final String sName,
+            final Function<GraphicSegment, Serializable> accessor,
+            final List<AttributeType> attributeTypes) {
+        this.accessorFunction = accessor;
+        this.shortName = sName;
+        this.longName = lName;
+        this.attributeDescriptors = createAttributeDescriptors(attributeTypes);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final String getShortName() {
+        return this.shortName;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final String getLongName() {
+        return this.longName;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Function<GraphicSegment, Serializable> getAccessorFunction() {
+        return this.accessorFunction;
+    }
+
+    /**
+     * Equivalent to getLongName()
+     *
+     * @return the attribute's long name.
+     */
+    @Override
+    public String toString() {
+        return this.getLongName();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<AttributeDescriptor> getAttributeDescriptors() {
+        return this.attributeDescriptors;
+    }
+
+    private Set<AttributeDescriptor> createAttributeDescriptors(
+            List<AttributeType> attributeTypes) {
+        Set<AttributeDescriptor> attributesDescriptors = new HashSet<>();
+        for (AttributeType attribute : attributeTypes) {
+            attributesDescriptors.add(createAttributeDescriptor(attribute));
+        }
+        return attributesDescriptors;
+    }
+
+    private AttributeDescriptor createAttributeDescriptor(AttributeType attributeType) {
+        return new AttributeDescriptorImpl(
+                ExtNitfUtility.EXT_NITF_PREFIX + ATTRIBUTE_NAME_PREFIX + longName,
+                true, /* indexed */
+                true, /* stored */
+                false, /* tokenized */
+                true, /* multivalued */
+                attributeType);
+    }
+}

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/ImageAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/ImageAttribute.java
@@ -16,11 +16,16 @@ package org.codice.alliance.transformer.nitf.image;
 import java.io.Serializable;
 import java.time.Instant;
 import java.time.ZonedDateTime;
+import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.Function;
 
+import org.apache.commons.lang.StringUtils;
 import org.codice.alliance.catalog.core.api.impl.types.IsrAttributes;
 import org.codice.alliance.catalog.core.api.types.Isr;
+import org.codice.alliance.transformer.nitf.ExtNitfUtility;
 import org.codice.alliance.transformer.nitf.common.NitfAttribute;
 import org.codice.imaging.nitf.core.common.DateTime;
 import org.codice.imaging.nitf.core.common.NitfFormatException;
@@ -29,7 +34,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import ddf.catalog.data.AttributeDescriptor;
-import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.AttributeType;
+import ddf.catalog.data.impl.AttributeDescriptorImpl;
+import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.types.DateTimeAttributes;
 import ddf.catalog.data.impl.types.MediaAttributes;
 import ddf.catalog.data.types.Media;
@@ -38,47 +45,246 @@ import ddf.catalog.data.types.Media;
  * NitfAttributes to represent the properties of a ImageSegment.
  */
 public enum ImageAttribute implements NitfAttribute<ImageSegment> {
+
+    /*
+     * Normalized attributes. These taxonomy terms will be duplicated by `ext.nitf.image.*` when
+     * appropriate
+     */
+
     IMAGE_DATE_AND_TIME(ddf.catalog.data.types.DateTime.START,
             "IDATIM",
             segment -> convertNitfDate(segment.getImageDateTime()),
-            new DateTimeAttributes()),
+            new DateTimeAttributes().getAttributeDescriptor(ddf.catalog.data.types.DateTime.START),
+            "imageDateAndTime"),
     TARGET_IDENTIFIER(Isr.TARGET_ID,
             "TGTID",
-            segment -> getTargetId(segment),
-            new IsrAttributes()),
+            ImageAttribute::getTargetId,
+            new IsrAttributes().getAttributeDescriptor(Isr.TARGET_ID),
+            "targetIdentifier"),
     IMAGE_IDENTIFIER_2(Isr.IMAGE_ID,
             "IID2",
             ImageSegment::getImageIdentifier2,
-            new IsrAttributes()),
+            new IsrAttributes().getAttributeDescriptor(Isr.IMAGE_ID),
+            "imageIdentifier2"),
     IMAGE_SOURCE(Isr.ORIGINAL_SOURCE,
             "ISORCE",
             ImageSegment::getImageSource,
-            new IsrAttributes()),
+            new IsrAttributes().getAttributeDescriptor(Isr.ORIGINAL_SOURCE),
+            "imageSource"),
     NUMBER_OF_SIGNIFICANT_ROWS_IN_IMAGE(Media.HEIGHT,
             "NROWS",
             ImageSegment::getNumberOfRows,
-            new MediaAttributes()),
+            new MediaAttributes().getAttributeDescriptor(Media.HEIGHT),
+            "numberOfSignificantRowsInImage"),
     NUMBER_OF_SIGNIFICANT_COLUMNS_IN_IMAGE(Media.WIDTH,
             "NCOLS",
             ImageSegment::getNumberOfColumns,
-            new MediaAttributes()),
+            new MediaAttributes().getAttributeDescriptor(Media.WIDTH),
+            "numberOfSignificantColumnsInImage"),
     IMAGE_REPRESENTATION(Media.ENCODING,
             "IREP",
             segment -> segment.getImageRepresentation()
                     .name(),
-            new MediaAttributes()),
+            new MediaAttributes().getAttributeDescriptor(Media.ENCODING),
+            "imageRepresentation"),
     IMAGE_CATEGORY(Isr.CATEGORY,
             "ICAT",
             segment -> segment.getImageCategory()
                     .name(),
-            new IsrAttributes()),
+            new IsrAttributes().getAttributeDescriptor(Isr.CATEGORY),
+            "imageCategory"),
     IMAGE_COMPRESSION(Media.COMPRESSION,
             "IC",
             segment -> segment.getImageCompression()
                     .name(),
-            new MediaAttributes());
+            new MediaAttributes().getAttributeDescriptor(Media.COMPRESSION),
+            "imageCompression"),
+
+    /*
+     * Non normalized attributes
+     */
+
+    FILE_PART_TYPE("filePartType", "IM", segment -> "IM", BasicTypes.STRING_TYPE),
+    IMAGE_IDENTIFIER_1("imageIdentifier1",
+            "IID1",
+            ImageSegment::getIdentifier,
+            BasicTypes.STRING_TYPE),
+    IMAGE_SECURITY_CLASSIFICATION("imageSecurityClassification",
+            "ISCLAS",
+            segment -> segment.getSecurityMetadata()
+                    .getSecurityClassification()
+                    .name(),
+            BasicTypes.STRING_TYPE),
+    IMAGE_CLASSIFICATION_SECURITY_SYSTEM("imageClassificationSecuritySystem",
+            "ISCLSY",
+            segment -> segment.getSecurityMetadata()
+                    .getSecurityClassificationSystem(),
+            BasicTypes.STRING_TYPE),
+    IMAGE_CODEWORDS("imageCodewords",
+            "ISCODE",
+            segment -> segment.getSecurityMetadata()
+                    .getCodewords(),
+            BasicTypes.STRING_TYPE),
+    IMAGE_CONTROL_AND_HANDLING("imageControlandHandling",
+            "ISCTLH",
+            segment -> segment.getSecurityMetadata()
+                    .getControlAndHandling(),
+            BasicTypes.STRING_TYPE),
+    IMAGE_RELEASING_INSTRUCTIONS("imageReleasingInstructions",
+            "ISREL",
+            segment -> segment.getSecurityMetadata()
+                    .getReleaseInstructions(),
+            BasicTypes.STRING_TYPE),
+    IMAGE_DECLASSIFICATION_TYPE("imageDeclassificationType",
+            "ISDCTP",
+            segment -> segment.getSecurityMetadata()
+                    .getDeclassificationType(),
+            BasicTypes.STRING_TYPE),
+    IMAGE_DECLASSIFICATION_DATE("imageDeclassificationDate",
+            "ISDCDT",
+            segment -> segment.getSecurityMetadata()
+                    .getDeclassificationDate(),
+            BasicTypes.STRING_TYPE),
+    IMAGE_DECLASSIFICATION_EXEMPTION("imageDeclassificationExemption",
+            "ISDCXM",
+            segment -> segment.getSecurityMetadata()
+                    .getDeclassificationExemption(),
+            BasicTypes.STRING_TYPE),
+    IMAGE_DOWNGRADE("imageDowngrade",
+            "ISDG",
+            segment -> segment.getSecurityMetadata()
+                    .getDowngrade(),
+            BasicTypes.STRING_TYPE),
+    IMAGE_DOWNGRADE_DATE("imageDowngradeDate",
+            "ISDGDT",
+            segment -> segment.getSecurityMetadata()
+                    .getDowngradeDate(),
+            BasicTypes.STRING_TYPE),
+    IMAGE_CLASSIFICATION_TEXT("imageClassificationText",
+            "ISCLTX",
+            segment -> segment.getSecurityMetadata()
+                    .getClassificationText(),
+            BasicTypes.STRING_TYPE),
+    IMAGE_CLASSIFICATION_AUTHORITY_TYPE("imageClassificationAuthorityType",
+            "ISCATP",
+            segment -> segment.getSecurityMetadata()
+                    .getClassificationAuthorityType(),
+            BasicTypes.STRING_TYPE),
+    IMAGE_CLASSIFICATION_AUTHORITY("imageClassificationAuthority",
+            "ISCAUT",
+            segment -> segment.getSecurityMetadata()
+                    .getClassificationAuthority(),
+            BasicTypes.STRING_TYPE),
+    IMAGE_CLASSIFICATION_REASON("imageClassificationReason",
+            "ISCRSN",
+            segment -> segment.getSecurityMetadata()
+                    .getClassificationReason(),
+            BasicTypes.STRING_TYPE),
+    IMAGE_SECURITY_SOURCE_DATE("imageSecuritySourceDate",
+            "ISSRDT",
+            segment -> segment.getSecurityMetadata()
+                    .getSecuritySourceDate(),
+            BasicTypes.STRING_TYPE),
+    IMAGE_SECURITY_CONTROL_NUMBER("imageSecurityControlNumber",
+            "ISCTLN",
+            segment -> segment.getSecurityMetadata()
+                    .getSecurityControlNumber(),
+            BasicTypes.STRING_TYPE),
+    PIXEL_VALUE_TYPE("pixelValueType",
+            "PVTYPE",
+            segment -> segment.getPixelValueType()
+                    .name(),
+            BasicTypes.STRING_TYPE),
+    ACTUAL_BITS_PER_PIXEL_PER_BAND("actualBitsPerPixelPerBand",
+            "ABPP",
+            ImageSegment::getActualBitsPerPixelPerBand,
+            BasicTypes.INTEGER_TYPE),
+    PIXEL_JUSTIFICATION("pixelJustification",
+            "PJUST",
+            segment -> segment.getPixelJustification()
+                    .name(),
+            BasicTypes.STRING_TYPE),
+    IMAGE_COORDINATE_REPRESENTATION("imageCoordinateRepresentation",
+            "ICORDS",
+            segment -> segment.getImageCoordinatesRepresentation()
+                    .name(),
+            BasicTypes.STRING_TYPE),
+    NUMBER_OF_IMAGE_COMMENTS("numberOfImageComments",
+            "NICOM",
+            segment -> segment.getImageComments()
+                    .size(),
+            BasicTypes.INTEGER_TYPE),
+    IMAGE_COMMENT_1("imageComment1",
+            "ICOM1",
+            segment -> segment.getImageComments()
+                    .size() > 0 ?
+                    segment.getImageComments()
+                            .get(0) :
+                    "",
+            BasicTypes.STRING_TYPE),
+    IMAGE_COMMENT_2("imageComment2",
+            "ICOM2",
+            segment -> segment.getImageComments()
+                    .size() > 1 ?
+                    segment.getImageComments()
+                            .get(1) :
+                    "",
+            BasicTypes.STRING_TYPE),
+    IMAGE_COMMENT_3("imageComment3",
+            "ICOM3",
+            segment -> segment.getImageComments()
+                    .size() > 2 ?
+                    segment.getImageComments()
+                            .get(2) :
+                    "",
+            BasicTypes.STRING_TYPE),
+    NUMBER_OF_BANDS("numberOfBands", "NBANDS", ImageSegment::getNumBands, BasicTypes.INTEGER_TYPE),
+    IMAGE_MODE("imageMode",
+            "IMODE",
+            segment -> segment.getImageMode()
+                    .name(),
+            BasicTypes.STRING_TYPE),
+    NUMBER_OF_BLOCKS_PER_ROW("numberOfBlocksPerRow",
+            "NBPR",
+            ImageSegment::getNumberOfBlocksPerRow,
+            BasicTypes.INTEGER_TYPE),
+    NUMBER_OF_BLOCKS_PER_COLUMN("numberOfBlocksPerColumn",
+            "NBPC",
+            ImageSegment::getNumberOfBlocksPerColumn,
+            BasicTypes.INTEGER_TYPE),
+    NUMBER_OF_PIXELS_PER_BLOCK_HORIZONTAL("numberOfPixelsPerBlockHorizontal",
+            "NPPBH",
+            ImageSegment::getNumberOfPixelsPerBlockHorizontal,
+            BasicTypes.INTEGER_TYPE),
+    NUMBER_OF_PIXELS_PER_BLOCK_VERTICAL("numberOfPixelsPerBlockVertical",
+            "NPPBV",
+            ImageSegment::getNumberOfPixelsPerBlockVertical,
+            BasicTypes.INTEGER_TYPE),
+    NUMBER_OF_BITS_PER_PIXEL("numberOfBitsPerPixel",
+            "NBPP",
+            ImageSegment::getNumberOfBitsPerPixelPerBand,
+            BasicTypes.INTEGER_TYPE),
+    IMAGE_DISPLAY_LEVEL("imageDisplayLevel",
+            "IDLVL",
+            ImageSegment::getImageDisplayLevel,
+            BasicTypes.INTEGER_TYPE),
+    IMAGE_ATTACHMENT_LEVEL("imageAttachmentLevel",
+            "IALVL",
+            ImageSegment::getAttachmentLevel,
+            BasicTypes.INTEGER_TYPE),
+    IMAGE_LOCATION("imageLocation",
+            "ILOC",
+            segment -> segment.getImageLocationRow() + "," + segment.getImageLocationColumn(),
+            BasicTypes.STRING_TYPE),
+    IMAGE_MAGNIFICATION("imageMagnification",
+            "IMAG",
+            segment -> segment.getImageMagnification()
+                    .trim(),
+            BasicTypes.STRING_TYPE);
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ImageAttribute.class);
+
+    private static final String ATTRIBUTE_NAME_PREFIX = "image.";
 
     private String shortName;
 
@@ -86,17 +292,37 @@ public enum ImageAttribute implements NitfAttribute<ImageSegment> {
 
     private Function<ImageSegment, Serializable> accessorFunction;
 
-    private AttributeDescriptor attributeDescriptor;
-    
-    ImageAttribute(final String lName,
-                   final String sName,
-                   final Function<ImageSegment, Serializable> accessor,
-                   MetacardType metacardType) {
+    private Set<AttributeDescriptor> attributeDescriptors;
+
+    ImageAttribute(final String lName, final String sName,
+            final Function<ImageSegment, Serializable> accessor, AttributeType attributeType) {
         this.accessorFunction = accessor;
         this.shortName = sName;
         this.longName = lName;
         // retrieving metacard attribute descriptor for this attribute to prevent later lookups
-        this.attributeDescriptor = metacardType.getAttributeDescriptor(longName);
+        this.attributeDescriptors = Collections.singleton(new AttributeDescriptorImpl(
+                ExtNitfUtility.EXT_NITF_PREFIX + ATTRIBUTE_NAME_PREFIX + lName,
+                true, /* indexed */
+                true, /* stored */
+                false, /* tokenized */
+                true, /* multivalued */
+                attributeType));
+    }
+
+    ImageAttribute(final String lName, final String sName,
+            final Function<ImageSegment, Serializable> accessor,
+            AttributeDescriptor attributeDescriptor, String extNitfName) {
+        this.accessorFunction = accessor;
+        this.shortName = sName;
+        this.longName = lName;
+        // retrieving metacard attribute descriptor for this attribute to prevent later lookups
+        this.attributeDescriptors = new HashSet<>();
+        this.attributeDescriptors.add(attributeDescriptor);
+        if (StringUtils.isNotEmpty(extNitfName)) {
+            this.attributeDescriptors.add(ExtNitfUtility.createDuplicateDescriptorAndRename(
+                    ATTRIBUTE_NAME_PREFIX + extNitfName,
+                    attributeDescriptor));
+        }
     }
 
     private static String getTargetId(ImageSegment imageSegment) {
@@ -158,8 +384,8 @@ public enum ImageAttribute implements NitfAttribute<ImageSegment> {
      * {@inheritDoc}
      */
     @Override
-    public AttributeDescriptor getAttributeDescriptor() {
-        return this.attributeDescriptor;
+    public Set<AttributeDescriptor> getAttributeDescriptors() {
+        return this.attributeDescriptors;
     }
 
     /**

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/ImageMetacardType.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/ImageMetacardType.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.transformer.nitf.image;
+
+import org.codice.alliance.catalog.core.api.impl.types.IsrAttributes;
+import org.codice.alliance.catalog.core.api.impl.types.SecurityAttributes;
+import org.codice.alliance.transformer.nitf.AbstractNitfMetacardType;
+import org.codice.alliance.transformer.nitf.common.AcftbAttribute;
+import org.codice.alliance.transformer.nitf.common.NitfHeaderAttribute;
+import org.codice.alliance.transformer.nitf.gmti.IndexedMtirpbAttribute;
+import org.codice.alliance.transformer.nitf.gmti.MtirpbAttribute;
+
+import ddf.catalog.data.impl.types.AssociationsAttributes;
+import ddf.catalog.data.impl.types.ContactAttributes;
+import ddf.catalog.data.impl.types.CoreAttributes;
+import ddf.catalog.data.impl.types.DateTimeAttributes;
+import ddf.catalog.data.impl.types.LocationAttributes;
+import ddf.catalog.data.impl.types.MediaAttributes;
+import ddf.catalog.data.impl.types.ValidationAttributes;
+
+public class ImageMetacardType extends AbstractNitfMetacardType {
+    private static final String NAME = "isr.image";
+
+    public ImageMetacardType() {
+        super(NAME, null);
+        this.initDescriptors();
+    }
+
+    @Override
+    public void initDescriptors() {
+        descriptors.addAll(getDescriptors(GraphicAttribute.values()));
+        descriptors.addAll(getDescriptors(ImageAttribute.values()));
+        descriptors.addAll(getDescriptors(LabelAttribute.values()));
+        descriptors.addAll(getDescriptors(SymbolAttribute.values()));
+        descriptors.addAll(getDescriptors(TextAttribute.values()));
+        descriptors.addAll(getDescriptors(NitfHeaderAttribute.values()));
+        descriptors.addAll(getDescriptors(AcftbAttribute.values()));
+        descriptors.addAll(getDescriptors(IndexedMtirpbAttribute.values()));
+        descriptors.addAll(getDescriptors(MtirpbAttribute.values()));
+        descriptors.addAll(new CoreAttributes().getAttributeDescriptors());
+        descriptors.addAll(new AssociationsAttributes().getAttributeDescriptors());
+        descriptors.addAll(new ContactAttributes().getAttributeDescriptors());
+        descriptors.addAll(new MediaAttributes().getAttributeDescriptors());
+        descriptors.addAll(new DateTimeAttributes().getAttributeDescriptors());
+        descriptors.addAll(new LocationAttributes().getAttributeDescriptors());
+        descriptors.addAll(new ValidationAttributes().getAttributeDescriptors());
+        descriptors.addAll(new IsrAttributes().getAttributeDescriptors());
+        descriptors.addAll(new SecurityAttributes().getAttributeDescriptors());
+    }
+}

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/LabelAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/LabelAttribute.java
@@ -1,0 +1,189 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.transformer.nitf.image;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+import org.codice.alliance.transformer.nitf.ExtNitfUtility;
+import org.codice.alliance.transformer.nitf.common.NitfAttribute;
+import org.codice.imaging.nitf.core.label.LabelSegment;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.AttributeType;
+import ddf.catalog.data.impl.AttributeDescriptorImpl;
+import ddf.catalog.data.impl.BasicTypes;
+
+/**
+ * NitfAttributes to represent the properties of a LabelSegmentHeader.
+ */
+public enum LabelAttribute implements NitfAttribute<LabelSegment> {
+    FILE_PART_TYPE("filePartType", "LA", segment -> "LA"),
+    LABEL_ID("labelID", "LID", LabelSegment::getIdentifier),
+    LABEL_SECURITY_CLASSIFICATION("labelSecurityClassification",
+            "LSCLAS",
+            segment -> segment.getSecurityMetadata()
+                    .getSecurityClassification()
+                    .name()),
+    LABEL_CODEWORDS("labelCodewords",
+            "LSCODE",
+            segment -> segment.getSecurityMetadata()
+                    .getCodewords()),
+    LABEL_CONTROL_AND_HANDLING("labelControlandHandling",
+            "LSCTLH",
+            segment -> segment.getSecurityMetadata()
+                    .getControlAndHandling()),
+    LABEL_RELEASING_INSTRUCTIONS("labelReleasingInstructions",
+            "LSREL",
+            segment -> segment.getSecurityMetadata()
+                    .getReleaseInstructions()),
+    LABEL_CLASSIFICATION_AUTHORITY("labelClassificationAuthority",
+            "LSCAUT",
+            segment -> segment.getSecurityMetadata()
+                    .getClassificationAuthority()),
+    LABEL_SECURITY_CONTROL_NUMBER("labelSecurityControlNumber",
+            "LSCTLN",
+            segment -> segment.getSecurityMetadata()
+                    .getSecurityControlNumber()),
+    LABEL_SECURITY_DOWNGRADE("labelSecurityDowngrade",
+            "LSDWNG",
+            segment -> segment.getSecurityMetadata()
+                    .getDowngrade()),
+    LABEL_DOWNGRADING_EVENT("labelDowngradingEvent",
+            "LSDEVT",
+            segment -> segment.getSecurityMetadata()
+                    .getDowngradeEvent()),
+    LABEL_CELL_WIDTH("labelCellWidth",
+            "LCW",
+            LabelSegment::getLabelCellWidth,
+            Collections.singletonList(BasicTypes.INTEGER_TYPE)),
+    LABEL_CELL_HEIGHT("labelCellHeight",
+            "LCH",
+            LabelSegment::getLabelCellHeight,
+            Collections.singletonList(BasicTypes.INTEGER_TYPE)),
+    LABEL_DISPLAY_LEVEL("labelDisplayLevel",
+            "LDLVL",
+            LabelSegment::getLabelDisplayLevel,
+            Collections.singletonList(BasicTypes.INTEGER_TYPE)),
+    ATTACHMENT_LEVEL("attachmentLevel",
+            "LALVL",
+            LabelSegment::getAttachmentLevel,
+            Collections.singletonList(BasicTypes.INTEGER_TYPE)),
+    LABEL_LOCATION("labelLocation",
+            "LLOC",
+            segment -> String.format("%s,%s",
+                    segment.getLabelLocationRow(),
+                    segment.getLabelLocationColumn())),
+    LABEL_TEXT_COLOR("labelTextColor",
+            "LTC",
+            segment -> segment.getLabelTextColour()
+                    .toString()),
+    LABEL_BACKGROUND_COLOR("labelBackgroundColor",
+            "LBC",
+            segment -> segment.getLabelBackgroundColour()
+                    .toString()),
+    EXTENDED_SUBHEADER_DATA_LENGTH("extendedSubheaderDataLength",
+            "LXSHDL",
+            LabelSegment::getExtendedHeaderDataOverflow,
+            Collections.singletonList(BasicTypes.INTEGER_TYPE));
+
+    public static final String ATTRIBUTE_NAME_PREFIX = "label.";
+
+    private String shortName;
+
+    private String longName;
+
+    private Function<LabelSegment, Serializable> accessorFunction;
+
+    private Set<AttributeDescriptor> attributeDescriptors;
+
+    LabelAttribute(final String lName, final String sName,
+            final Function<LabelSegment, Serializable> accessor) {
+        this(lName, sName, accessor, Collections.singletonList(BasicTypes.STRING_TYPE));
+    }
+
+    LabelAttribute(final String lName, final String sName,
+            final Function<LabelSegment, Serializable> accessor,
+            List<AttributeType> attributeTypes) {
+        this.accessorFunction = accessor;
+        this.shortName = sName;
+        this.longName = lName;
+        this.attributeDescriptors = createAttributeDescriptors(attributeTypes);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final String getShortName() {
+        return this.shortName;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final String getLongName() {
+        return this.longName;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Function<LabelSegment, Serializable> getAccessorFunction() {
+        return accessorFunction;
+    }
+
+    /**
+     * Equivalent to getLongName()
+     *
+     * @return the attribute's long name.
+     */
+    @Override
+    public String toString() {
+        return getLongName();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<AttributeDescriptor> getAttributeDescriptors() {
+        return this.attributeDescriptors;
+    }
+
+    private Set<AttributeDescriptor> createAttributeDescriptors(
+            List<AttributeType> attributeTypes) {
+        Set<AttributeDescriptor> attributesDescriptors = new HashSet<>();
+        for (AttributeType attribute : attributeTypes) {
+            attributesDescriptors.add(createAttributeDescriptor(attribute));
+        }
+        return attributesDescriptors;
+    }
+
+    private AttributeDescriptor createAttributeDescriptor(AttributeType attributeType) {
+        return new AttributeDescriptorImpl(
+                ExtNitfUtility.EXT_NITF_PREFIX + ATTRIBUTE_NAME_PREFIX + longName,
+                true, /* indexed */
+                true, /* stored */
+                false, /* tokenized */
+                true, /* multivalued */
+                attributeType);
+    }
+}

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/NitfImageTransformer.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/NitfImageTransformer.java
@@ -71,7 +71,20 @@ public class NitfImageTransformer extends SegmentHandler {
 
         nitfSegmentsFlow.forEachImageSegment(segment -> handleImageSegmentHeader(metacard,
                 segment,
-                polygonList));
+                polygonList))
+                .forEachGraphicSegment(segment -> handleSegmentHeader(metacard,
+                        segment,
+                        GraphicAttribute.values()))
+                .forEachTextSegment(segment -> handleSegmentHeader(metacard,
+                        segment,
+                        TextAttribute.values()))
+                .forEachSymbolSegment(segment -> handleSegmentHeader(metacard,
+                        segment,
+                        SymbolAttribute.values()))
+                .forEachLabelSegment(segment -> handleSegmentHeader(metacard,
+                        segment,
+                        LabelAttribute.values()))
+                .end();
 
         // Set GEOGRAPHY from discovered polygons
         if (polygonList.size() == 1) {
@@ -141,7 +154,7 @@ public class NitfImageTransformer extends SegmentHandler {
                         }
                     });
 
-            LOGGER.debug("Setting the metacard attribute [{}, {}]", Isr.COMMENTS, sb.toString());
+            LOGGER.trace("Setting the metacard attribute [{}, {}]", Isr.COMMENTS, sb.toString());
             metacard.setAttribute(new AttributeImpl(Isr.COMMENTS, sb.toString()));
         }
     }

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/SymbolAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/SymbolAttribute.java
@@ -1,0 +1,208 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.transformer.nitf.image;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+import org.codice.alliance.transformer.nitf.ExtNitfUtility;
+import org.codice.alliance.transformer.nitf.common.NitfAttribute;
+import org.codice.imaging.nitf.core.symbol.SymbolSegment;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.AttributeType;
+import ddf.catalog.data.impl.AttributeDescriptorImpl;
+import ddf.catalog.data.impl.BasicTypes;
+
+/**
+ * NitfAttributes to represent the properties of a SymbolSegment.
+ */
+public enum SymbolAttribute implements NitfAttribute<SymbolSegment> {
+    FILE_PART_TYPE("filePartType", "SY", segment -> "SY"),
+    SYMBOL_ID("symbolID", "SID", SymbolSegment::getIdentifier),
+    SYMBOL_NAME("symbolName", "SNAME", SymbolSegment::getSymbolName),
+    SYMBOL_SECURITY_CLASSIFICATION("symbolSecurityClassification",
+            "SSCLAS",
+            segment -> segment.getSecurityMetadata()
+                    .getSecurityClassification()
+                    .name()),
+    SYMBOL_CODEWORDS("symbolCodewords",
+            "SSCODE",
+            segment -> segment.getSecurityMetadata()
+                    .getCodewords()),
+    SYMBOL_CONTROL_AND_HANDLING("symbolControlandHandling",
+            "SSCTLH",
+            segment -> segment.getSecurityMetadata()
+                    .getControlAndHandling()),
+    SYMBOL_RELEASING_INSTRUCTIONS("symbolReleasingInstructions",
+            "SSREL",
+            segment -> segment.getSecurityMetadata()
+                    .getReleaseInstructions()),
+    SYMBOL_CLASSIFICATION_AUTHORITY("symbolClassificationAuthority",
+            "SSCAUT",
+            segment -> segment.getSecurityMetadata()
+                    .getClassificationAuthority()),
+    SYMBOL_SECURITY_CONTROL_NUMBER("symbolSecurityControlNumber",
+            "SSCTLN",
+            segment -> segment.getSecurityMetadata()
+                    .getSecurityControlNumber()),
+    SYMBOL_SECURITY_DOWNGRADE("symbolSecurityDowngrade",
+            "SSDWNG",
+            segment -> segment.getSecurityMetadata()
+                    .getDowngrade()),
+    SYMBOL_DOWNGRADING_EVENT("symbolDowngradingEvent",
+            "SSDEVT",
+            segment -> segment.getSecurityMetadata()
+                    .getDowngradeEvent()),
+    SYMBOL_TYPE("symbolType",
+            "STYPE",
+            segment -> segment.getSymbolType()
+                    .name()),
+    NUMBER_OF_LINES_PER_SYMBOL("numberOfLinesPerSymbol",
+            "NLIPS",
+            SymbolSegment::getNumberOfLinesPerSymbol,
+            Collections.singletonList(BasicTypes.INTEGER_TYPE)),
+    NUMBER_OF_PIXELS_PER_LINE("numberOfPixelsPerLine",
+            "NPIXPL",
+            SymbolSegment::getNumberOfPixelsPerLine,
+            Collections.singletonList(BasicTypes.INTEGER_TYPE)),
+    LINE_WIDTH("lineWidth",
+            "NWDTH",
+            SymbolSegment::getLineWidth,
+            Collections.singletonList(BasicTypes.INTEGER_TYPE)),
+    NUMBER_OF_BITS_PER_PIXEL("numberOfBitsPerPixel",
+            "NBPP",
+            SymbolSegment::getNumberOfBitsPerPixel,
+            Collections.singletonList(BasicTypes.INTEGER_TYPE)),
+    DISPLAY_LEVEL("displayLevel",
+            "SDLVL",
+            SymbolSegment::getSymbolDisplayLevel,
+            Collections.singletonList(BasicTypes.INTEGER_TYPE)),
+    ATTACHMENT_LEVEL("attachmentLevel",
+            "SALVL",
+            SymbolSegment::getAttachmentLevel,
+            Collections.singletonList(BasicTypes.INTEGER_TYPE)),
+    SYMBOL_LOCATION("symbolLocation",
+            "SLOC",
+            segment -> String.format("%s,%s",
+                    segment.getSymbolLocationRow(),
+                    segment.getSymbolLocationColumn())),
+    SECOND_SYMBOL_LOCATION("secondSymbolLocation",
+            "SLOC2",
+            segment -> String.format("%s,%s",
+                    segment.getSymbolLocation2Row(),
+                    segment.getSymbolLocation2Column())),
+    SYMBOL_COLOR("symbolColor",
+            "SCOLOR",
+            segment -> segment.getSymbolColour()
+                    .toString()),
+    SYMBOL_NUMBER("symbolNumber", "SNUM", SymbolSegment::getSymbolNumber),
+    SYMBOL_ROTATION("symbolRotation",
+            "SROT",
+            SymbolSegment::getSymbolRotation,
+            Collections.singletonList(BasicTypes.INTEGER_TYPE)),
+    EXTENDED_SUBHEADER_DATA_LENGTH("extendedSubheaderDataLength",
+            "SXSHDL",
+            SymbolSegment::getExtendedHeaderDataOverflow,
+            Collections.singletonList(BasicTypes.INTEGER_TYPE));
+
+    public static final String ATTRIBUTE_NAME_PREFIX = "symbol.";
+
+    private String shortName;
+
+    private String longName;
+
+    private Function<SymbolSegment, Serializable> accessorFunction;
+
+    private Set<AttributeDescriptor> attributeDescriptors;
+
+    SymbolAttribute(final String lName, final String sName,
+            final Function<SymbolSegment, Serializable> accessor) {
+        this(lName, sName, accessor, Collections.singletonList(BasicTypes.STRING_TYPE));
+    }
+
+    SymbolAttribute(final String lName, final String sName,
+            final Function<SymbolSegment, Serializable> accessor,
+            List<AttributeType> attributeTypes) {
+        this.accessorFunction = accessor;
+        this.shortName = sName;
+        this.longName = lName;
+        this.attributeDescriptors = createAttributeDescriptors(attributeTypes);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final String getShortName() {
+        return this.shortName;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final String getLongName() {
+        return this.longName;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Function<SymbolSegment, Serializable> getAccessorFunction() {
+        return accessorFunction;
+    }
+
+    /**
+     * Equivalent to getLongName()
+     *
+     * @return the attribute's long name.
+     */
+    @Override
+    public String toString() {
+        return getLongName();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<AttributeDescriptor> getAttributeDescriptors() {
+        return this.attributeDescriptors;
+    }
+
+    private Set<AttributeDescriptor> createAttributeDescriptors(
+            List<AttributeType> attributeTypes) {
+        Set<AttributeDescriptor> attributesDescriptors = new HashSet<>();
+        for (AttributeType attribute : attributeTypes) {
+            attributesDescriptors.add(createAttributeDescriptor(attribute));
+        }
+        return attributesDescriptors;
+    }
+
+    private AttributeDescriptor createAttributeDescriptor(AttributeType attributeType) {
+        return new AttributeDescriptorImpl(
+                ExtNitfUtility.EXT_NITF_PREFIX + ATTRIBUTE_NAME_PREFIX + longName,
+                true, /* indexed */
+                true, /* stored */
+                false, /* tokenized */
+                true, /* multivalued */
+                attributeType);
+    }
+}

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/TextAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/TextAttribute.java
@@ -1,0 +1,223 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.transformer.nitf.image;
+
+import java.io.Serializable;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+import org.codice.alliance.transformer.nitf.ExtNitfUtility;
+import org.codice.alliance.transformer.nitf.common.NitfAttribute;
+import org.codice.imaging.nitf.core.common.DateTime;
+import org.codice.imaging.nitf.core.text.TextSegment;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.AttributeType;
+import ddf.catalog.data.impl.AttributeDescriptorImpl;
+import ddf.catalog.data.impl.BasicTypes;
+
+/**
+ * NitfAttributes to represent the properties of a TextSegment.
+ */
+public enum TextAttribute implements NitfAttribute<TextSegment> {
+    FILE_PART_TYPE("filePartType", "TE", segment -> "TE"),
+    TEXT_IDENTIFIER("textIdentifier", "TEXTID", TextSegment::getIdentifier),
+    TEXT_ATTACHMENT_LEVEL("textAttachmentLevel",
+            "TXTALVL",
+            TextSegment::getAttachmentLevel,
+            Collections.singletonList(BasicTypes.INTEGER_TYPE)),
+    TEXT_DATE_AND_TIME("textDateAndTime",
+            "TXTDT",
+            segment -> convertNitfDate(segment.getTextDateTime()),
+            Collections.singletonList(BasicTypes.DATE_TYPE)),
+    TEXT_TITLE("textTitle", "TXTITL", TextSegment::getTextTitle),
+    TEXT_SECURITY_CLASSIFICATION("textSecurityClassification",
+            "TSCLAS",
+            segment -> segment.getSecurityMetadata()
+                    .getSecurityClassificationSystem()),
+    TEXT_CLASSIFICATION_SECURITY_SYSTEM("textClassificationSecuritySystem",
+            "TSCLSY",
+            segment -> segment.getSecurityMetadata()
+                    .getSecurityClassificationSystem()),
+    TEXT_CODEWORDS("textCodewords",
+            "TSCODE",
+            segment -> segment.getSecurityMetadata()
+                    .getCodewords()),
+    TEXT_CONTROL_AND_HANDLING("textControlandHandling",
+            "TSCTLH",
+            segment -> segment.getSecurityMetadata()
+                    .getControlAndHandling()),
+    TEXT_RELEASING_INSTRUCTIONS("textReleasingInstructions",
+            "TSREL",
+            segment -> segment.getSecurityMetadata()
+                    .getReleaseInstructions()),
+    TEXT_DECLASSIFICATION_TYPE("textDeclassificationType",
+            "TSDCTP",
+            segment -> segment.getSecurityMetadata()
+                    .getDeclassificationType()),
+    TEXT_DECLASSIFICATION_DATE("textDeclassificationDate",
+            "TSDCDT",
+            segment -> segment.getSecurityMetadata()
+                    .getDeclassificationDate()),
+    TEXT_DECLASSIFICATION_EXEMPTION("textDeclassificationExemption",
+            "TSDCXM",
+            segment -> segment.getSecurityMetadata()
+                    .getDeclassificationExemption()),
+    TEXT_DOWNGRADE("textDowngrade",
+            "TSDG",
+            segment -> segment.getSecurityMetadata()
+                    .getDowngrade()),
+    TEXT_DOWNGRADE_DATE("textDowngradeDate",
+            "TSDGDT",
+            segment -> segment.getSecurityMetadata()
+                    .getDowngradeDate()),
+    TEXT_CLASSIFICATION_TEXT("textClassificationText",
+            "TSCLTX",
+            segment -> segment.getSecurityMetadata()
+                    .getClassificationText()),
+    TEXT_CLASSIFICATION_AUTHORITY_TYPE("textClassificationAuthorityType",
+            "TSCA TP",
+            segment -> segment.getSecurityMetadata()
+                    .getClassificationAuthorityType()),
+    TEXT_CLASSIFICATION_AUTHORITY("textClassificationAuthority",
+            "TSCAUT",
+            segment -> segment.getSecurityMetadata()
+                    .getClassificationAuthority()),
+    TEXT_CLASSIFICATION_REASON("textClassificationReason",
+            "TSCRSN",
+            segment -> segment.getSecurityMetadata()
+                    .getClassificationReason()),
+    TEXT_SECURITY_SOURCE_DATE("textSecuritySourceDate",
+            "TSSRDT",
+            segment -> segment.getSecurityMetadata()
+                    .getSecuritySourceDate()),
+    TEXT_SECURITY_CONTROL_NUMBER("textSecurityControlNumber",
+            "TSCTLN",
+            segment -> segment.getSecurityMetadata()
+                    .getSecurityControlNumber()),
+    TEXT_FORMAT("textFormat",
+            "TXTFMT",
+            segment -> segment.getTextFormat()
+                    .name()),
+    TEXT_EXTENDED_SUBHEADER_DATA_LENGTH("textExtendedSubheaderDataLength",
+            "TXSHDL",
+            TextSegment::getExtendedHeaderDataOverflow,
+            Collections.singletonList(BasicTypes.INTEGER_TYPE));
+
+    public static final String ATTRIBUTE_NAME_PREFIX = "text.";
+
+    private String shortName;
+
+    private String longName;
+
+    private Function<TextSegment, Serializable> accessorFunction;
+
+    private Set<AttributeDescriptor> attributeDescriptors;
+
+    TextAttribute(final String lName, final String sName,
+            final Function<TextSegment, Serializable> accessor) {
+        this(lName, sName, accessor, Collections.singletonList(BasicTypes.STRING_TYPE));
+    }
+
+    TextAttribute(final String lName, final String sName,
+            final Function<TextSegment, Serializable> accessor,
+            List<AttributeType> attributeTypes) {
+        this.longName = lName;
+        this.shortName = sName;
+        this.accessorFunction = accessor;
+        this.attributeDescriptors = createAttributeDescriptors(attributeTypes);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final String getShortName() {
+        return this.shortName;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final String getLongName() {
+        return this.longName;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Function<TextSegment, Serializable> getAccessorFunction() {
+        return accessorFunction;
+    }
+
+    /**
+     * Equivalent to getLongName()
+     *
+     * @return the attribute's long name.
+     */
+    @Override
+    public String toString() {
+        return getLongName();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<AttributeDescriptor> getAttributeDescriptors() {
+        return this.attributeDescriptors;
+    }
+
+    private static Date convertNitfDate(DateTime nitfDateTime) {
+        if (nitfDateTime == null || nitfDateTime.getZonedDateTime() == null) {
+            return null;
+        }
+
+        ZonedDateTime zonedDateTime = nitfDateTime.getZonedDateTime();
+        Instant instant = zonedDateTime.toInstant();
+
+        if (instant != null) {
+            return Date.from(instant);
+        }
+
+        return null;
+    }
+
+    private Set<AttributeDescriptor> createAttributeDescriptors(
+            List<AttributeType> attributeTypes) {
+        Set<AttributeDescriptor> attributesDescriptors = new HashSet<>();
+        for (AttributeType attribute : attributeTypes) {
+            attributesDescriptors.add(createAttributeDescriptor(attribute));
+        }
+        return attributesDescriptors;
+    }
+
+    private AttributeDescriptor createAttributeDescriptor(AttributeType attributeType) {
+        return new AttributeDescriptorImpl(
+                ExtNitfUtility.EXT_NITF_PREFIX + ATTRIBUTE_NAME_PREFIX + longName,
+                true, /* indexed */
+                true, /* stored */
+                false, /* tokenized */
+                true, /* multivalued */
+                attributeType);
+    }
+}

--- a/catalog/imaging/imaging-transformer-nitf/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -20,42 +20,14 @@
            http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0
            http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd">
 
-    <bean id="imageMetacardType"
-          class="ddf.catalog.data.impl.MetacardTypeImpl">
-        <argument value="isr.image"/>
-        <argument>
-            <list>
-                <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
-                <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
-                <bean class="ddf.catalog.data.impl.types.MediaAttributes"/>
-                <bean class="ddf.catalog.data.impl.types.DateTimeAttributes"/>
-                <bean class="ddf.catalog.data.impl.types.LocationAttributes"/>
-                <bean class="ddf.catalog.data.impl.types.ValidationAttributes"/>
-                <bean class="org.codice.alliance.catalog.core.api.impl.types.IsrAttributes"/>
-                <bean class="org.codice.alliance.catalog.core.api.impl.types.SecurityAttributes"/>
-            </list>
-        </argument>
+    <bean id="imageMetacardType" class="org.codice.alliance.transformer.nitf.image.ImageMetacardType">
     </bean>
 
     <bean id="imageMetacardFactory" class="org.codice.alliance.transformer.nitf.MetacardFactory">
         <property name="metacardType" ref="imageMetacardType"/>
     </bean>
 
-    <bean id="gmtiMetacardType"
-          class="ddf.catalog.data.impl.MetacardTypeImpl">
-        <argument value="isr.gmti"/>
-        <argument>
-            <list>
-                <bean class="ddf.catalog.data.impl.types.AssociationsAttributes"/>
-                <bean class="ddf.catalog.data.impl.types.ContactAttributes"/>
-                <bean class="ddf.catalog.data.impl.types.MediaAttributes"/>
-                <bean class="ddf.catalog.data.impl.types.DateTimeAttributes"/>
-                <bean class="ddf.catalog.data.impl.types.LocationAttributes"/>
-                <bean class="ddf.catalog.data.impl.types.ValidationAttributes"/>
-                <bean class="org.codice.alliance.catalog.core.api.impl.types.IsrAttributes"/>
-                <bean class="org.codice.alliance.catalog.core.api.impl.types.SecurityAttributes"/>
-            </list>
-        </argument>
+    <bean id="gmtiMetacardType" class="org.codice.alliance.transformer.nitf.gmti.GmtiMetacardType">
     </bean>
 
     <bean id="geometryFactory" class="com.vividsolutions.jts.geom.GeometryFactory"/>

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageAttributeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageAttributeTest.java
@@ -18,7 +18,10 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.codice.imaging.nitf.core.common.NitfFormatException;
@@ -28,17 +31,35 @@ import org.junit.Test;
 
 public class ImageAttributeTest {
 
+    public static final String COMMENT_1 = "comment 1";
+
+    public static final String COMMENT_2 = "comment 2";
+
+    public static final String COMMENT_3 = "comment 3";
+
     private ImageSegment imageSegment;
 
     @Before
     public void setUp() {
         this.imageSegment = mock(ImageSegment.class);
+        List<String> imageSegmentComments = new ArrayList<>();
+        imageSegmentComments.add(COMMENT_1);
+        imageSegmentComments.add(COMMENT_2);
+        imageSegmentComments.add(COMMENT_3);
+        when(imageSegment.getImageComments()).thenReturn(imageSegmentComments);
     }
 
     @Test
     public void testImageAttributes() throws NitfFormatException {
         Stream.of(ImageAttribute.values())
                 .forEach(attribute -> assertThat(attribute.getShortName(), is(notNullValue())));
+
+        assertThat(ImageAttribute.IMAGE_COMMENT_1.getAccessorFunction()
+                .apply(imageSegment), is(COMMENT_1));
+        assertThat(ImageAttribute.IMAGE_COMMENT_2.getAccessorFunction()
+                .apply(imageSegment), is(COMMENT_2));
+        assertThat(ImageAttribute.IMAGE_COMMENT_3.getAccessorFunction()
+                .apply(imageSegment), is(COMMENT_3));
 
         assertThat(ImageAttribute.TARGET_IDENTIFIER.getAccessorFunction()
                 .apply(imageSegment), is(nullValue()));

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageInputTransformerTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageInputTransformerTest.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p>
+ * <p/>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p>
+ * <p/>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -26,11 +26,15 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.TimeZone;
 
 import org.codice.alliance.catalog.core.api.types.Isr;
 import org.codice.alliance.transformer.nitf.MetacardFactory;
+import org.codice.alliance.transformer.nitf.common.NitfAttribute;
 import org.codice.alliance.transformer.nitf.common.NitfHeaderAttribute;
 import org.codice.alliance.transformer.nitf.common.NitfHeaderTransformer;
 import org.codice.imaging.nitf.fluent.NitfParserInputFlow;
@@ -40,11 +44,10 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
-import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.MetacardImpl;
-import ddf.catalog.data.impl.MetacardTypeImpl;
-import ddf.catalog.data.types.Core;
 import ddf.catalog.federation.FederationException;
 import ddf.catalog.source.SourceUnavailableException;
 import ddf.catalog.source.UnsupportedQueryException;
@@ -52,7 +55,7 @@ import ddf.catalog.source.UnsupportedQueryException;
 public class ImageInputTransformerTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(ImageInputTransformerTest.class);
 
-    private static final String GEO_NITF = "/i_3001a.ntf";
+    private static final String GEO_NITF = "i_3001a.ntf";
 
     private NitfImageTransformer transformer = null;
 
@@ -60,18 +63,13 @@ public class ImageInputTransformerTest {
 
     private MetacardFactory metacardFactory = null;
 
-    private static final String IMAGE_METACARD = "isr.image";
-
-    List<MetacardType> metacardTypeList = new ArrayList<>();
-
     @Before
     public void createTransformer()
             throws UnsupportedQueryException, SourceUnavailableException, FederationException {
         transformer = new NitfImageTransformer();
 
-        this.metacardFactory = new MetacardFactory();
-        metacardFactory.setMetacardType(new MetacardTypeImpl(
-                IMAGE_METACARD, metacardTypeList));
+        metacardFactory = new MetacardFactory();
+        metacardFactory.setMetacardType(new ImageMetacardType());
 
         headerTransformer = new NitfHeaderTransformer();
     }
@@ -102,104 +100,51 @@ public class ImageInputTransformerTest {
         validateDate(metacard, metacard.getCreatedDate(), "1997-12-17 10:26:30");
         validateDate(metacard, metacard.getEffectiveDate(), "1997-12-17 10:26:30");
         validateDate(metacard, metacard.getModifiedDate(), "1997-12-17 10:26:30");
+
         assertThat(metacard.getMetacardType()
                 .getName(), is("isr.image"));
-        assertThat(
-                "Checks an uncompressed 1024x1024 8 bit mono image with GEOcentric data. Airfield",
-                is(metacard.getTitle()));
+        assertThat(metacard.getTitle(),
+                is("Checks an uncompressed 1024x1024 8 bit mono image with GEOcentric data. Airfield"));
         String wkt = metacard.getLocation();
         assertTrue(wkt.matches(
                 "^POLYGON \\(\\(85 32.98\\d*, 85.00\\d* 32.98\\d*, 85.00\\d* 32.98\\d*, 85 32.98\\d*, 85 32.98\\d*\\)\\)"));
 
-        assertThat(metacard.getAttribute(NitfHeaderAttribute.FILE_PROFILE_NAME.toString())
-                .getValue(), is("NITF_TWO_ONE"));
-        assertThat(metacard.getAttribute(NitfHeaderAttribute.FILE_VERSION.toString())
-                .getValue(), is("NITF_TWO_ONE"));
-        assertThat(metacard.getAttribute(NitfHeaderAttribute.ORIGINATING_STATION_ID.toString())
-                .getValue(), is("i_3001a"));
+        Map<NitfAttribute, Object> map = initAttributesToBeAsserted();
+        assertAttributesMap(metacard, map);
 
-        Date fileDateAndTime = (Date) metacard.getAttribute(Core.CREATED)
-                .getValue();
-        String fileDateAndTimeString =
-                DateTimeFormatter.ISO_INSTANT.format(fileDateAndTime.toInstant());
-        assertThat(fileDateAndTimeString, is("1997-12-17T10:26:30Z"));
-        assertThat(metacard.getAttribute(NitfHeaderAttribute.FILE_TITLE.toString())
-                        .getValue(),
-                is("Checks an uncompressed 1024x1024 8 bit mono image with GEOcentric data. Airfield"));
-        assertThat(metacard.getAttribute(NitfHeaderAttribute.FILE_SECURITY_CLASSIFICATION.toString())
-                .getValue(), is("UNCLASSIFIED"));
-        assertThat(metacard.getAttribute(
-                NitfHeaderAttribute.FILE_CLASSIFICATION_SECURITY_SYSTEM.toString()),
-                is(nullValue()));
-        assertThat(metacard.getAttribute(NitfHeaderAttribute.FILE_CODE_WORDS.toString()),
-                is(nullValue()));
-        assertThat(metacard.getAttribute(NitfHeaderAttribute.FILE_CONTROL_AND_HANDLING.toString()),
-                is(nullValue()));
-        assertThat(metacard.getAttribute(NitfHeaderAttribute.FILE_RELEASING_INSTRUCTIONS.toString()),
-                is(nullValue()));
-        assertThat(metacard.getAttribute(NitfHeaderAttribute.ORIGINATORS_NAME.toString())
-                .getValue(), is("JITC Fort Huachuca, AZ"));
-        assertThat(metacard.getAttribute(NitfHeaderAttribute.ORIGINATORS_PHONE_NUMBER.toString())
-                .getValue(), is("(520) 538-5458"));
-
-        Date imageDateTime = (Date) metacard.getAttribute(
-                ImageAttribute.IMAGE_DATE_AND_TIME.toString())
-                .getValue();
-        String imageDateTimeString =
-                DateTimeFormatter.ISO_INSTANT.format(imageDateTime.toInstant());
-        assertThat(imageDateTimeString, is("1996-12-17T10:26:30Z"));
-        assertThat(metacard.getAttribute(ImageAttribute.TARGET_IDENTIFIER.toString()),
-                is(nullValue()));
-        assertThat(metacard.getAttribute(ImageAttribute.IMAGE_IDENTIFIER_2.toString())
-                .getValue(), is("- BASE IMAGE -"));
-        assertThat(metacard.getAttribute(ImageAttribute.IMAGE_SOURCE.toString())
-                .getValue(), is("Unknown"));
-        assertThat(metacard.getAttribute(
-                ImageAttribute.NUMBER_OF_SIGNIFICANT_ROWS_IN_IMAGE.toString())
-                .getValue(), is(1024L));
-        assertThat(metacard.getAttribute(
-                ImageAttribute.NUMBER_OF_SIGNIFICANT_COLUMNS_IN_IMAGE.toString())
-                .getValue(), is(1024L));
-        assertThat(metacard.getAttribute(ImageAttribute.IMAGE_REPRESENTATION.toString())
-                .getValue(), is("MONOCHROME"));
-        assertThat(metacard.getAttribute(ImageAttribute.IMAGE_CATEGORY.toString())
-                .getValue(), is("VISUAL"));
-        assertThat(metacard.getAttribute(ImageAttribute.IMAGE_COMPRESSION.toString())
-                .getValue(), is("NOTCOMPRESSED"));
-
+        Map<NitfAttribute, String> dateMap = initDateAttributesToBeAsserted();
+        assertDateAttributesMap(metacard, dateMap);
     }
 
     @Test
     public void testHandleMissionIdSuccessful() throws Exception {
         Metacard metacard = metacardFactory.createMetacard("missionIdTest");
         transformer.handleMissionIdentifier(metacard, "0123456789ABC");
-        assertThat(metacard.getAttribute(Isr.MISSION_ID.toString()).getValue(),
-                is("789A"));
+        assertThat(metacard.getAttribute(Isr.MISSION_ID)
+                .getValue(), is("789A"));
     }
 
     @Test
     public void testHandleMissionIdEmpty() throws Exception {
         Metacard metacard = metacardFactory.createMetacard("noMissionIdTest");
         transformer.handleMissionIdentifier(metacard, "0123456");
-        assertThat(metacard.getAttribute(Isr.MISSION_ID.toString()),
-                is(nullValue()));
+        assertThat(metacard.getAttribute(Isr.MISSION_ID), nullValue());
     }
 
     @Test
     public void testHandleMissionIdNoImageIdentifier() throws Exception {
         Metacard metacard = metacardFactory.createMetacard("noIdentifierTest");
         transformer.handleMissionIdentifier(metacard, null);
-        assertThat(metacard.getAttribute(Isr.MISSION_ID.toString()),
-                is(nullValue()));
+        assertThat(metacard.getAttribute(Isr.MISSION_ID), nullValue());
     }
 
     @Test
     public void testHandleCommentsSuccessful() throws Exception {
         final String blockComment =
-                "The credit belongs to the man who is actually in the arena, whose face is marred" +
-                " by dust and sweat and blood; who strives valiantly; who errs, who comes short a" +
-                "gain and again, because there is no effort without error and shortcoming; but wh" +
-                "o does actually strive to do the deeds.";
+                "The credit belongs to the man who is actually in the arena, whose face is marred"
+                        + " by dust and sweat and blood; who strives valiantly; who errs, who comes short a"
+                        + "gain and again, because there is no effort without error and shortcoming; but wh"
+                        + "o does actually strive to do the deeds.";
 
         List<String> commentsList = Arrays.asList(
                 "The credit belongs to the man who is actually in the arena, whose face is marred",
@@ -208,8 +153,8 @@ public class ImageInputTransformerTest {
                 "o does actually strive to do the deeds.");
         Metacard metacard = metacardFactory.createMetacard("commentsTest");
         transformer.handleComments(metacard, commentsList);
-        assertThat(metacard.getAttribute(Isr.COMMENTS.toString()).getValue(),
-                is(blockComment));
+        assertThat(metacard.getAttribute(Isr.COMMENTS)
+                .getValue(), is(blockComment));
     }
 
     @Test
@@ -217,8 +162,7 @@ public class ImageInputTransformerTest {
         List<String> commentsList = new ArrayList<>();
         Metacard metacard = metacardFactory.createMetacard("commentsTest");
         transformer.handleComments(metacard, commentsList);
-        assertThat(metacard.getAttribute(Isr.COMMENTS.toString()),
-                is(nullValue()));
+        assertThat(metacard.getAttribute(Isr.COMMENTS), nullValue());
     }
 
     private void validateDate(Metacard metacard, Date date, String expectedDate) {
@@ -230,7 +174,113 @@ public class ImageInputTransformerTest {
     }
 
     private InputStream getInputStream(String filename) {
-        assertNotNull("Test file missing", getClass().getResource(filename));
-        return getClass().getResourceAsStream(filename);
+        assertNotNull("Test file missing",
+                getClass().getClassLoader()
+                        .getResource(filename));
+        return getClass().getClassLoader()
+                .getResourceAsStream(filename);
+    }
+
+    private void assertDateAttributesMap(Metacard metacard, Map<NitfAttribute, String> map) {
+        for (Map.Entry<NitfAttribute, String> entry : map.entrySet()) {
+            for (AttributeDescriptor attributeDescriptor : (Set<AttributeDescriptor>) entry.getKey()
+                    .getAttributeDescriptors()) {
+                Attribute attribute = metacard.getAttribute(attributeDescriptor.getName());
+                Date fileDateAndTime = (Date) attribute.getValue();
+                String fileDateAndTimeString =
+                        DateTimeFormatter.ISO_INSTANT.format(fileDateAndTime.toInstant());
+
+                assertThat(fileDateAndTimeString, is(entry.getValue()));
+            }
+        }
+    }
+
+    private void assertAttributesMap(Metacard metacard, Map<NitfAttribute, Object> map) {
+        for (Map.Entry<NitfAttribute, Object> entry : map.entrySet()) {
+            for (AttributeDescriptor attributeDescriptor : (Set<AttributeDescriptor>) entry.getKey()
+                    .getAttributeDescriptors()) {
+                Attribute attribute = metacard.getAttribute(attributeDescriptor.getName());
+                if (attribute != null) {
+                    assertThat(attribute.getValue(), is(entry.getValue()));
+                } else {
+                    assertThat(attribute, nullValue());
+                }
+            }
+        }
+    }
+
+    private Map<NitfAttribute, Object> initAttributesToBeAsserted() {
+        //key value pair of attributes and expected values
+        Map<NitfAttribute, Object> map = new HashMap<>();
+        map.put(NitfHeaderAttribute.FILE_PROFILE_NAME, "NITF_TWO_ONE");
+        map.put(NitfHeaderAttribute.FILE_VERSION, "NITF_TWO_ONE");
+        map.put(NitfHeaderAttribute.COMPLEXITY_LEVEL, 3);
+        map.put(NitfHeaderAttribute.STANDARD_TYPE, "BF01");
+        map.put(NitfHeaderAttribute.ORIGINATING_STATION_ID, "i_3001a");
+        map.put(NitfHeaderAttribute.FILE_TITLE,
+                "Checks an uncompressed 1024x1024 8 bit mono image with GEOcentric data. Airfield");
+        map.put(NitfHeaderAttribute.FILE_SECURITY_CLASSIFICATION, "UNCLASSIFIED");
+        map.put(NitfHeaderAttribute.FILE_CLASSIFICATION_SECURITY_SYSTEM, null);
+        map.put(NitfHeaderAttribute.FILE_CODE_WORDS, null);
+        map.put(NitfHeaderAttribute.FILE_CONTROL_AND_HANDLING, null);
+        map.put(NitfHeaderAttribute.FILE_RELEASING_INSTRUCTIONS, null);
+        map.put(NitfHeaderAttribute.FILE_DECLASSIFICATION_TYPE, null);
+        map.put(NitfHeaderAttribute.FILE_DECLASSIFICATION_DATE, null);
+        map.put(NitfHeaderAttribute.FILE_DECLASSIFICATION_EXEMPTION, null);
+        map.put(NitfHeaderAttribute.FILE_DOWNGRADE, null);
+        map.put(NitfHeaderAttribute.FILE_RELEASING_INSTRUCTIONS, null);
+        map.put(NitfHeaderAttribute.FILE_DOWNGRADE_DATE, null);
+        map.put(NitfHeaderAttribute.FILE_CLASSIFICATION_TEXT, null);
+        map.put(NitfHeaderAttribute.FILE_CLASSIFICATION_AUTHORITY_TYPE, null);
+        map.put(NitfHeaderAttribute.FILE_CLASSIFICATION_AUTHORITY, null);
+        map.put(NitfHeaderAttribute.FILE_CLASSIFICATION_REASON, null);
+        map.put(NitfHeaderAttribute.FILE_SECURITY_SOURCE_DATE, null);
+        map.put(NitfHeaderAttribute.FILE_SECURITY_CONTROL_NUMBER, null);
+        map.put(NitfHeaderAttribute.FILE_COPY_NUMBER, "00000");
+        map.put(NitfHeaderAttribute.FILE_NUMBER_OF_COPIES, "00000");
+        map.put(NitfHeaderAttribute.FILE_BACKGROUND_COLOR, "[0xff,0xff,0xff]");
+        map.put(NitfHeaderAttribute.ORIGINATORS_NAME, "JITC Fort Huachuca, AZ");
+        map.put(NitfHeaderAttribute.ORIGINATORS_PHONE_NUMBER, "(520) 538-5458");
+        map.put(ImageAttribute.FILE_PART_TYPE, "IM");
+        map.put(ImageAttribute.IMAGE_IDENTIFIER_1, "Missing ID");
+        map.put(ImageAttribute.TARGET_IDENTIFIER, null);
+        map.put(ImageAttribute.IMAGE_IDENTIFIER_2, "- BASE IMAGE -");
+        map.put(ImageAttribute.IMAGE_SECURITY_CLASSIFICATION, "UNCLASSIFIED");
+        map.put(ImageAttribute.IMAGE_CLASSIFICATION_SECURITY_SYSTEM, null);
+        map.put(ImageAttribute.IMAGE_CODEWORDS, null);
+        map.put(ImageAttribute.IMAGE_CONTROL_AND_HANDLING, null);
+        map.put(ImageAttribute.IMAGE_RELEASING_INSTRUCTIONS, null);
+        map.put(ImageAttribute.IMAGE_DECLASSIFICATION_TYPE, null);
+        map.put(ImageAttribute.IMAGE_DECLASSIFICATION_DATE, null);
+        map.put(ImageAttribute.IMAGE_DECLASSIFICATION_EXEMPTION, null);
+        map.put(ImageAttribute.IMAGE_DOWNGRADE, null);
+        map.put(ImageAttribute.IMAGE_DOWNGRADE_DATE, null);
+        map.put(ImageAttribute.IMAGE_CLASSIFICATION_TEXT, null);
+        map.put(ImageAttribute.IMAGE_CLASSIFICATION_AUTHORITY_TYPE, null);
+        map.put(ImageAttribute.IMAGE_CLASSIFICATION_AUTHORITY, null);
+        map.put(ImageAttribute.IMAGE_CLASSIFICATION_REASON, null);
+        map.put(ImageAttribute.IMAGE_SECURITY_SOURCE_DATE, null);
+        map.put(ImageAttribute.IMAGE_SECURITY_CONTROL_NUMBER, null);
+        map.put(ImageAttribute.IMAGE_SOURCE, "Unknown");
+        map.put(ImageAttribute.NUMBER_OF_SIGNIFICANT_ROWS_IN_IMAGE, 1024L);
+        map.put(ImageAttribute.NUMBER_OF_SIGNIFICANT_COLUMNS_IN_IMAGE, 1024L);
+        map.put(ImageAttribute.PIXEL_VALUE_TYPE, "INTEGER");
+        map.put(ImageAttribute.IMAGE_REPRESENTATION, "MONOCHROME");
+        map.put(ImageAttribute.IMAGE_CATEGORY, "VISUAL");
+        map.put(ImageAttribute.ACTUAL_BITS_PER_PIXEL_PER_BAND, 8);
+        map.put(ImageAttribute.PIXEL_JUSTIFICATION, "RIGHT");
+        map.put(ImageAttribute.IMAGE_COORDINATE_REPRESENTATION, "GEOGRAPHIC");
+        map.put(ImageAttribute.NUMBER_OF_IMAGE_COMMENTS, 0);
+        map.put(ImageAttribute.IMAGE_COMMENT_1, null);
+        map.put(ImageAttribute.IMAGE_COMPRESSION, "NOTCOMPRESSED");
+        return map;
+    }
+
+    private Map<NitfAttribute, String> initDateAttributesToBeAsserted() {
+        //key value pair of attributes and expected values
+        Map<NitfAttribute, String> map = new HashMap<>();
+        map.put(NitfHeaderAttribute.FILE_DATE_AND_TIME, "1997-12-17T10:26:30Z");
+        map.put(ImageAttribute.IMAGE_DATE_AND_TIME, "1996-12-17T10:26:30Z");
+        return map;
     }
 }

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/TestTextAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/TestTextAttribute.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.transformer.nitf.image;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.stream.Stream;
+
+import org.codice.imaging.nitf.core.common.DateTime;
+import org.codice.imaging.nitf.core.security.SecurityMetadata;
+import org.codice.imaging.nitf.core.text.TextFormat;
+import org.codice.imaging.nitf.core.text.TextSegment;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestTextAttribute {
+
+    public static final int TEXT_ATTACHMENT_LEVEL = 0;
+
+    public static final int EXTENDED_HEADER_DATA_OVERFLOW = 0;
+
+    public static final String TEXT_TITLE = "TEXT_TITLE";
+
+    public static final TextFormat TEXT_FORMAT = TextFormat.USMTF;
+
+    public static final String TEXT_IDENTIFIER = "101";
+
+    private TextSegment textSegment;
+
+    private DateTime currentDateTime;
+
+    @Before
+    public void setUp() {
+        this.textSegment = mock(TextSegment.class);
+        this.currentDateTime = DateTime.getNitfDateTimeForNow();
+        when(textSegment.getIdentifier()).thenReturn(TEXT_IDENTIFIER);
+        when(textSegment.getSecurityMetadata()).thenReturn(mock(SecurityMetadata.class));
+        when(textSegment.getTextDateTime()).thenReturn(currentDateTime);
+        when(textSegment.getTextFormat()).thenReturn(TEXT_FORMAT);
+        when(textSegment.getTextTitle()).thenReturn(TEXT_TITLE);
+        when(textSegment.getAttachmentLevel()).thenReturn(TEXT_ATTACHMENT_LEVEL);
+        when(textSegment.getExtendedHeaderDataOverflow()).thenReturn(EXTENDED_HEADER_DATA_OVERFLOW);
+    }
+
+    @Test
+    public void testLongAndShortNames() {
+        Stream.of(TextAttribute.values())
+                .forEach(attribute -> assertThat(attribute.getShortName(), is(notNullValue())));
+
+        Stream.of(TextAttribute.values())
+                .forEach(attribute -> assertThat(attribute.getLongName(), is(notNullValue())));
+
+        Stream.of(TextAttribute.values())
+                .forEach(attribute -> assertThat(attribute.toString(),
+                        is(attribute.getLongName())));
+
+        assertThat(TextAttribute.TEXT_ATTACHMENT_LEVEL.getAccessorFunction()
+                .apply(textSegment), is(TEXT_ATTACHMENT_LEVEL));
+        assertThat(TextAttribute.TEXT_IDENTIFIER.getAccessorFunction()
+                .apply(textSegment), is(TEXT_IDENTIFIER));
+        assertThat(TextAttribute.TEXT_DATE_AND_TIME.getAccessorFunction()
+                .apply(textSegment), notNullValue());
+        assertThat(TextAttribute.TEXT_TITLE.getAccessorFunction()
+                .apply(textSegment), is(TEXT_TITLE));
+        assertThat(TextAttribute.TEXT_EXTENDED_SUBHEADER_DATA_LENGTH.getAccessorFunction()
+                .apply(textSegment), is(EXTENDED_HEADER_DATA_OVERFLOW));
+
+        assertThat(TextAttribute.TEXT_SECURITY_CLASSIFICATION.getAccessorFunction()
+                .apply(textSegment), nullValue());
+        assertThat(TextAttribute.TEXT_CLASSIFICATION_SECURITY_SYSTEM.getAccessorFunction()
+                .apply(textSegment), nullValue());
+        assertThat(TextAttribute.TEXT_CODEWORDS.getAccessorFunction()
+                .apply(textSegment), nullValue());
+        assertThat(TextAttribute.TEXT_CONTROL_AND_HANDLING.getAccessorFunction()
+                .apply(textSegment), nullValue());
+        assertThat(TextAttribute.TEXT_RELEASING_INSTRUCTIONS.getAccessorFunction()
+                .apply(textSegment), nullValue());
+        assertThat(TextAttribute.TEXT_DECLASSIFICATION_DATE.getAccessorFunction()
+                .apply(textSegment), nullValue());
+        assertThat(TextAttribute.TEXT_DECLASSIFICATION_TYPE.getAccessorFunction()
+                .apply(textSegment), nullValue());
+        assertThat(TextAttribute.TEXT_DECLASSIFICATION_EXEMPTION.getAccessorFunction()
+                .apply(textSegment), nullValue());
+        assertThat(TextAttribute.TEXT_DOWNGRADE.getAccessorFunction()
+                .apply(textSegment), nullValue());
+        assertThat(TextAttribute.TEXT_DOWNGRADE_DATE.getAccessorFunction()
+                .apply(textSegment), nullValue());
+        assertThat(TextAttribute.TEXT_CLASSIFICATION_TEXT.getAccessorFunction()
+                .apply(textSegment), nullValue());
+        assertThat(TextAttribute.TEXT_CLASSIFICATION_AUTHORITY_TYPE.getAccessorFunction()
+                .apply(textSegment), nullValue());
+        assertThat(TextAttribute.TEXT_CLASSIFICATION_AUTHORITY.getAccessorFunction()
+                .apply(textSegment), nullValue());
+        assertThat(TextAttribute.TEXT_CLASSIFICATION_REASON.getAccessorFunction()
+                .apply(textSegment), nullValue());
+        assertThat(TextAttribute.TEXT_SECURITY_SOURCE_DATE.getAccessorFunction()
+                .apply(textSegment), nullValue());
+        assertThat(TextAttribute.TEXT_CLASSIFICATION_SECURITY_SYSTEM.getAccessorFunction()
+                .apply(textSegment), nullValue());
+        assertThat(TextAttribute.TEXT_SECURITY_CONTROL_NUMBER.getAccessorFunction()
+                .apply(textSegment), nullValue());
+    }
+}


### PR DESCRIPTION
#### What does this PR do?
- Adds all previously available NITF attributes (and current supported TREs fields) into both Image and GMTI NITF `MetacardType`s under the `ext.nitf.*` namespace.
- NITF Attributes that also map to the taxonomy are duplicated in the `Metacard`. This is so that Imagery Analysts can operate on the `Metacard`'s attributes with terms they are familiar with.
- Removes `MtirpbAttribute.AIRCRAFT_LOCATION` -> `Isr.DWELL_LOCATION` taxonomy mapping.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@dcruver @lcrosenbu @bdeining @glenhein 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith 
@pklinef
#### How should this be tested?
Full build
Start an instance of Alliance and ingest some NITFs, verify that attributes are visible in the `Metacard` view in the UI as well as in the `Metacard` XML representation.

#### Any background context you want to provide?
Some NITF specific fields that Imagery Analysts want, in order to perform operations against, do not map to the taxonomy. The decision was made that all fields of a NITF will be added as `Attribute`s under the `ext.nitf.*` namespace. This way Imagery Analysts can operate on NITF specific fields that do not map to the taxonomy. NITF fields that map to the taxonomy will be duplicated as one of the taxonomy attributes, and in an `Attribute` under `ext.nitf.*`.
#### What are the relevant tickets?
[CAL-131](https://codice.atlassian.net/browse/CAL-131)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

