### PR TITLE
CAL-142 Fixed bug in the FMV video where the PacketBuffer TimerTask d…

### DIFF
--- a/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/UdpStreamMonitor.java
+++ b/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/UdpStreamMonitor.java
@@ -325,13 +325,13 @@ public class UdpStreamMonitor implements StreamMonitor {
     private void shutdown() {
         if (serverThread != null) {
             LOGGER.debug("shutting down monitor server thread");
-
-            eventLoopGroup.shutdownGracefully();
-
             joinServerThread();
-
             serverThread = null;
-
+        }
+        if(eventLoopGroup != null) {
+            eventLoopGroup.shutdownGracefully();
+        }
+        if(udpStreamProcessor != null) {
             udpStreamProcessor.shutdown();
         }
     }

--- a/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/netty/PacketBuffer.java
+++ b/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/netty/PacketBuffer.java
@@ -377,6 +377,10 @@ public class PacketBuffer {
         }
     }
 
+    public void cancelTimer() {
+        timer.cancel();
+    }
+
     private File getTempFile() throws IOException {
         if (currentTempFile == null) {
             tempFileCreateTime = dateSupplier.get()

--- a/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/netty/UdpStreamProcessor.java
+++ b/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/netty/UdpStreamProcessor.java
@@ -310,13 +310,13 @@ public class UdpStreamProcessor implements StreamProcessor {
      * of IDR boundaries.
      */
     public void shutdown() {
-
         try {
+            LOGGER.trace("Shutting down stream processor.");
+            packetBuffer.cancelTimer();
             streamShutdownPlugin.onShutdown(context);
         } catch (StreamShutdownException e) {
             LOGGER.debug("unable to shutdown", e);
         }
-
     }
 
     public void checkForRollover() {


### PR DESCRIPTION
#### What does this PR do?
This PR fixes a bug where the TimerTask in PacketBuffer.java did not shut down properly
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@glenhein @lcrosenbu 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@jlcsmith
#### How should this be tested?
Build and install Alliance Experimental, `log:set DEBUG org.codice.alliance.video.stream.mpegts` , configure an FMV stream, cancel it and observe that the TimerTask is cancelled as well.
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/CAL-142
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

…oes not shut down properly