### PR TITLE
CAL-137 Add email support to NSILI OrderMgr interface

### DIFF
--- a/catalog/core/catalog-core-api-impl/pom.xml
+++ b/catalog/core/catalog-core-api-impl/pom.xml
@@ -42,6 +42,10 @@
             <artifactId>catalog-core-api-impl</artifactId>
             <version>${ddf.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/catalog/core/catalog-email-api/pom.xml
+++ b/catalog/core/catalog-email-api/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 /**
  * Copyright (c) Codice Foundation
@@ -14,38 +14,26 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.codice.alliance.nsili</groupId>
-        <artifactId>nsili</artifactId>
+        <groupId>org.codice.alliance.catalog</groupId>
+        <artifactId>core</artifactId>
         <version>0.2-SNAPSHOT</version>
     </parent>
-
-    <artifactId>catalog-nsili-orb-impl</artifactId>
+    <groupId>org.codice.alliance.catalog.core</groupId>
+    <artifactId>catalog-email-api</artifactId>
     <packaging>bundle</packaging>
-    <name>Alliance :: NSILI :: ORB :: IMPL</name>
+    <name>Alliance :: Catalog :: Email :: API</name>
 
     <dependencies>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>${commons-lang3.version}</version>
         </dependency>
         <dependency>
-            <groupId>ddf.catalog.core</groupId>
-            <artifactId>catalog-core-api-impl</artifactId>
-            <version>${ddf.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>ddf.platform.util</groupId>
-            <artifactId>platform-util</artifactId>
-            <version>${ddf.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codice.alliance.nsili</groupId>
-            <artifactId>catalog-nsili-orb-api</artifactId>
-            <version>${project.version}</version>
+            <groupId>javax.mail</groupId>
+            <artifactId>mail</artifactId>
         </dependency>
     </dependencies>
 
@@ -54,15 +42,13 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Export-Package/>
-                        <Embed-Dependency>
-                            catalog-core-api-impl,
-                            platform-util
-                        </Embed-Dependency>
+                        <Export-Package>
+                            org.codice.alliance.core.email
+                        </Export-Package>
+                        <Embed-Dependency/>
                     </instructions>
                 </configuration>
             </plugin>
@@ -77,11 +63,6 @@
                         </goals>
                         <configuration>
                             <haltOnFailure>true</haltOnFailure>
-                            <excludes>
-                                <exclude>
-                                    /src/test/
-                                </exclude>
-                            </excludes>
                             <rules>
                                 <rule>
                                     <element>BUNDLE</element>
@@ -89,22 +70,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.90</minimum>
+                                            <minimum>0</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.75</minimum>
+                                            <minimum>0</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.75</minimum>
+                                            <minimum>0</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.90</minimum>
+                                            <minimum>0</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/core/catalog-email-api/src/main/java/org/codice/alliance/core/email/EmailSender.java
+++ b/catalog/core/catalog-email-api/src/main/java/org/codice/alliance/core/email/EmailSender.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.alliance.core.email;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+/**
+ * Interface for sending email with optional attachments.
+ *
+ * <b> This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ */
+public interface EmailSender {
+
+    /**
+     * @param fromEmail   non-null from email address
+     * @param toEmail     non-null to email address
+     * @param subject     non-null subject line of email to be sent
+     * @param body        non-null body of email to be sent
+     * @param attachments non-null list of filename/input stream pairs, the caller is responsible for closing the input streams
+     * @throws IOException exception thrown if failed to send email
+     */
+    void sendEmail(String fromEmail, String toEmail, String subject, String body,
+            List<Pair<String, InputStream>> attachments) throws IOException;
+
+    /**
+     * @param fromEmail non-null from email address
+     * @param toEmail   non-null to email address
+     * @param subject   non-null subject line of email to be sent
+     * @param body      non-null body of email to be sent
+     * @throws IOException exception thrown if failed to send email
+     */
+    void sendEmail(String fromEmail, String toEmail, String subject, String body)
+            throws IOException;
+
+}

--- a/catalog/core/catalog-email-impl/pom.xml
+++ b/catalog/core/catalog-email-impl/pom.xml
@@ -15,41 +15,49 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.codice.alliance.nsili</groupId>
-        <artifactId>nsili</artifactId>
+        <groupId>org.codice.alliance.catalog</groupId>
+        <artifactId>core</artifactId>
         <version>0.2-SNAPSHOT</version>
     </parent>
-
-    <artifactId>catalog-nsili-orb-impl</artifactId>
+    <modelVersion>4.0.0</modelVersion>
+    <name>Alliance :: Catalog :: Email :: Impl</name>
+    <groupId>org.codice.alliance.catalog.core</groupId>
+    <artifactId>catalog-email-impl</artifactId>
     <packaging>bundle</packaging>
-    <name>Alliance :: NSILI :: ORB :: IMPL</name>
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>${commons-lang3.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>ddf.catalog.core</groupId>
-            <artifactId>catalog-core-api-impl</artifactId>
-            <version>${ddf.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>ddf.platform.util</groupId>
-            <artifactId>platform-util</artifactId>
-            <version>${ddf.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codice.alliance.nsili</groupId>
-            <artifactId>catalog-nsili-orb-api</artifactId>
+            <groupId>org.codice.alliance.catalog.core</groupId>
+            <artifactId>catalog-email-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.mail</groupId>
+            <artifactId>mail</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>${commons-io.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
-
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.felix</groupId>
@@ -58,11 +66,6 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Export-Package/>
-                        <Embed-Dependency>
-                            catalog-core-api-impl,
-                            platform-util
-                        </Embed-Dependency>
                     </instructions>
                 </configuration>
             </plugin>
@@ -89,22 +92,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.90</minimum>
+                                            <minimum>0.77</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.75</minimum>
+                                            <minimum>0.50</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.75</minimum>
+                                            <minimum>0.40</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.90</minimum>
+                                            <minimum>0.77</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/core/catalog-email-impl/src/main/java/org/codice/alliance/core/email/impl/EmailSenderImpl.java
+++ b/catalog/core/catalog-email-impl/src/main/java/org/codice/alliance/core/email/impl/EmailSenderImpl.java
@@ -1,0 +1,208 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.alliance.core.email.impl;
+
+import static org.apache.commons.lang3.Validate.notNull;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+
+import javax.activation.DataHandler;
+import javax.activation.FileDataSource;
+import javax.mail.BodyPart;
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.Multipart;
+import javax.mail.Session;
+import javax.mail.Transport;
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeBodyPart;
+import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
+import javax.xml.ws.Holder;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.codice.alliance.core.email.EmailSender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * <b> This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ */
+public class EmailSenderImpl implements EmailSender {
+
+    private static final int BUFFER_SIZE = 4096;
+
+    private static final int DEFAULT_PORT = 25;
+
+    private static final long MEGABYTE = 1024*1024;
+
+    private static final long DEFAULT_MAX_ATTACHMENT_SIZE = Long.MAX_VALUE;
+
+    private static final String SMTP_HOST_PROPERTY = "mail.smtp.host";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EmailSenderImpl.class);
+
+    private static final String SMTP_PORT_PROPERTY = "mail.smtp.port";
+
+    private static final String SMTP_AUTH_PROPERTY = "mail.smtp.auth";
+
+    private int mailPort = DEFAULT_PORT;
+
+    private String mailHost;
+
+    private long maxAttachmentSize = DEFAULT_MAX_ATTACHMENT_SIZE;
+
+    public void setMailPort(int mailPort) {
+        this.mailPort = mailPort;
+    }
+
+    public void setMailHost(String mailHost) {
+        this.mailHost = mailHost;
+    }
+
+    /**
+     * @param maxAttachmentSize unit is 1024*1024 bytes
+     */
+    public void setMaxAttachmentSize(long maxAttachmentSize) {
+        this.maxAttachmentSize = maxAttachmentSize * MEGABYTE;
+    }
+
+    /**
+     * sendEmail method sends email after receiving input parameters
+     */
+    @Override
+    public void sendEmail(String fromEmail, String toEmail, String subject, String body,
+            List<Pair<String, InputStream>> attachments) throws IOException {
+        notNull(fromEmail, "fromEmail must be non-null");
+        notNull(toEmail, "toEmail must be non-null");
+        notNull(subject, "subject must be non-null");
+        notNull(body, "body must be non-null");
+        notNull(attachments, "attachments must be non-null");
+
+        if (StringUtils.isBlank(mailHost)) {
+            throw new IOException("the mail server hostname has not been configured");
+        }
+
+        List<File> tempFiles = new LinkedList<>();
+
+        try {
+            InternetAddress emailAddr = new InternetAddress(toEmail);
+            emailAddr.validate();
+
+            Properties properties = createSessionProperties();
+
+            Session session = Session.getDefaultInstance(properties);
+
+            MimeMessage mimeMessage = new MimeMessage(session);
+            mimeMessage.setFrom(new InternetAddress(fromEmail));
+            mimeMessage.addRecipient(Message.RecipientType.TO, emailAddr);
+            mimeMessage.setSubject(subject);
+
+            BodyPart messageBodyPart = new MimeBodyPart();
+            messageBodyPart.setText(body);
+
+            Multipart multipart = new MimeMultipart();
+            multipart.addBodyPart(messageBodyPart);
+
+            Holder<Long> bytesWritten = new Holder<>(0L);
+
+            for (Pair<String, InputStream> attachment : attachments) {
+
+                messageBodyPart = new MimeBodyPart();
+                File file = File.createTempFile("email-sender-", ".dat");
+                tempFiles.add(file);
+
+                copyDataToTempFile(file, attachment.getValue(), bytesWritten);
+                messageBodyPart.setDataHandler(new DataHandler(new FileDataSource(file)));
+                messageBodyPart.setFileName(attachment.getKey());
+                multipart.addBodyPart(messageBodyPart);
+
+            }
+
+            mimeMessage.setContent(multipart);
+
+            send(mimeMessage);
+
+            LOGGER.debug("Email sent to " + toEmail);
+
+        } catch (AddressException e) {
+            throw new IOException("invalid email address: email=" + toEmail, e);
+        } catch (MessagingException e) {
+            throw new IOException("message error occured on send", e);
+        } finally {
+            tempFiles.forEach(file -> {
+                if (!file.delete()) {
+                    LOGGER.debug("unable to delete tmp file: path={}", file);
+                }
+            });
+        }
+    }
+
+    @Override
+    public void sendEmail(String fromEmail, String toEmail, String subject, String body)
+            throws IOException {
+        sendEmail(fromEmail, toEmail, subject, body, Collections.emptyList());
+    }
+
+    private void copyDataToTempFile(File file, InputStream inputStream, Holder<Long> bytesWritten)
+            throws IOException {
+
+        try (OutputStream outputStream = new FileOutputStream(file)) {
+
+            byte[] buffer = new byte[BUFFER_SIZE];
+
+            int c;
+            while ((c = inputStream.read(buffer)) != -1) {
+                outputStream.write(buffer, 0, c);
+                bytesWritten.value = bytesWritten.value + c;
+                if (bytesWritten.value > maxAttachmentSize) {
+                    throw new IOException(
+                            "total attachment size exceeds limit: limit=" + maxAttachmentSize);
+                }
+            }
+
+        }
+
+    }
+
+    void send(Message message) throws MessagingException {
+        Transport.send(message);
+    }
+
+    private Properties createSessionProperties() {
+        Properties properties = System.getProperties();
+        properties.setProperty(SMTP_HOST_PROPERTY, mailHost);
+        properties.setProperty(SMTP_AUTH_PROPERTY, "false");
+        properties.setProperty(SMTP_PORT_PROPERTY, Integer.toString(mailPort));
+        return properties;
+    }
+
+    @Override
+    public String toString() {
+        return "EmailSenderImpl{" + "mailPort=" + mailPort + ", mailHost='" + mailHost + '\''
+                + ", maxAttachmentSize=" + maxAttachmentSize + '}';
+    }
+}

--- a/catalog/core/catalog-email-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-email-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+           xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0
+           http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+
+    <bean id="emailService" class="org.codice.alliance.core.email.impl.EmailSenderImpl">
+        <cm:managed-properties
+                persistent-id="org.codice.alliance.core.email.impl.EmailSenderImpl"
+                update-strategy="container-managed"/>
+    </bean>
+
+    <service ref="emailService" interface="org.codice.alliance.core.email.EmailSender"/>
+
+</blueprint>

--- a/catalog/core/catalog-email-impl/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/core/catalog-email-impl/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
+
+    <OCD name="Email Sender"
+         id="org.codice.alliance.core.email.impl.EmailSenderImpl"
+         description="Configure the hostname (or IP address) and port number of an SMTP mail server that will receive the emails. Also, control the maximum total size of attachments for cases where the SMTP server limits the attachment size.">
+
+        <AD
+                description="Mail server hostname (must be resolvable by DNS) or IP address."
+                name="Host" id="mailHost" required="true"
+                type="String" default=""/>
+
+        <AD
+                description="Mail server port number."
+                name="Port" id="mailPort" required="false"
+                type="Integer" default="25"/>
+
+        <AD
+                description="Maximum size of combined attachements (MB)."
+                name="Maximum Attachment Size" id="maxAttachmentSize" required="false"
+                type="Long" default="250"/>
+
+    </OCD>
+
+    <Designate pid="org.codice.alliance.core.email.impl.EmailSenderImpl">
+        <Object ocdref="org.codice.alliance.core.email.impl.EmailSenderImpl"/>
+    </Designate>
+
+</metatype:MetaData>

--- a/catalog/core/catalog-email-impl/src/test/java/org/codice/alliance/core/email/impl/EmailSenderImplTest.java
+++ b/catalog/core/catalog-email-impl/src/test/java/org/codice/alliance/core/email/impl/EmailSenderImplTest.java
@@ -1,0 +1,200 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.alliance.core.email.impl;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMultipart;
+import javax.xml.ws.Holder;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.junit.Before;
+import org.junit.Test;
+
+public class EmailSenderImplTest {
+
+    private static final String TO_ADDR = "to@test.com";
+
+    private static final String FROM_ADDR = "from@test.com";
+
+    private static final String SUBJECT_LINE = "subject line";
+
+    private static final String BODY = "body text";
+
+    private static final String HOST = "host.com";
+
+    private EmailSenderImpl emailSender;
+
+    private Holder<Message> capturedMessage = new Holder<>();
+
+    @Before
+    public void setup() {
+        emailSender = new EmailSenderImpl() {
+            @Override
+            void send(Message message) throws MessagingException {
+                capturedMessage.value = message;
+            }
+        };
+        emailSender.setMailHost(HOST);
+    }
+
+    @Test
+    public void testSendEmailSubject() throws IOException, MessagingException {
+
+        emailSender.sendEmail(FROM_ADDR, TO_ADDR, SUBJECT_LINE, BODY, Collections.emptyList());
+
+        assertThat(capturedMessage.value.getSubject(), is(SUBJECT_LINE));
+
+    }
+
+    @Test
+    public void testToAddress() throws IOException, MessagingException {
+
+        emailSender.sendEmail(FROM_ADDR, TO_ADDR, SUBJECT_LINE, BODY, Collections.emptyList());
+
+        assertThat(capturedMessage.value.getAllRecipients()[0].toString(), is(TO_ADDR));
+
+    }
+
+    @Test
+    public void testFromAddress() throws IOException, MessagingException {
+
+        emailSender.sendEmail(FROM_ADDR, TO_ADDR, SUBJECT_LINE, BODY, Collections.emptyList());
+
+        assertThat(capturedMessage.value.getFrom()[0].toString(), is(FROM_ADDR));
+
+    }
+
+    @Test
+    public void testBody() throws IOException, MessagingException {
+
+        emailSender.sendEmail(FROM_ADDR, TO_ADDR, SUBJECT_LINE, BODY, Collections.emptyList());
+
+        MimeMultipart mimeMultipart = (MimeMultipart) capturedMessage.value.getContent();
+
+        Object content = mimeMultipart.getBodyPart(0)
+                .getContent();
+
+        assertThat(content, is(BODY));
+
+    }
+
+    @Test
+    public void testAttachment() throws IOException, MessagingException {
+
+        final List<String> attachmentLines = new LinkedList<>();
+        Holder<String> filename = new Holder<>();
+
+        int bodyPartIndex = 1;
+
+        emailSender = new EmailSenderImpl() {
+            @Override
+            void send(Message message) throws MessagingException {
+                try {
+                    FileInputStream fis =
+                            (FileInputStream) ((MimeMultipart) message.getContent()).getBodyPart(
+                                    bodyPartIndex)
+                                    .getContent();
+                    filename.value = ((MimeMultipart) message.getContent()).getBodyPart(
+                            bodyPartIndex)
+                            .getFileName();
+                    attachmentLines.addAll(IOUtils.readLines(fis));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+
+        emailSender.setMailHost(HOST);
+
+        String attachedData = "attached data";
+        String attachedFilename = "fileName.txt";
+
+        emailSender.sendEmail(FROM_ADDR,
+                TO_ADDR,
+                SUBJECT_LINE,
+                BODY,
+                Collections.singletonList(new ImmutablePair<>(attachedFilename,
+                        new ByteArrayInputStream(attachedData.getBytes()))));
+
+        assertThat(filename.value, is(attachedFilename));
+        assertThat(attachmentLines, is(Collections.singletonList(attachedData)));
+
+    }
+
+    /**
+     * Set the max attachment size to 1MB and send an attachment of size 2MB.
+     */
+    @Test(expected = IOException.class)
+    public void testTooBigAttachment() throws IOException, MessagingException {
+
+        final List<String> attachmentLines = new LinkedList<>();
+        Holder<String> filename = new Holder<>();
+
+        int bodyPartIndex = 1;
+
+        emailSender = new EmailSenderImpl() {
+            @Override
+            void send(Message message) throws MessagingException {
+                try {
+                    FileInputStream fis =
+                            (FileInputStream) ((MimeMultipart) message.getContent()).getBodyPart(
+                                    bodyPartIndex)
+                                    .getContent();
+                    filename.value = ((MimeMultipart) message.getContent()).getBodyPart(
+                            bodyPartIndex)
+                            .getFileName();
+                    attachmentLines.addAll(IOUtils.readLines(fis));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+
+        emailSender.setMaxAttachmentSize(1);
+
+        emailSender.setMailHost(HOST);
+
+        String attachedData = generateString(2000000);
+        String attachedFilename = "fileName.txt";
+
+        emailSender.sendEmail(FROM_ADDR,
+                TO_ADDR,
+                SUBJECT_LINE,
+                BODY,
+                Collections.singletonList(new ImmutablePair<>(attachedFilename,
+                        new ByteArrayInputStream(attachedData.getBytes()))));
+
+    }
+
+    private String generateString(int length) {
+        char[] charArray = new char[length];
+        Arrays.fill(charArray, ' ');
+        return new String(charArray);
+    }
+
+}

--- a/catalog/core/pom.xml
+++ b/catalog/core/pom.xml
@@ -30,6 +30,8 @@
         <module>catalog-core-api</module>
         <module>catalog-core-api-impl</module>
         <module>catalog-core-metacardtypes</module>
+        <module>catalog-email-api</module>
+        <module>catalog-email-impl</module>
     </modules>
 
 </project>

--- a/catalog/nsili/catalog-nsili-endpoint/pom.xml
+++ b/catalog/nsili/catalog-nsili-endpoint/pom.xml
@@ -169,6 +169,11 @@
             <artifactId>versioning-common</artifactId>
             <version>${ddf.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.codice.alliance.catalog.core</groupId>
+            <artifactId>catalog-email-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <resources>
@@ -199,7 +204,6 @@
                             jgrapht-core,
                             antlr4-runtime,
                             guava,
-                            commons-lang3,
                             geospatial,
                             security-handler-api-impl,
                             httpcore,

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/LibraryImpl.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/LibraryImpl.java
@@ -13,6 +13,8 @@
  */
 package org.codice.alliance.nsili.endpoint;
 
+import static org.apache.commons.lang3.Validate.notNull;
+
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -23,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import org.codice.alliance.core.email.EmailSender;
 import org.codice.alliance.nsili.common.CorbaUtils;
 import org.codice.alliance.nsili.common.GIAS.AccessCriteria;
 import org.codice.alliance.nsili.common.GIAS.CatalogMgrHelper;
@@ -45,6 +48,7 @@ import org.codice.alliance.nsili.common.UCO.exception_details;
 import org.codice.alliance.nsili.endpoint.managers.CatalogMgrImpl;
 import org.codice.alliance.nsili.endpoint.managers.CreationMgrImpl;
 import org.codice.alliance.nsili.endpoint.managers.DataModelMgrImpl;
+import org.codice.alliance.nsili.endpoint.managers.EmailConfiguration;
 import org.codice.alliance.nsili.endpoint.managers.OrderMgrImpl;
 import org.codice.alliance.nsili.endpoint.managers.ProductMgrImpl;
 import org.codice.alliance.nsili.endpoint.managers.StandingQueryMgrImpl;
@@ -77,6 +81,8 @@ public class LibraryImpl extends LibraryPOA {
     private POA poa;
 
     private CatalogFramework catalogFramework;
+
+    private EmailConfiguration emailConfiguration;
 
     private FilterBuilder filterBuilder;
 
@@ -187,6 +193,8 @@ public class LibraryImpl extends LibraryPOA {
             OrderMgrImpl orderMgr = new OrderMgrImpl();
             orderMgr.setCatalogFramework(catalogFramework);
             orderMgr.setFilterBuilder(filterBuilder);
+            orderMgr.setEmailConfiguration(emailConfiguration);
+
             if (!CorbaUtils.isIdActive(poa,
                     managerId.getBytes(Charset.forName(NsiliEndpoint.ENCODING)))) {
                 try {
@@ -335,5 +343,14 @@ public class LibraryImpl extends LibraryPOA {
     public static boolean queryContainsStatus(String bqsQuery) {
         return bqsQuery.toLowerCase()
                 .contains(LibraryImpl.CARD_STATUS.toLowerCase());
+    }
+
+    /**
+     *
+     * @param emailConfiguration must be non-null
+     */
+    public void setEmailConfiguration(EmailConfiguration emailConfiguration) {
+        notNull(emailConfiguration, "emailConfiguration must be non-null");
+        this.emailConfiguration = emailConfiguration;
     }
 }

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/NsiliEndpoint.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/NsiliEndpoint.java
@@ -13,6 +13,8 @@
  */
 package org.codice.alliance.nsili.endpoint;
 
+import static org.apache.commons.lang3.Validate.notNull;
+
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -24,7 +26,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.codice.alliance.core.email.EmailSender;
 import org.codice.alliance.nsili.common.NsilCorbaExceptionUtil;
+import org.codice.alliance.nsili.endpoint.managers.EmailConfiguration;
 import org.codice.alliance.nsili.orb.api.CorbaOrb;
 import org.codice.alliance.nsili.orb.api.CorbaServiceListener;
 import org.codice.ddf.security.common.Security;
@@ -65,6 +69,8 @@ public class NsiliEndpoint implements CorbaServiceListener, QuerySources {
     private LibraryImpl library = null;
 
     private BundleContext context;
+
+    private EmailSender emailSender;
 
     private CatalogFramework framework;
 
@@ -259,6 +265,62 @@ public class NsiliEndpoint implements CorbaServiceListener, QuerySources {
         }
     }
 
+    private EmailConfiguration emailConfiguration = new EmailConfiguration();
+
+    /**
+     * Method sets emailSender field of library
+     *
+     * @param emailSender: Cannot be null
+     */
+    public void setEmailSender(EmailSender emailSender) {
+        notNull(emailSender, "emailSender must be non-null");
+
+        this.emailConfiguration.setEmailSender(emailSender);
+        if (library != null) {
+            library.setEmailConfiguration(emailConfiguration);
+        }
+    }
+
+    /**
+     *
+     * @param emailFrom must be non-null
+     */
+    public void setEmailFrom(String emailFrom) {
+        notNull(emailFrom, "emailFrom must be non-null");
+
+        this.emailConfiguration.setFromEmail(emailFrom);
+        if (library != null) {
+            library.setEmailConfiguration(emailConfiguration);
+        }
+
+    }
+
+    /**
+     *
+     * @param emailSubject must be non-null
+     */
+    public void setEmailSubject(String emailSubject) {
+        notNull(emailSubject, "emailSubject must be non-null");
+
+        this.emailConfiguration.setSubject(emailSubject);
+        if (library != null) {
+            library.setEmailConfiguration(emailConfiguration);
+        }
+    }
+
+    /**
+     *
+     * @param emailBody must be non-null
+     */
+    public void setEmailBody(String emailBody) {
+        notNull(emailBody, "emailBody must be non-null");
+
+        this.emailConfiguration.setBody(emailBody);
+        if (library != null) {
+            library.setEmailConfiguration(emailConfiguration);
+        }
+    }
+
     public void destroy() {
         LOGGER.debug("Destroying NSILI Endpoint");
         if (corbaOrb != null) {
@@ -331,6 +393,7 @@ public class NsiliEndpoint implements CorbaServiceListener, QuerySources {
         library.setRemoveSourceLibrary(removeSourceLibrary);
         library.setOutgoingValidationEnabled(outgoingValidationEnabled);
         library.setMaxWaitToStartTimeMsecs(TimeUnit.SECONDS.toMillis(maxWaitToStartTimeSec));
+        library.setEmailConfiguration(emailConfiguration);
 
         libraryRef = rootPOA.servant_to_reference(library);
 

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/managers/EmailConfiguration.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/managers/EmailConfiguration.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.nsili.endpoint.managers;
+
+import org.codice.alliance.core.email.EmailSender;
+
+public class EmailConfiguration {
+
+    private EmailSender emailSender;
+
+    private String fromEmail;
+
+    private String subject;
+
+    private String body;
+
+    public EmailSender getEmailSender() {
+        return emailSender;
+    }
+
+    public void setEmailSender(EmailSender emailSender) {
+        this.emailSender = emailSender;
+    }
+
+    public String getFromEmail() {
+        return fromEmail;
+    }
+
+    public void setFromEmail(String fromEmail) {
+        this.fromEmail = fromEmail;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+}

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/managers/OrderMgrImpl.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/managers/OrderMgrImpl.java
@@ -62,6 +62,8 @@ public class OrderMgrImpl extends OrderMgrPOA {
 
     private Set<String> querySources = new HashSet<>();
 
+    private EmailConfiguration emailConfiguration;
+
     public void setCatalogFramework(CatalogFramework catalogFramework) {
         this.catalogFramework = catalogFramework;
     }
@@ -114,7 +116,8 @@ public class OrderMgrImpl extends OrderMgrPOA {
                 protocol,
                 port,
                 getAccessManager(),
-                catalogFramework);
+                catalogFramework,
+                emailConfiguration);
 
         String id = UUID.randomUUID()
                 .toString();
@@ -242,4 +245,7 @@ public class OrderMgrImpl extends OrderMgrPOA {
         return accessManager;
     }
 
+    public void setEmailConfiguration(EmailConfiguration emailConfiguration) {
+        this.emailConfiguration = emailConfiguration;
+    }
 }

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/requests/DestinationSink.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/requests/DestinationSink.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.alliance.nsili.endpoint.requests;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import ddf.catalog.data.Metacard;
+
+public interface DestinationSink {
+
+    /**
+     * Write a data stream to a destination.
+     *
+     * @param fileData    the data to write
+     * @param size        the number of bytes to be written
+     * @param name        the name of the file to be written
+     * @param contentType the content type of the file to be written
+     * @param metacards   the metacards associated with the fileData
+     * @throws IOException exception indicating that data could not be written
+     */
+    void writeFile(InputStream fileData, long size, String name, String contentType,
+            List<Metacard> metacards) throws IOException;
+}

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/requests/EmailDestinationSink.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/requests/EmailDestinationSink.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.alliance.nsili.endpoint.requests;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.codice.alliance.nsili.endpoint.managers.EmailConfiguration;
+
+import ddf.catalog.data.Metacard;
+
+/**
+ * Send data as an email attachment.
+ */
+public class EmailDestinationSink implements DestinationSink {
+
+    private static final String METACARD_IDS = "%metacard.ids%";
+
+    private static final String METACARD_TITLES = "%metacard.titles%";
+
+    private final String emailDest;
+
+    private final EmailConfiguration emailConfiguration;
+
+    public EmailDestinationSink(String emailDest, EmailConfiguration emailConfiguration) {
+        this.emailDest = emailDest;
+        this.emailConfiguration = emailConfiguration;
+    }
+
+    @Override
+    public void writeFile(InputStream fileData, long size, String name, String contentType,
+            List<Metacard> metacards) throws IOException {
+        emailConfiguration.getEmailSender()
+                .sendEmail(emailConfiguration.getFromEmail(),
+                        emailDest,
+                        emailConfiguration.getSubject(),
+                        replaceTitles(replaceIds(emailConfiguration.getBody(), metacards), metacards),
+                        Collections.singletonList(new ImmutablePair<>(name, fileData)));
+    }
+
+    private String replaceIds(String bodyTemplate, List<Metacard> metacards) {
+        return bodyTemplate.replace(METACARD_IDS,
+                metacards.stream()
+                        .map(Metacard::getId)
+                        .collect(Collectors.joining(", ")));
+    }
+
+    private String replaceTitles(String bodyTemplate, List<Metacard> metacards) {
+        return bodyTemplate.replace(METACARD_TITLES,
+                metacards.stream()
+                        .map(Metacard::getTitle)
+                        .collect(Collectors.joining(", ")));
+    }
+
+}

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/requests/FtpDestinationSink.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/requests/FtpDestinationSink.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.alliance.nsili.endpoint.requests;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.protocol.HTTP;
+import org.codice.alliance.nsili.common.GIAS.Destination;
+import org.codice.alliance.nsili.common.UCO.FileLocation;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.data.Metacard;
+
+/**
+ * Write data to an FTP server.
+ */
+public class FtpDestinationSink implements DestinationSink {
+    private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(OrderRequestImpl.class);
+
+    private Destination destination;
+
+    private FileLocation fileLocation;
+
+    private String protocol;
+
+    private int port;
+
+    FtpDestinationSink(FileLocation fileLocation, int port, String protocol) {
+        this.fileLocation = fileLocation;
+        this.protocol = protocol;
+        this.port = port;
+    }
+
+    @Override
+    public void writeFile(InputStream fileData, long size, String name, String contentType,
+            List<Metacard> metacards) throws IOException {
+        CloseableHttpClient httpClient = null;
+        String urlPath = protocol + "://" + fileLocation.host_name + ":" + port + "/"
+                + fileLocation.path_name + "/" + name;
+
+        LOGGER.debug("Writing ordered file to URL: {}", urlPath);
+
+        try {
+            HttpPut putMethod = new HttpPut(urlPath);
+            putMethod.addHeader(HTTP.CONTENT_TYPE, contentType);
+            HttpEntity httpEntity = new InputStreamEntity(fileData, size);
+            putMethod.setEntity(httpEntity);
+
+            if (StringUtils.isNotEmpty(fileLocation.user_name) && fileLocation.password != null) {
+                CredentialsProvider credsProvider = new BasicCredentialsProvider();
+                credsProvider.setCredentials(new AuthScope(fileLocation.host_name, port),
+                        new UsernamePasswordCredentials(fileLocation.user_name,
+                                fileLocation.password));
+                httpClient = HttpClients.custom()
+                        .setDefaultCredentialsProvider(credsProvider)
+                        .build();
+            } else {
+                httpClient = HttpClients.createDefault();
+            }
+
+            httpClient.execute(putMethod);
+            fileData.close();
+            putMethod.releaseConnection();
+        } finally {
+            if (httpClient != null) {
+                httpClient.close();
+            }
+        }
+    }
+
+}

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -44,15 +44,23 @@
         <property name="outgoingValidationEnabled" value="false" />
         <property name="libraryVersion" value="NSILI|3.2" />
         <property name="removeSourceLibrary" value="true" />
+        <property name="maxPendingResults" value="10000"/>
         <property name="querySources">
             <array/>
         </property>
-        <property name="corbaOrb" ref="nsiliCorbaOrb" />
+        <property name="corbaOrb" ref="nsiliCorbaOrb"/>
+        <property name="emailSender" ref="emailSender"/>
+        <property name="emailFrom" value="donotreply@nowhere.com"/>
+        <property name="emailSubject" value="requested nsili product"/>
+        <property name="emailBody" value="Attached Resources: %metacard.titles%"/>
     </bean>
 
     <bean id="nsiliWebSvc" class="org.codice.alliance.nsili.endpoint.NsiliWebEndpoint">
         <argument ref="nsiliEndpoint"/>
     </bean>
+
+    <reference id="emailSender" interface="org.codice.alliance.core.email.EmailSender"
+               availability="mandatory"/>
 
     <jaxrs:server id="NsiliService" address="/nsili">
         <jaxrs:serviceBeans>

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -51,6 +51,27 @@
                 name="Enabled Outgoing Validation" id="outgoingValidationEnabled" required="true" type="Boolean"
                 default="false"
         />
+
+        <AD
+                name="Sources to Query:" id="querySources" description="Configured sources to query from this endpoint. Empty list defaults to local only."
+                required="true" type="String" cardinality="1000"
+                default=""
+        />
+
+        <AD
+                name="Email From Address" id="emailFrom" description="The 'from' address used when sending an email to be used when the client request product to be delivered by email."
+                required="true" type="String" default="donotreply@nowhere.com"
+        />
+
+        <AD     name="Email Subject Line" id="emailSubject" description="The subject line used when sending an email to be used when the client request product to be delivered by email."
+                required="true" type="String" default="requested nsili product"
+        />
+
+        <AD
+                name="Email Body" id="emailBody" description="The body text used when sending an email. The tag '%metacards.ids%' will be replaced with a list of metacard identifiers that correspond to the attached file. The tag '%metacards.titles%' will be replaced with a list of metacard titles that correspond to the attached file. To be used when the client request product to be delivered by email. Example: Attached Resources: %metacard.titles%"
+                required="true" type="String" default="Attached Resources: %metacard.titles%"
+        />
+
     </OCD>
 
     <Designate pid="org.codice.alliance.nsili.endpoint">

--- a/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/NsiliEndpointTest.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/NsiliEndpointTest.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.codice.alliance.core.email.EmailSender;
 import org.codice.alliance.nsili.common.GIAS.AccessCriteria;
 import org.codice.alliance.nsili.common.GIAS.LibraryManager;
 import org.codice.alliance.nsili.common.NsiliManagerType;
@@ -71,6 +72,8 @@ public class NsiliEndpointTest extends NsiliCommonTest {
     private AccessCriteria testAccessCriteria;
 
     private CorbaOrb mockCorbaOrb = mock(CorbaOrb.class);
+
+    private String mailHost = "mailhost.dummy.com";
 
     @Before
     public void setUp()
@@ -271,7 +274,7 @@ public class NsiliEndpointTest extends NsiliCommonTest {
         doReturn(new HashSet<>(Arrays.asList(FRAMEWORK_SOURCE_IDS))).when(mockFramework)
                 .getSourceIds();
         nsiliEndpoint.setFramework(mockFramework);
-
+        nsiliEndpoint.setEmailSender(mock(EmailSender.class));
         nsiliEndpoint.init();
     }
 

--- a/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/NsiliLibraryImplTest.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/NsiliLibraryImplTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 
+import org.codice.alliance.core.email.EmailSender;
 import org.codice.alliance.nsili.common.GIAS.LibraryDescription;
 import org.codice.alliance.nsili.common.UCO.InvalidInputParameter;
 import org.codice.alliance.nsili.common.UCO.ProcessingFault;
@@ -112,6 +113,7 @@ public class NsiliLibraryImplTest extends NsiliCommonTest {
         nsiliEndpoint.setSecurityManager(securityManager);
         nsiliEndpoint.setCorbaOrb(mockCorbaOrb);
         nsiliEndpoint.setLibraryVersion("NSILI|3.2");
+        nsiliEndpoint.setEmailSender(mock(EmailSender.class));
         nsiliEndpoint.init();
     }
 }

--- a/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/NsiliWebEndpointTest.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/NsiliWebEndpointTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 
 import javax.ws.rs.core.Response;
 
+import org.codice.alliance.core.email.EmailSender;
 import org.codice.alliance.nsili.orb.api.CorbaOrb;
 import org.junit.After;
 import org.junit.Before;
@@ -77,6 +78,7 @@ public class NsiliWebEndpointTest extends NsiliCommonTest {
         nsiliEndpoint = new NsiliEndpoint();
         nsiliEndpoint.setSecurityManager(securityManager);
         nsiliEndpoint.setCorbaOrb(mockCorbaOrb);
+        nsiliEndpoint.setEmailSender(mock(EmailSender.class));
         nsiliEndpoint.init();
     }
 

--- a/catalog/nsili/catalog-nsili-source/pom.xml
+++ b/catalog/nsili/catalog-nsili-source/pom.xml
@@ -203,7 +203,6 @@
                             jts,
                             antlr4-runtime,
                             guava,
-                            commons-lang3,
                             geospatial,
                             commons-net
                         </Embed-Dependency>

--- a/catalog/nsili/nsili-app/pom.xml
+++ b/catalog/nsili/nsili-app/pom.xml
@@ -62,6 +62,16 @@
             <artifactId>catalog-core-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.codice.alliance.catalog.core</groupId>
+            <artifactId>catalog-email-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.alliance.catalog.core</groupId>
+            <artifactId>catalog-email-impl</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/catalog/nsili/nsili-app/src/main/resources/features.xml
+++ b/catalog/nsili/nsili-app/src/main/resources/features.xml
@@ -27,6 +27,13 @@
         <bundle>mvn:org.codice.alliance.nsili/catalog-nsili-orb-impl/${project.version}</bundle>
     </feature>
 
+    <feature name="catalog-email" install="manual" version="${project.version}"
+             description="Alliance Email Sending Service">
+        <bundle dependency="true">mvn:org.apache.commons/commons-lang3/${commons-lang3.version}</bundle>
+        <bundle>mvn:org.codice.alliance.catalog.core/catalog-email-api/${project.version}</bundle>
+        <bundle>mvn:org.codice.alliance.catalog.core/catalog-email-impl/${project.version}</bundle>
+    </feature>
+
     <feature name="catalog-nsili-source" install="manual" version="${project.version}"
              description="Alliance NSILI Source">
         <feature prerequisite="true">catalog-nsili-orb-impl</feature>
@@ -37,6 +44,8 @@
     <feature name="catalog-nsili-endpoint" install="manual" version="${project.version}"
              description="Alliance NSILI Endpoint">
         <feature prerequisite="true">catalog-nsili-orb-impl</feature>
+        <feature prerequisite="true">catalog-email</feature>
+        <bundle dependency="true">mvn:org.apache.commons/commons-lang3/${commons-lang3.version}</bundle>
         <bundle dependency="true">mvn:org.codice.alliance.catalog.core/catalog-core-api/${project.version}</bundle>
         <bundle>mvn:org.codice.alliance.nsili/catalog-nsili-endpoint/${project.version}</bundle>
         <bundle>mvn:org.codice.alliance.nsili/catalog-nsili-sourcestoquery-ui/${project.version}</bundle>
@@ -45,6 +54,8 @@
     <feature name="nsili-app" install="auto" version="${project.version}"
              description="The Alliance NSILI App provides interoperability with STANAG 4559 compliant services. ::Alliance NSILI">
         <feature prerequisite="true">catalog-app</feature>
+        <bundle dependency="true">mvn:org.apache.commons/commons-lang3/${commons-lang3.version}</bundle>
+        <feature>catalog-email</feature>
         <feature>catalog-nsili-orb-api</feature>
         <feature>catalog-nsili-orb-impl</feature>
         <feature>catalog-nsili-source</feature>

--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -55,6 +55,11 @@
                 <artifactId>commons-beanutils</artifactId>
                 <version>${commons-beanutils.version}</version>
             </dependency>
+            <dependency>
+                <groupId>javax.mail</groupId>
+                <artifactId>mail</artifactId>
+                <version>${javax-mail.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/distribution/sdk/sample-nsili-client/README.md
+++ b/distribution/sdk/sample-nsili-client/README.md
@@ -19,6 +19,6 @@ Codice Alliance contains a sample NSILI client to be used for testing purposes. 
 
 ```
 mvn -Pcorba.client -Dexec.args=IORURL
-e.g. mvn -Pcorba.client -Dexec.args="http://localhost:20002/data/ior.txt"
-     mvn -Pcorba.client -Dexec.args="https://localhost:8993/services/nsili/ior.txt"
+e.g. mvn -Pcorba.client -Dexec.args="url=http://localhost:20002/data/ior.txt"
+     mvn -Pcorba.client -Dexec.args="url=https://localhost:8993/services/nsili/ior.txt,email=test@test.com"
 ```

--- a/distribution/sdk/sample-nsili-client/src/main/java/org/codice/alliance/nsili/client/Client.java
+++ b/distribution/sdk/sample-nsili-client/src/main/java/org/codice/alliance/nsili/client/Client.java
@@ -46,7 +46,20 @@ public class Client {
     public void runTest(String[] args) throws Exception {
         startHttpListener();
 
-        String iorURL = args[0];
+        String iorURL = null;
+        String emailAddress = null;
+
+        String[] arguments = args[0].split(",");
+        for(String argument : arguments) {
+            String[] parts = argument.split("=", 2);
+            if(parts[0].equals("url")) {
+                iorURL = parts[1];
+            } else if(parts[0].equals("email")) {
+                emailAddress = parts[1];
+            }
+
+        }
+
         org.omg.CORBA.ORB orb = org.omg.CORBA.ORB.init(args, null);
 
         POA rootPOA = POAHelper.narrow(orb.resolve_initial_references("RootPOA"));
@@ -54,6 +67,10 @@ public class Client {
                 .activate();
 
         NsiliClient nsiliClient = new NsiliClient(orb, rootPOA);
+
+        if(emailAddress != null) {
+            nsiliClient.setEmailAddress(emailAddress);
+        }
 
         // Get IOR File
         String iorFile = nsiliClient.getIorTextFile(iorURL);

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
         <alliance-nsili>Alliance NSILI</alliance-nsili>
         <alliance-video>Alliance Video</alliance-video>
         <commons-configuration.version>1.10</commons-configuration.version>
+        <javax-mail.version>1.4.4</javax-mail.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
#### What does this PR do?

Add email support to NSILI OrderMgr interface
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@kcwire 
@troymohl 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@beyelerb
@jlcsmith
#### How should this be tested?

1) Build and install Alliance. 
2) Go to Alliance NSILI configuration and select 'Email Sender'. Set the Host field. If you don't know the hostname of your email server, then try running the command 'dig mx DOMAIN.COM' where DOMAIN.COM is the domain name your email address.
3) Ingest content into Alliance.
3) In a shell, go to distribution/sdk/sample-nsili-client. Run the command: mvn -Pcorba.client -Dexec.args="url=https://localhost:8993/services/nsili/ior.txt,email=EMAILADDR" where EMAILADDR is your email address.
#### Any background context you want to provide?

An integration test for the email sender code is planned in another ticket, when the email sender code is migrated to DDF.
#### What are the relevant tickets?

CAL-137
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
