### PR TITLE
CAL-148 imaging-transformer-nitf doesn't clean up temporary files

### DIFF
--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/NitfParserAdapter.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/NitfParserAdapter.java
@@ -14,6 +14,7 @@
 package org.codice.alliance.transformer.nitf;
 
 import java.io.InputStream;
+import java.util.Optional;
 
 import org.codice.imaging.nitf.core.common.NitfFormatException;
 import org.codice.imaging.nitf.fluent.NitfParserInputFlow;
@@ -39,5 +40,15 @@ public class NitfParserAdapter {
      */
     public void wrapException(Exception exception) throws CatalogTransformerException {
         throw new CatalogTransformerException(exception);
+    }
+
+    /**
+     *
+     * @param nitfSegmentsFlow - the NitfSegmentsFlow object to end.  This method call will
+     *                           delete any temp files created by this route.
+     */
+    public void endNitfSegmentsFlow(NitfSegmentsFlow nitfSegmentsFlow) {
+        Optional.of(nitfSegmentsFlow)
+                .ifPresent(flow -> flow.end());
     }
 }

--- a/catalog/imaging/imaging-transformer-nitf/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -67,6 +67,9 @@
             <setBody>
                 <method ref="nitfParserAdapter" method="parseNitf(${body})"/>
             </setBody>
+            <setHeader headerName="nitfSegmentsFlow">
+                <simple>${body}</simple>
+            </setHeader>
             <routingSlip>
                 <method ref="routingSlip" method="channel(${body})"/>
             </routingSlip>
@@ -78,16 +81,19 @@
                 <exception>java.lang.Exception</exception>
                 <bean ref="nitfParserAdapter" method="wrapException"/>
             </onException>
-            <setHeader headerName="metacard">
+            <setBody>
                 <method ref="imageMetacardFactory" method="createMetacard(${header.id})"/>
+            </setBody>
+            <setHeader headerName="nitfSegmentsFlow">
+                <method ref="nitfHeaderTransformer"
+                        method="transform(${header.nitfSegmentsFlow}, ${body})"/>
             </setHeader>
             <setBody>
-                <method ref="nitfHeaderTransformer"
-                        method="transform(${body}, ${header.metacard})"/>
+                <method ref="nitfImageTransformer" method="transform(${header.nitfSegmentsFlow}, ${body})"/>
             </setBody>
-            <setBody>
-                <method ref="nitfImageTransformer" method="transform(${body}, ${header.metacard})"/>
-            </setBody>
+            <setHeader headerName="nitfSegmentsFlow">
+                <method ref="nitfParserAdapter" method="endNitfSegmentsFlow(${header.nitfSegmentsFlow})"/>
+            </setHeader>
         </route>
 
         <route>
@@ -96,16 +102,19 @@
                 <exception>java.lang.Exception</exception>
                 <bean ref="nitfParserAdapter" method="wrapException"/>
             </onException>
-            <setHeader headerName="metacard">
+            <setBody>
                 <method ref="gmtiMetacardFactory" method="createMetacard(${header.id})"/>
+            </setBody>
+            <setHeader headerName="nitfSegmentsFlow">
+                <method ref="nitfHeaderTransformer"
+                        method="transform(${header.nitfSegmentsFlow}, ${body})"/>
             </setHeader>
             <setBody>
-                <method ref="nitfHeaderTransformer"
-                        method="transform(${body}, ${header.metacard})"/>
+                <method ref="nitfGmtiTransformer" method="transform(${header.nitfSegmentsFlow}, ${body})"/>
             </setBody>
-            <setBody>
-                <method ref="nitfGmtiTransformer" method="transform(${body}, ${header.metacard})"/>
-            </setBody>
+            <setHeader headerName="nitfSegmentsFlow">
+                <method ref="nitfParserAdapter" method="endNitfSegmentsFlow(${header.nitfSegmentsFlow})"/>
+            </setHeader>
         </route>
     </camelContext>
 


### PR DESCRIPTION
#### What does this PR do?
This change adds a call to NitfSegmentsFlow.end() at either end of the camel
route. This will delete the temporary files that are created as part of the
NITF ingest process.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@roelens8 
@rzwiefel 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@beyelerb
@jaymcnallie 
 
#### How should this be tested?
1) verify that there are no files in ${DDF_HOME}/data/tmp with names that start with 'nitf'.
2) start DDF
3) ingest any nitf file
4) repeat step 1
     - temporary files should be created during ingest, but removed after ingest is complete.

#### Any background context you want to provide?
On Windows, this test will only succeed when using an imaging-nitf build that includes IMG-191.  On Mac or Linux, the test should succeed with or without IMG-191.

#### What are the relevant tickets?
CAL-148, IMG-191

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests