### PR TITLE
CAL-152 Moved docs to profile to enable excluded docs

### DIFF
--- a/distribution/alliance/pom.xml
+++ b/distribution/alliance/pom.xml
@@ -303,28 +303,7 @@
                             </artifactItems>
                         </configuration>
                     </execution>
-                    <!--Include Documentation-->
-                    <execution>
-                        <id>unpack-alliance-documentation</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.codice.alliance</groupId>
-                                    <artifactId>docs</artifactId>
-                                    <version>${project.version}</version>
-                                    <outputDirectory>${setup.folder}/documentation/alliance
-                                    </outputDirectory>
-                                    <classifier>docs-export</classifier>
-                                    <type>zip</type>
-                                </artifactItem>
-                            </artifactItems>
-                            <overWriteSnapshots>true</overWriteSnapshots>
-                        </configuration>
-                    </execution>
+
                 </executions>
             </plugin>
             <!-- Overwrite system.properties settings -->
@@ -425,4 +404,53 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>documentation</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack-alliance-docs</id>
+                                <!--
+                                The unpack needs to run in an earlier phase than the copy,
+                                due to a recurring bug in maven that causes plugins in the
+                                same lifecycle phase to run in orders other than that which
+                                they were declared in.
+
+                                See https://issues.apache.org/jira/browse/MNG-5799 as well
+                                as the related tickets for more details.
+                                -->
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.codice.alliance</groupId>
+                                            <artifactId>docs</artifactId>
+                                            <version>${project.version}</version>
+                                            <outputDirectory>${setup.folder}/documentation/alliance
+                                            </outputDirectory>
+                                            <classifier>docs-export</classifier>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                    </artifactItems>
+                                    <overWriteSnapshots>true</overWriteSnapshots>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>


### PR DESCRIPTION
#### What does this PR do?

Updates `distribution/alliance/pom.xml` to allow skipping documentation on quick development builds.


#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@AzGoalie @harrison-tarr 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jaymcnallie
@jlcsmith
#### How should this be tested?

successful build with documentation enabled
successful build with documentation disabled


#### What are the relevant tickets?

https://codice.atlassian.net/browse/CAL-152

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

