### PR TITLE
CAL-131 Updated Image Magnification to only set a double as per the Nitf Spec

### DIFF
--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/ImageAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/ImageAttribute.java
@@ -396,9 +396,8 @@ public class ImageAttribute extends NitfAttributeImpl<ImageSegment> {
     public static final ImageAttribute IMAGE_MAGNIFICATION =
             new ImageAttribute("imageMagnification",
                     "IMAG",
-                    segment -> segment.getImageMagnification()
-                            .trim(),
-                    BasicTypes.STRING_TYPE,
+                    ImageSegment::getImageMagnificationAsDouble,
+                    BasicTypes.DOUBLE_TYPE,
                     ATTRIBUTE_NAME_PREFIX);
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ImageAttribute.class);


### PR DESCRIPTION
#### What does this PR do? 
The imageMagnification attribute of a nitf metacard was previously being assigned values of multiple types. This change uses the ImageSegment method to ensure a single double value is returned as described by the NGA NITF requirements document. 

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@peterhuffer @dcruver @clockard 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jaymcnallie
@jlcsmith
@kcwire 

#### How should this be tested?
Review the change. Build.

#### Any background context you want to provide?
#### What are the relevant tickets?
CAL-131: Add all Nitf attributes into Nitf metacard types
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests