### PR TITLE
CAL-159: Ensure that NSIL_SECURITY and NSIL_METADATA_SECURITY are always populated

### DIFF
--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliConstants.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/NsiliConstants.java
@@ -331,6 +331,8 @@ public class NsiliConstants {
 
     public static final String GENERAL_ASSESSMENT = "generalAssessment";
 
+    public static final String NATO = "NATO";
+
     //Association Constants
     public static final String HAS_PART = "HAS PART";
 

--- a/catalog/nsili/catalog-nsili-common/src/test/java/org/codice/alliance/nsili/common/ResultDAGConverterTest.java
+++ b/catalog/nsili/catalog-nsili-common/src/test/java/org/codice/alliance/nsili/common/ResultDAGConverterTest.java
@@ -134,6 +134,7 @@ public class ResultDAGConverterTest {
     @Test
     public void testMandatoryAttributesSuccess() throws Exception {
         MetacardImpl card = getTestCard();
+        card.setAttribute(new AttributeImpl(Core.RESOURCE_DOWNLOAD_URL, "http://test/file.jpg"));
 
         ResultImpl result = new ResultImpl();
         result.setMetacard(card);
@@ -146,6 +147,40 @@ public class ResultDAGConverterTest {
                 new ArrayList<>(),
                 mandatoryAttrs);
         assertThat(dag, notNullValue());
+
+        String fileArchiveAttr = NsiliConstants.NSIL_PRODUCT + ":" + NsiliConstants.NSIL_FILE + "."
+                + NsiliConstants.ARCHIVED;
+        assertThat(checkDagContains(dag, fileArchiveAttr), is(true));
+
+        String securityClassAttr =
+                NsiliConstants.NSIL_PRODUCT + ":" + NsiliConstants.NSIL_SECURITY + "."
+                        + NsiliConstants.CLASSIFICATION;
+        assertThat(checkDagContains(dag, securityClassAttr), is(true));
+
+        String securityPolicyAttr =
+                NsiliConstants.NSIL_PRODUCT + ":" + NsiliConstants.NSIL_SECURITY + "."
+                        + NsiliConstants.POLICY;
+        assertThat(checkDagContains(dag, securityPolicyAttr), is(true));
+
+        String securityReleasabilityAttr =
+                NsiliConstants.NSIL_PRODUCT + ":" + NsiliConstants.NSIL_SECURITY + "."
+                        + NsiliConstants.RELEASABILITY;
+        assertThat(checkDagContains(dag, securityReleasabilityAttr), is(true));
+
+        String metadataSecurityClassAttr =
+                NsiliConstants.NSIL_PRODUCT + ":" + NsiliConstants.NSIL_METADATA_SECURITY + "."
+                        + NsiliConstants.CLASSIFICATION;
+        assertThat(checkDagContains(dag, metadataSecurityClassAttr), is(true));
+
+        String metadataSecurityPolicyAttr =
+                NsiliConstants.NSIL_PRODUCT + ":" + NsiliConstants.NSIL_METADATA_SECURITY + "."
+                        + NsiliConstants.POLICY;
+        assertThat(checkDagContains(dag, metadataSecurityPolicyAttr), is(true));
+
+        String metadataSecurityReleasabilityAttr =
+                NsiliConstants.NSIL_PRODUCT + ":" + NsiliConstants.NSIL_METADATA_SECURITY + "."
+                        + NsiliConstants.RELEASABILITY;
+        assertThat(checkDagContains(dag, metadataSecurityReleasabilityAttr), is(true));
     }
 
     @Test

--- a/distribution/sdk/sample-nsili-client/src/main/java/org/codice/alliance/nsili/client/NsiliClient.java
+++ b/distribution/sdk/sample-nsili-client/src/main/java/org/codice/alliance/nsili/client/NsiliClient.java
@@ -128,6 +128,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.MetacardTypeImpl;
 import ddf.catalog.resource.impl.URLResourceReader;
 
 public class NsiliClient {
@@ -882,6 +883,7 @@ public class NsiliClient {
 
     private String getProductID(DAG dag) {
         DAGConverter dagConverter = new DAGConverter(new URLResourceReader());
+        dagConverter.setNsiliMetacardType(new MetacardTypeImpl("TestNsiliMetacardType", new ArrayList<>()));
         Metacard metacard = dagConverter.convertDAG(dag, false, "");
         return metacard.getId();
     }


### PR DESCRIPTION
#### What does this PR do?

Fixes issue where NSIL_SECURITY and/or NSIL_METADATA_SECURITY were not always being set. These are mandatory fields in NSILI and they are now defaulted per the spec. Additionally, fixed a regression error where NSIL_FILE.ARCHIVE was not being in all cases, and set defaults on mandatory fields.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@bdeining 
@peterhuffer 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@jlcsmith
@millerw8 
#### How should this be tested?

Run a full build and the standalone test client in alliance/distribution/sdk/sample-nsili-client:
mvn -nsu -Pcorba.client -Dexec.args="https://localhost:8993/services/nsili/ior.txt"

Test with CSD Alpha.
#### Any background context you want to provide?
#### What are the relevant tickets?

https://codice.atlassian.net/browse/CAL-159
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
