### PR TITLE
CAL-164 Set the log level to trace in the MpegTsUdpClient

### DIFF
--- a/distribution/sdk/sample-mpegts-streamgenerator/pom.xml
+++ b/distribution/sdk/sample-mpegts-streamgenerator/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.12</version>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/distribution/sdk/sample-mpegts-streamgenerator/src/main/java/org/codice/alliance/distribution/sdk/video/stream/mpegts/MpegTsUdpClient.java
+++ b/distribution/sdk/sample-mpegts-streamgenerator/src/main/java/org/codice/alliance/distribution/sdk/video/stream/mpegts/MpegTsUdpClient.java
@@ -55,7 +55,12 @@ import io.netty.channel.socket.nio.NioDatagramChannel;
  */
 public class MpegTsUdpClient {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(MpegTsUdpClient.class);
+    private static final Logger LOGGER;
+
+    static {
+        System.setProperty(org.slf4j.impl.SimpleLogger.DEFAULT_LOG_LEVEL_KEY, "TRACE");
+        LOGGER = LoggerFactory.getLogger(MpegTsUdpClient.class);
+    }
 
     private static final int PACKET_SIZE = 188;
 
@@ -73,7 +78,6 @@ public class MpegTsUdpClient {
     private static final boolean HANDLE_QUOTING = false;
 
     public static void main(String[] args) {
-
         String[] arguments = args[0].split(",");
 
         if (arguments.length < 1) {


### PR DESCRIPTION
#### What does this PR do?
This PR sets the log level to trace for the MpegTsUdpClient so valuable information can be seen 
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@troymohl 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@jlcsmith
#### How should this be tested?
Run the sample-mpegts-generator maven profile (see README).
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

