### PR TITLE
CAL-167 Added Image Nitf constants to ImageMetacardType

### DIFF
--- a/catalog/imaging/imaging-transformer-nitf/pom.xml
+++ b/catalog/imaging/imaging-transformer-nitf/pom.xml
@@ -145,7 +145,9 @@
                             jai-imageio-jpeg2000,
                             commons-lang3
                         </Embed-Dependency>
-                        <Export-Package/>
+                        <Export-Package>
+                            org.codice.alliance.transformer.nitf.image
+                        </Export-Package>
                         <Import-Package>!sun.security.action,*</Import-Package>
                     </instructions>
                 </configuration>

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/ImageMetacardType.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/ImageMetacardType.java
@@ -16,6 +16,7 @@ package org.codice.alliance.transformer.nitf.image;
 import org.codice.alliance.catalog.core.api.impl.types.IsrAttributes;
 import org.codice.alliance.catalog.core.api.impl.types.SecurityAttributes;
 import org.codice.alliance.transformer.nitf.AbstractNitfMetacardType;
+import org.codice.alliance.transformer.nitf.ExtNitfUtility;
 import org.codice.alliance.transformer.nitf.common.AcftbAttribute;
 import org.codice.alliance.transformer.nitf.common.AimidbAttribute;
 import org.codice.alliance.transformer.nitf.common.NitfHeaderAttribute;
@@ -32,6 +33,112 @@ import ddf.catalog.data.impl.types.ValidationAttributes;
 
 public class ImageMetacardType extends AbstractNitfMetacardType {
     private static final String NAME = "isr.image";
+
+    public static final String COMPLEXITY_LEVEL =
+            ExtNitfUtility.EXT_NITF_PREFIX + "complexityLevel";
+
+    public static final String FILE_CLASSIFICATION_AUTHORITY = ExtNitfUtility.EXT_NITF_PREFIX
+            + "fileClassificationAuthority";
+
+    public static final String FILE_CLASSIFICATION_AUTHORITY_TYPE = ExtNitfUtility.EXT_NITF_PREFIX
+            + "fileClassificationAuthorityType";
+
+    public static final String FILE_CLASSIFICATION_REASON = ExtNitfUtility.EXT_NITF_PREFIX
+            + "fileClassificationReason";
+
+    public static final String FILE_CLASSIFICATION_SECURITY_SYSTEM = ExtNitfUtility.EXT_NITF_PREFIX
+            + "fileClassificationSecuritySystem";
+
+    public static final String FILE_CLASSIFICATION_TEXT = ExtNitfUtility.EXT_NITF_PREFIX
+            + "fileClassificationText";
+
+    public static final String FILE_CODE_WORDS =
+            ExtNitfUtility.EXT_NITF_PREFIX + "fileCodewords";
+
+    public static final String FILE_CONTROL_AND_HANDLING = ExtNitfUtility.EXT_NITF_PREFIX
+            + "fileControlAndHandling";
+
+    public static final String FILE_DATE_AND_TIME =
+            ExtNitfUtility.EXT_NITF_PREFIX + "fileDateAndTime";
+
+    public static final String FILE_DECLASSIFICATION_DATE = ExtNitfUtility.EXT_NITF_PREFIX
+            + "fileDeclassificationDate";
+
+    public static final String FILE_DECLASSIFICATION_TYPE = ExtNitfUtility.EXT_NITF_PREFIX
+            + "fileDeclassificationType";
+
+    public static final String FILE_RELEASING_INSTRUCTIONS = ExtNitfUtility.EXT_NITF_PREFIX
+            + "fileReleasingInstructions";
+
+    public static final String FILE_SECURITY_CLASSIFICATION = ExtNitfUtility.EXT_NITF_PREFIX
+            + "fileSecurityClassification";
+
+    public static final String FILE_SECURITY_CONTROL_NUMBER = ExtNitfUtility.EXT_NITF_PREFIX
+            + "fileSecurityControlNumber";
+
+    public static final String FILE_SECURITY_SOURCE_DATE = ExtNitfUtility.EXT_NITF_PREFIX
+            + "fileSecuritySourceDate";
+
+    public static final String FILE_TITLE =
+            ExtNitfUtility.EXT_NITF_PREFIX + "fileTitle";
+
+    public static final String FILE_VERSION =
+            ExtNitfUtility.EXT_NITF_PREFIX + "fileVersion";
+
+    public static final String ORIGINATORS_NAME =
+            ExtNitfUtility.EXT_NITF_PREFIX + "originatorsName";
+
+    public static final String ORIGINATING_STATION_ID = ExtNitfUtility.EXT_NITF_PREFIX
+            + "originatingStationId";
+
+    public static final String FILE_PART_TYPE =
+            ExtNitfUtility.EXT_NITF_PREFIX + "filePartType";
+
+    public static final String IMAGE_CATEGORY =
+            ExtNitfUtility.EXT_NITF_PREFIX + "imageCategory";
+
+    public static final String IMAGE_COMMENT_1 =
+            ExtNitfUtility.EXT_NITF_PREFIX + "imageComment1";
+
+    public static final String IMAGE_COMPRESSION =
+            ExtNitfUtility.EXT_NITF_PREFIX + "imageCompression";
+
+    public static final String IMAGE_COORDINATE_REPRESENTATION = ExtNitfUtility.EXT_NITF_PREFIX
+            + "imageCoordinateRepresentation";
+
+    public static final String IMAGE_DATE_AND_TIME =
+            ExtNitfUtility.EXT_NITF_PREFIX + "imageDateAndTime";
+
+    public static final String IMAGE_IDENTIFIER_1 =
+            ExtNitfUtility.EXT_NITF_PREFIX + "imageIdentifier1";
+
+    public static final String IMAGE_MAGNIFICATION =
+            ExtNitfUtility.EXT_NITF_PREFIX + "imageMagnification";
+
+    public static final String IMAGE_MODE =
+            ExtNitfUtility.EXT_NITF_PREFIX + "imageMode";
+
+    public static final String IMAGE_REPRESENTATION =
+            ExtNitfUtility.EXT_NITF_PREFIX + "imageRepresentation";
+
+    public static final String IMAGE_SOURCE =
+            ExtNitfUtility.EXT_NITF_PREFIX + "imageSource";
+
+    public static final String NUMBER_OF_BANDS =
+            ExtNitfUtility.EXT_NITF_PREFIX + "numberOfBands";
+
+    public static final String NUMBER_OF_BITS_PER_PIXEL =
+            ExtNitfUtility.EXT_NITF_PREFIX + "numberOfBitsPerPixel";
+
+    public static final String NUMBER_OF_SIGNIFICANT_COLUMNS_IN_IMAGE =
+            ExtNitfUtility.EXT_NITF_PREFIX
+                    + "numberOfSignificantColumnsInImage";
+
+    public static final String NUMBER_OF_SIGNIFICANT_ROWS_IN_IMAGE = ExtNitfUtility.EXT_NITF_PREFIX
+            + "numberOfSignificantRowsInImage";
+
+    public static final String TARGET_IDENTIFIER =
+            ExtNitfUtility.EXT_NITF_PREFIX + "targetIdentifier";
 
     public ImageMetacardType() {
         super(NAME, null);


### PR DESCRIPTION
#### What does this PR do?
Currently the Nitf image attributes are referenced by calling **ExtNitfUtility.EXT_NITF_PREFIX + ImageAttribute.SPECIFIC_ATTRIBUTE.getLongName()** or using the literal string value. Constant values have been added to the ImageMetacardType so that other developers can access these attributes more easily and improve maintainability.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@brendan-hofmann @peterhuffer @dcruver @clockard 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jaymcnallie
@jlcsmith 

#### How should this be tested?
Inspect the changes, make sure the build is successful.

#### Any background context you want to provide?
#### What are the relevant tickets?
CAL-167 https://codice.atlassian.net/browse/CAL-167

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

