### PR TITLE
CAL-163 Implement KLV security classification mapping

### DIFF
--- a/catalog/core/catalog-core-classification-api/pom.xml
+++ b/catalog/core/catalog-core-classification-api/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.codice.alliance.catalog</groupId>
+        <artifactId>core</artifactId>
+        <version>0.2-SNAPSHOT</version>
+    </parent>
+    <groupId>org.codice.alliance.catalog.core</groupId>
+    <artifactId>catalog-core-classification-api</artifactId>
+    <packaging>bundle</packaging>
+    <name>Alliance :: Catalog :: Core :: Security Classification :: API</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Export-Package>
+                            org.codice.alliance.catalog.core.internal.api.classification
+                        </Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/catalog/core/catalog-core-classification-api/src/main/java/org/codice/alliance/catalog/core/internal/api/classification/SecurityClassificationService.java
+++ b/catalog/core/catalog-core-classification-api/src/main/java/org/codice/alliance/catalog/core/internal/api/classification/SecurityClassificationService.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.catalog.core.internal.api.classification;
+
+import java.util.Comparator;
+
+/**
+ * <b> This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ */
+public interface SecurityClassificationService {
+
+    /**
+     * Get a comparator for comparing two security classification strings. Classification strings
+     * will be sorted so that the lowest security is first and the highest security is last.
+     *
+     * @return non-null value
+     */
+    Comparator<String> getSecurityClassificationComparator();
+
+}

--- a/catalog/core/catalog-core-classification-impl/pom.xml
+++ b/catalog/core/catalog-core-classification-impl/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.codice.alliance.catalog</groupId>
+        <artifactId>core</artifactId>
+        <version>0.2-SNAPSHOT</version>
+    </parent>
+    <groupId>org.codice.alliance.catalog.core</groupId>
+    <artifactId>catalog-core-classification-impl</artifactId>
+    <packaging>bundle</packaging>
+    <name>Alliance :: Catalog :: Core :: Security Classification :: Impl</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.codice.alliance.catalog.core</groupId>
+            <artifactId>catalog-core-classification-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.95</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.95</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.95</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.95</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/catalog/core/catalog-core-classification-impl/src/main/java/org/codice/alliance/catalog/core/internal/impl/classification/SecurityClassificationServiceImpl.java
+++ b/catalog/core/catalog-core-classification-impl/src/main/java/org/codice/alliance/catalog/core/internal/impl/classification/SecurityClassificationServiceImpl.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.catalog.core.internal.impl.classification;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.ws.Holder;
+
+import org.codice.alliance.catalog.core.internal.api.classification.SecurityClassificationService;
+
+/**
+ * Returns a comparator that sorts classification strings based on a user defined sort order {@link #setSortOrder(List)}.
+ * If a comparator encounters a classification string that was not in the user defined sort order, then
+ * that string will be given the highest possible sort priority.
+ * <p>
+ * <b> This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ */
+public class SecurityClassificationServiceImpl implements SecurityClassificationService {
+
+    private volatile SecurityClassificationComparator comparator;
+
+    private static String normalize(String s) {
+        return s.replaceAll("\\s", "")
+                .toLowerCase();
+    }
+
+    @Override
+    public Comparator<String> getSecurityClassificationComparator() {
+        return comparator;
+    }
+
+    /**
+     * Leading and trailing whitespace will be trimmed.
+     *
+     * @param rawSortOrder a pipe-separated list of classification strings
+     */
+    public void setSortOrder(List<String> rawSortOrder) {
+        Map<String, Integer> newSecurityClassificationSortOrder = new HashMap<>();
+
+        Holder<Integer> i = new Holder<>(0);
+        rawSortOrder.forEach(classification -> {
+            newSecurityClassificationSortOrder.put(normalize(classification), i.value);
+            i.value++;
+        });
+
+        comparator = new SecurityClassificationComparator(newSecurityClassificationSortOrder);
+    }
+
+    private static class SecurityClassificationComparator implements Comparator<String> {
+
+        private final Map<String, Integer> securityClassificationSortOrder;
+
+        private SecurityClassificationComparator(
+                Map<String, Integer> securityClassificationSortOrder) {
+            this.securityClassificationSortOrder = securityClassificationSortOrder;
+        }
+
+        @Override
+        public int compare(String classification1, String classification2) {
+            Integer sortOrder1 = securityClassificationSortOrder.get(normalize(classification1));
+            Integer sortOrder2 = securityClassificationSortOrder.get(normalize(classification2));
+
+            if (sortOrder1 == null) {
+                sortOrder1 = Integer.MAX_VALUE;
+            }
+
+            if (sortOrder2 == null) {
+                sortOrder2 = Integer.MAX_VALUE;
+            }
+
+            return sortOrder1.compareTo(sortOrder2);
+        }
+    }
+}

--- a/catalog/core/catalog-core-classification-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/core/catalog-core-classification-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+           xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0
+           http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+
+    <bean id="securityClassificationService" class="org.codice.alliance.catalog.core.internal.impl.classification.SecurityClassificationServiceImpl">
+        <cm:managed-properties
+                persistent-id="org.codice.alliance.catalog.core.internal.impl.classification.SecurityClassificationServiceImpl"
+                update-strategy="container-managed"/>
+        <property name="sortOrder">
+            <list>
+                <value>u</value>
+                <value>unclassified</value>
+                <value>r</value>
+                <value>restricted</value>
+                <value>c</value>
+                <value>confidential</value>
+                <value>s</value>
+                <value>secret</value>
+                <value>ts</value>
+                <value>top secret</value>
+            </list>
+        </property>
+    </bean>
+
+    <service ref="securityClassificationService" interface="org.codice.alliance.catalog.core.internal.api.classification.SecurityClassificationService"/>
+
+</blueprint>

--- a/catalog/core/catalog-core-classification-impl/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/core/catalog-core-classification-impl/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
+
+    <OCD name="Security Classification Service"
+         id="org.codice.alliance.catalog.core.internal.impl.classification.SecurityClassificationServiceImpl">
+
+        <AD
+                description="Security classification sort order. The least restrictive classification string should be the first entry in the list and the most restrictive classification string should be the last entry."
+                name="Sort Order" id="sortOrder" required="true"
+                type="String" cardinality="100" default="u,unclassified,r,restricted,c,confidential,s,secret,ts,top secret"/>
+
+    </OCD>
+
+    <Designate pid="org.codice.alliance.catalog.core.internal.impl.classification.SecurityClassificationServiceImpl">
+        <Object ocdref="org.codice.alliance.catalog.core.internal.impl.classification.SecurityClassificationServiceImpl"/>
+    </Designate>
+
+</metatype:MetaData>

--- a/catalog/core/catalog-core-classification-impl/src/test/java/org/codice/alliance/catalog/core/internal/impl/classification/SecurityClassificationServiceImplTest.java
+++ b/catalog/core/catalog-core-classification-impl/src/test/java/org/codice/alliance/catalog/core/internal/impl/classification/SecurityClassificationServiceImplTest.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.catalog.core.internal.impl.classification;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+public class SecurityClassificationServiceImplTest {
+
+    @Test
+    public void testSort() {
+        SecurityClassificationServiceImpl service = new SecurityClassificationServiceImpl();
+        service.setSortOrder(Arrays.asList("a", "b", "c"));
+        List<String> in = Arrays.asList("a", "b", "c", "a", "b", "c", "a", "b", "c");
+        Collections.sort(in, service.getSecurityClassificationComparator());
+        assertThat(in, is(Arrays.asList("a", "a", "a", "b", "b", "b", "c", "c", "c")));
+    }
+
+    @Test
+    public void testSortWithoutSortOrderEntry() {
+        SecurityClassificationServiceImpl service = new SecurityClassificationServiceImpl();
+        service.setSortOrder(Arrays.asList("a", "b"));
+        List<String> in = Arrays.asList("a", "b", "c", "a", "b", "c", "a", "b", "c");
+        Collections.sort(in, service.getSecurityClassificationComparator());
+        assertThat(in, is(Arrays.asList("a", "a", "a", "b", "b", "b", "c", "c", "c")));
+    }
+
+    @Test
+    public void testSetSortedOrder() {
+        SecurityClassificationServiceImpl service = new SecurityClassificationServiceImpl();
+        service.setSortOrder(Arrays.asList(" c ", "\t\tb ", "   a \n\n"));
+        List<String> in = Arrays.asList("a", "b", "c", "a", "b", "c", "a", "b", "c");
+        Collections.sort(in, service.getSecurityClassificationComparator());
+        assertThat(in, is(Arrays.asList("c", "c", "c", "b", "b", "b", "a", "a", "a")));
+    }
+
+}

--- a/catalog/core/pom.xml
+++ b/catalog/core/pom.xml
@@ -32,6 +32,8 @@
         <module>catalog-core-metacardtypes</module>
         <module>catalog-email-api</module>
         <module>catalog-email-impl</module>
+        <module>catalog-core-classification-api</module>
+        <module>catalog-core-classification-impl</module>
     </modules>
 
 </project>

--- a/catalog/security/security-app/pom.xml
+++ b/catalog/security/security-app/pom.xml
@@ -43,6 +43,16 @@
             <artifactId>catalog-plugin-defaultsecurityattributevalues</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.codice.alliance.catalog.core</groupId>
+            <artifactId>catalog-core-classification-impl</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.alliance.catalog.core</groupId>
+            <artifactId>catalog-core-classification-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/catalog/security/security-app/src/main/resources/features.xml
+++ b/catalog/security/security-app/src/main/resources/features.xml
@@ -36,4 +36,12 @@
              description="The Alliance Security App provides features to enhance security. ::Alliance Security">
         <feature prerequisite="true">catalog-app</feature>
     </feature>
+
+    <feature name="security-classification-service" install="auto" version="${project.version}"
+             description="Service for ranking/sorting security classification strings.">
+        <bundle dependency="true">mvn:org.apache.commons/commons-lang3/${commons-lang3.version}</bundle>
+        <bundle>mvn:org.codice.alliance.catalog.core/catalog-core-classification-api/${project.version}</bundle>
+        <bundle>mvn:org.codice.alliance.catalog.core/catalog-core-classification-impl/${project.version}</bundle>
+    </feature>
+
 </features>

--- a/catalog/video/video-app/src/main/resources/features.xml
+++ b/catalog/video/video-app/src/main/resources/features.xml
@@ -19,6 +19,7 @@
     <feature name="mpegts-stream" install="auto" version="${project.version}"
              description="Consume UDP MPEG-TS Stream">
         <feature prerequisite="true">video-app</feature>
+        <feature prerequisite="true">security-classification-service</feature>
         <bundle>mvn:org.codice.alliance.video/video-mpegts-transformer/${project.version}
         </bundle>
         <bundle>mvn:org.codice.alliance.video/video-mpegts-stream/${project.version}</bundle>
@@ -28,6 +29,7 @@
     <feature name="mpegts-input-transformer" install="auto" version="${project.version}"
              description="Transform MPEG-TS Files">
         <feature prerequisite="true">video-app</feature>
+        <feature prerequisite="true">security-classification-service</feature>
         <bundle>mvn:org.codice.alliance.video/video-mpegts-transformer/${project.version}
         </bundle>
         <configfile finalname="/etc/DDF_Custom_Mime_Type_Resolver.mpegts.config">
@@ -40,6 +42,7 @@
         <feature prerequisite="true">catalog-app</feature>
         <feature prerequisite="true">catalog-core-validator</feature>
         <feature prerequisite="true">catalog-core-validationparser</feature>
+        <feature prerequisite="true">security-classification-service</feature>
         <bundle dependency="true">mvn:com.google.guava/guava/${guava.version}</bundle>
         <bundle>mvn:org.codice.ddf/klv/${ddf.version}</bundle>
         <bundle>mvn:org.codice.alliance.catalog.core/catalog-core-api/${project.version}</bundle>

--- a/catalog/video/video-mpegts-stream/pom.xml
+++ b/catalog/video/video-mpegts-stream/pom.xml
@@ -127,7 +127,11 @@
             <artifactId>video-security</artifactId>
             <version>${project.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.codice.alliance.catalog.core</groupId>
+            <artifactId>catalog-core-classification-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/metacard/MetacardUpdater.java
+++ b/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/metacard/MetacardUpdater.java
@@ -40,6 +40,8 @@ public interface MetacardUpdater {
         void visit(UnionSingleMetacardUpdater unionMetacardUpdater);
 
         void visit(CreatedDateMetacardUpdater createdDateMetacardUpdater);
+
+        void visit(SecurityClassificationMetacardUpdater securityClassificationMetacardUpdater);
     }
 
 }

--- a/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/metacard/SecurityClassificationMetacardUpdater.java
+++ b/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/metacard/SecurityClassificationMetacardUpdater.java
@@ -13,15 +13,71 @@
  */
 package org.codice.alliance.video.stream.mpegts.metacard;
 
-import org.codice.alliance.libs.klv.AttributeNameConstants;
+import static org.apache.commons.lang.Validate.notNull;
 
-public class SecurityClassificationMetacardUpdater extends UnionSingleMetacardUpdater {
-    public SecurityClassificationMetacardUpdater() {
-        super(AttributeNameConstants.SECURITY_CLASSIFICATION);
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import org.codice.alliance.catalog.core.api.types.Security;
+import org.codice.alliance.catalog.core.internal.api.classification.SecurityClassificationService;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+
+/**
+ * Get the Security.CLASSIFICATION strings from the parent and child metacards, select the
+ * string with the highest security rating, and set the parent metacard Security.CLASSIFICATION
+ * with that rating. Uses {@link SecurityClassificationService#getSecurityClassificationComparator()}
+ * to get a comparator that will be used to sort the security strings from the lowest to highest
+ * security rating.
+ */
+public class SecurityClassificationMetacardUpdater implements MetacardUpdater {
+
+    private SecurityClassificationService securityClassificationService;
+
+    /**
+     * @param securityClassificationService must be non-null
+     */
+    public SecurityClassificationMetacardUpdater(
+            SecurityClassificationService securityClassificationService) {
+        notNull(securityClassificationService, "securityClassificationService must be non-null");
+        this.securityClassificationService = securityClassificationService;
     }
 
     @Override
     public String toString() {
         return "SecurityClassificationMetacardUpdater{}";
+    }
+
+    @Override
+    public void update(Metacard parent, Metacard child) {
+
+        Comparator<String> comparator =
+                securityClassificationService.getSecurityClassificationComparator();
+
+        Stream.of(parent, child)
+                .map(this::getAttribute)
+                .filter(Objects::nonNull)
+                .map(Attribute::getValues)
+                .filter(Objects::nonNull)
+                .flatMap(Collection::stream)
+                .filter(String.class::isInstance)
+                .map(String.class::cast)
+                .max(comparator)
+                .ifPresent(classification -> {
+                    parent.setAttribute(new AttributeImpl(Security.CLASSIFICATION, classification));
+                });
+    }
+
+    private Attribute getAttribute(Metacard metacard) {
+        return metacard.getAttribute(Security.CLASSIFICATION);
+    }
+
+    @Override
+    public void accept(Visitor visitor) {
+        visitor.visit(this);
     }
 }

--- a/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/netty/UdpStreamProcessor.java
+++ b/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/netty/UdpStreamProcessor.java
@@ -40,6 +40,7 @@ import org.codice.alliance.video.stream.mpegts.metacard.LineStringMetacardUpdate
 import org.codice.alliance.video.stream.mpegts.metacard.LocationMetacardUpdater;
 import org.codice.alliance.video.stream.mpegts.metacard.MetacardUpdater;
 import org.codice.alliance.video.stream.mpegts.metacard.ModifiedDateMetacardUpdater;
+import org.codice.alliance.video.stream.mpegts.metacard.SecurityClassificationMetacardUpdater;
 import org.codice.alliance.video.stream.mpegts.metacard.TemporalEndMetacardUpdater;
 import org.codice.alliance.video.stream.mpegts.metacard.TemporalStartMetacardUpdater;
 import org.codice.alliance.video.stream.mpegts.metacard.UnionMetacardUpdater;
@@ -203,6 +204,11 @@ public class UdpStreamProcessor implements StreamProcessor {
 
             @Override
             public void visit(CreatedDateMetacardUpdater createdDateMetacardUpdater) {
+
+            }
+
+            @Override
+            public void visit(SecurityClassificationMetacardUpdater securityClassificationMetacardUpdater) {
 
             }
         });

--- a/catalog/video/video-mpegts-stream/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/video/video-mpegts-stream/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -23,6 +23,10 @@
     <reference-list id="metacardTypeList" interface="ddf.catalog.data.MetacardType"
                     filter="(name=isr.video)" availability="mandatory"/>
 
+    <reference id="securityClassificationService"
+               interface="org.codice.alliance.catalog.core.internal.api.classification.SecurityClassificationService"
+               availability="mandatory"/>
+
     <reference id="catalogFramework" interface="ddf.catalog.CatalogFramework"/>
 
     <bean id="geometryFunction" class="org.codice.alliance.libs.klv.GeometryOperatorList">
@@ -151,7 +155,9 @@
                             <bean class="org.codice.alliance.video.stream.mpegts.metacard.PlatformDesignationMetacardUpdater"/>
                             <bean class="org.codice.alliance.video.stream.mpegts.metacard.ImageCoordSystemMetacardUpdater"/>
                             <bean class="org.codice.alliance.video.stream.mpegts.metacard.ImageSourceSensorMetacardUpdater"/>
-                            <bean class="org.codice.alliance.video.stream.mpegts.metacard.SecurityClassificationMetacardUpdater"/>
+                            <bean class="org.codice.alliance.video.stream.mpegts.metacard.SecurityClassificationMetacardUpdater">
+                                <argument ref="securityClassificationService"/>
+                            </bean>
                             <bean class="org.codice.alliance.video.stream.mpegts.metacard.LocationCountryCodeMetacardUpdater"/>
                             <bean class="org.codice.alliance.video.stream.mpegts.metacard.SecurityCodewordsMetacardUpdater"/>
                             <bean class="org.codice.alliance.video.stream.mpegts.metacard.SecurityDisseminationControlsMetacardUpdater"/>

--- a/catalog/video/video-mpegts-transformer/pom.xml
+++ b/catalog/video/video-mpegts-transformer/pom.xml
@@ -197,7 +197,7 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.79</minimum>
+                                            <minimum>0.87</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
@@ -207,12 +207,12 @@
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.41</minimum>
+                                            <minimum>0.22</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.87</minimum>
+                                            <minimum>0.58</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/video/video-mpegts-transformer/src/main/java/org/codice/alliance/transformer/video/MpegTsInputTransformer.java
+++ b/catalog/video/video-mpegts-transformer/src/main/java/org/codice/alliance/transformer/video/MpegTsInputTransformer.java
@@ -26,9 +26,11 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.io.IOUtils;
 import org.codice.alliance.libs.klv.AttributeNameConstants;
+import org.codice.alliance.libs.klv.BaseKlvProcessorVisitor;
 import org.codice.alliance.libs.klv.KlvHandler;
 import org.codice.alliance.libs.klv.KlvHandlerFactory;
 import org.codice.alliance.libs.klv.KlvProcessor;
+import org.codice.alliance.libs.klv.SecurityClassificationKlvProcessor;
 import org.codice.alliance.libs.klv.Stanag4609ParseException;
 import org.codice.alliance.libs.klv.Stanag4609Parser;
 import org.codice.alliance.libs.klv.Stanag4609Processor;
@@ -55,6 +57,8 @@ public class MpegTsInputTransformer implements InputTransformer {
     private static final Logger LOGGER = LoggerFactory.getLogger(MpegTsInputTransformer.class);
 
     private static final Integer DEFAULT_SUBSAMPLE_COUNT = 50;
+
+    private static final String CLASSIFICATION_MUST_BE_NON_NULL = "classification must be non-null";
 
     private final InputTransformer innerTransformer;
 
@@ -130,6 +134,42 @@ public class MpegTsInputTransformer implements InputTransformer {
     public Metacard transform(InputStream inputStream)
             throws IOException, CatalogTransformerException {
         return transform(inputStream, null);
+    }
+
+    public void setSecurityClassificationCode1(String classification) {
+        notNull(classification, CLASSIFICATION_MUST_BE_NON_NULL);
+        klvProcessor.accept(new SetSecurityClassificationString((short) 1, classification));
+    }
+
+    public void setSecurityClassificationCode2(String classification) {
+        notNull(classification, CLASSIFICATION_MUST_BE_NON_NULL);
+        klvProcessor.accept(new SetSecurityClassificationString((short) 2, classification));
+    }
+
+    public void setSecurityClassificationCode3(String classification) {
+        notNull(classification, CLASSIFICATION_MUST_BE_NON_NULL);
+        klvProcessor.accept(new SetSecurityClassificationString((short) 3, classification));
+    }
+
+    public void setSecurityClassificationCode4(String classification) {
+        notNull(classification, CLASSIFICATION_MUST_BE_NON_NULL);
+        klvProcessor.accept(new SetSecurityClassificationString((short) 4, classification));
+    }
+
+    public void setSecurityClassificationCode5(String classification) {
+        notNull(classification, CLASSIFICATION_MUST_BE_NON_NULL);
+        klvProcessor.accept(new SetSecurityClassificationString((short) 5, classification));
+    }
+
+    public void setSecurityClassificationDefault(String classification) {
+        notNull(classification, CLASSIFICATION_MUST_BE_NON_NULL);
+        klvProcessor.accept(new BaseKlvProcessorVisitor() {
+            @Override
+            public void visit(
+                    SecurityClassificationKlvProcessor securityClassificationKlvProcessor) {
+                securityClassificationKlvProcessor.setDefaultSecurityClassification(classification);
+            }
+        });
     }
 
     @Override

--- a/catalog/video/video-mpegts-transformer/src/main/java/org/codice/alliance/transformer/video/SetDistanceToleranceVisitor.java
+++ b/catalog/video/video-mpegts-transformer/src/main/java/org/codice/alliance/transformer/video/SetDistanceToleranceVisitor.java
@@ -13,26 +13,19 @@
  */
 package org.codice.alliance.transformer.video;
 
-import org.codice.alliance.libs.klv.ClassifyingCountryKlvProcessor;
-import org.codice.alliance.libs.klv.CopyPresentKlvProcessor;
-import org.codice.alliance.libs.klv.DistinctKlvProcessor;
-import org.codice.alliance.libs.klv.DistinctSingleKlvProcessor;
+import org.codice.alliance.libs.klv.BaseKlvProcessorVisitor;
 import org.codice.alliance.libs.klv.FrameCenterKlvProcessor;
 import org.codice.alliance.libs.klv.GeometryOperator;
 import org.codice.alliance.libs.klv.GeometryReducer;
-import org.codice.alliance.libs.klv.KlvProcessor;
 import org.codice.alliance.libs.klv.LocationKlvProcessor;
 import org.codice.alliance.libs.klv.NormalizeGeometry;
-import org.codice.alliance.libs.klv.SensorAltitudeKlvProcessor;
-import org.codice.alliance.libs.klv.SetDatesKlvProcessor;
 import org.codice.alliance.libs.klv.SimplifyGeometryFunction;
-import org.codice.alliance.libs.klv.UnionKlvProcessor;
 
 /**
  * Call {@link SimplifyGeometryFunction#setDistanceTolerance(Double)} that is embedded within a
  * KlvProcessor.
  */
-class SetDistanceToleranceVisitor implements KlvProcessor.Visitor {
+class SetDistanceToleranceVisitor extends BaseKlvProcessorVisitor {
 
     private final Double distanceTolerance;
 
@@ -60,21 +53,6 @@ class SetDistanceToleranceVisitor implements KlvProcessor.Visitor {
     }
 
     @Override
-    public void visit(DistinctKlvProcessor distinctKlvProcessor) {
-
-    }
-
-    @Override
-    public void visit(DistinctSingleKlvProcessor distinctSingleKlvProcessor) {
-
-    }
-
-    @Override
-    public void visit(CopyPresentKlvProcessor copyPresentKlvProcessor) {
-
-    }
-
-    @Override
     public void visit(FrameCenterKlvProcessor frameCenterKlvProcessor) {
         frameCenterKlvProcessor.getGeometryOperator()
                 .accept(geometryFunctionVisitor);
@@ -86,23 +64,4 @@ class SetDistanceToleranceVisitor implements KlvProcessor.Visitor {
                 .accept(geometryFunctionVisitor);
     }
 
-    @Override
-    public void visit(SetDatesKlvProcessor setDatesKlvProcessor) {
-
-    }
-
-    @Override
-    public void visit(ClassifyingCountryKlvProcessor classifyingCountryKlvProcessor) {
-        
-    }
-
-    @Override
-    public void visit(UnionKlvProcessor abstractUnionKlvProcessor) {
-
-    }
-
-    @Override
-    public void visit(SensorAltitudeKlvProcessor sensorAltitudeKlvProcessor) {
-
-    }
 }

--- a/catalog/video/video-mpegts-transformer/src/main/java/org/codice/alliance/transformer/video/SetSecurityClassificationString.java
+++ b/catalog/video/video-mpegts-transformer/src/main/java/org/codice/alliance/transformer/video/SetSecurityClassificationString.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.transformer.video;
+
+import org.codice.alliance.libs.klv.BaseKlvProcessorVisitor;
+import org.codice.alliance.libs.klv.SecurityClassificationKlvProcessor;
+
+/**
+ * This visitor implementation calls {@link SecurityClassificationKlvProcessor#setSecurityClassification(Short, String)}
+ * with a specific code and classification string.
+ */
+public class SetSecurityClassificationString extends BaseKlvProcessorVisitor {
+
+    private final Short code;
+
+    private final String classification;
+
+    public SetSecurityClassificationString(Short code, String classification) {
+        this.code = code;
+        this.classification = classification;
+    }
+
+    @Override
+    public void visit(SecurityClassificationKlvProcessor securityClassificationKlvProcessor) {
+        securityClassificationKlvProcessor.setSecurityClassification(code, classification);
+    }
+}

--- a/catalog/video/video-mpegts-transformer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/video/video-mpegts-transformer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -22,6 +22,10 @@
     <reference-list id="metacardTypeList" interface="ddf.catalog.data.MetacardType"
                     filter="(name=isr.video)" availability="mandatory"/>
 
+    <reference id="securityClassificationService"
+               interface="org.codice.alliance.catalog.core.internal.api.classification.SecurityClassificationService"
+               availability="mandatory"/>
+
     <bean id="simplifyAndNormalize" class="org.codice.alliance.libs.klv.GeometryOperatorList">
         <argument>
             <list>
@@ -81,7 +85,19 @@
                         <bean class="org.codice.alliance.libs.klv.PlatformIdKlvProcessor"/>
                         <bean class="org.codice.alliance.libs.klv.PlatformDesignationKlvProcessor"/>
                         <bean class="org.codice.alliance.libs.klv.ImageSourceSensorKlvProcessor"/>
-                        <bean class="org.codice.alliance.libs.klv.SecurityClassificationKlvProcessor"/>
+                        <bean class="org.codice.alliance.libs.klv.SecurityClassificationKlvProcessor">
+                            <argument ref="securityClassificationService"/>
+                            <argument>
+                                <map>
+                                    <entry key="1" value="UNCLASSIFIED"/>
+                                    <entry key="2" value="RESTRICTED"/>
+                                    <entry key="3" value="CONFIDENTIAL"/>
+                                    <entry key="4" value="SECRET"/>
+                                    <entry key="5" value="TOP SECRET"/>
+                                </map>
+                            </argument>
+                            <argument value="unclassified"/>
+                        </bean>
                         <bean class="org.codice.alliance.libs.klv.FrameCenterKlvProcessor">
                             <argument>
                                 <bean class="org.codice.alliance.libs.klv.GeometryOperatorList">

--- a/catalog/video/video-mpegts-transformer/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/video/video-mpegts-transformer/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -27,6 +27,36 @@
             name="Distance Tolerance" id="distanceTolerance" required="false"
             type="Double" default="0.0001"/>
 
+        <AD
+            description="Security classification string that corresponds to STANAG field 'Security Classification' on the Security Metadata Local Set code 1."
+            name="Security Classification - 1" id="securityClassificationCode1" required="true"
+            type="String" default="UNCLASSIFIED"/>
+
+        <AD
+            description="Security classification string that corresponds to STANAG field 'Security Classification' on the Security Metadata Local Set code 2."
+            name="Security Classification - 2" id="securityClassificationCode2" required="true"
+            type="String" default="RESTRICTED"/>
+
+        <AD
+            description="Security classification string that corresponds to STANAG field 'Security Classification' on the Security Metadata Local Set code 3."
+            name="Security Classification - 3" id="securityClassificationCode3" required="true"
+            type="String" default="CONFIDENTIAL"/>
+
+        <AD
+            description="Security classification string that corresponds to STANAG field 'Security Classification' on the Security Metadata Local Set code 4."
+            name="Security Classification - 4" id="securityClassificationCode4" required="true"
+            type="String" default="SECRET"/>
+
+        <AD
+            description="Security classification string that corresponds to STANAG field 'Security Classification' on the Security Metadata Local Set code 5."
+            name="Security Classification - 5" id="securityClassificationCode5" required="true"
+            type="String" default="TOP SECRET"/>
+
+        <AD
+            description="Security classification string that is used if STANAG field 'Security Classification' on the Security Metadata Local Set is unrecognized."
+            name="Security Classification - Default" id="securityClassificationDefault" required="true"
+            type="String" default="TOP SECRET"/>
+
     </OCD>
 
     <Designate pid="org.codice.alliance.transformer.video.MpegTsInputTransformer">

--- a/libs/klv/pom.xml
+++ b/libs/klv/pom.xml
@@ -115,6 +115,11 @@
             <artifactId>mpegts-streamer</artifactId>
             <version>${mpegts-streamer.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.codice.alliance.catalog.core</groupId>
+            <artifactId>catalog-core-classification-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
     </dependencies>
 
@@ -170,7 +175,7 @@
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.67</minimum>
+                                            <minimum>0.65</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>

--- a/libs/klv/src/main/java/org/codice/alliance/libs/klv/BaseKlvProcessorVisitor.java
+++ b/libs/klv/src/main/java/org/codice/alliance/libs/klv/BaseKlvProcessorVisitor.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.libs.klv;
+
+/**
+ * This implementation provides an empty body for each visit method, since most implementations
+ * only need to define a limited number of visit methods.
+ */
+public abstract class BaseKlvProcessorVisitor implements KlvProcessor.Visitor {
+
+    @Override
+    public void visit(DistinctKlvProcessor distinctKlvProcessor) {
+
+    }
+
+    @Override
+    public void visit(DistinctSingleKlvProcessor distinctSingleKlvProcessor) {
+
+    }
+
+    @Override
+    public void visit(CopyPresentKlvProcessor copyPresentKlvProcessor) {
+
+    }
+
+    @Override
+    public void visit(FrameCenterKlvProcessor frameCenterKlvProcessor) {
+
+    }
+
+    @Override
+    public void visit(LocationKlvProcessor locationKlvProcessor) {
+
+    }
+
+    @Override
+    public void visit(SetDatesKlvProcessor setDatesKlvProcessor) {
+
+    }
+
+    @Override
+    public void visit(ClassifyingCountryKlvProcessor classifyingCountryKlvProcessor) {
+
+    }
+
+    @Override
+    public void visit(UnionKlvProcessor abstractUnionKlvProcessor) {
+
+    }
+
+    @Override
+    public void visit(SensorAltitudeKlvProcessor sensorAltitudeKlvProcessor) {
+
+    }
+
+    @Override
+    public void visit(SecurityClassificationKlvProcessor securityClassificationKlvProcessor) {
+
+    }
+}

--- a/libs/klv/src/main/java/org/codice/alliance/libs/klv/KlvProcessor.java
+++ b/libs/klv/src/main/java/org/codice/alliance/libs/klv/KlvProcessor.java
@@ -47,6 +47,7 @@ public interface KlvProcessor {
 
         void visit(SensorAltitudeKlvProcessor sensorAltitudeKlvProcessor);
 
+        void visit(SecurityClassificationKlvProcessor securityClassificationKlvProcessor);
     }
 
     class Configuration {

--- a/libs/klv/src/main/java/org/codice/alliance/libs/klv/SecurityClassificationKlvProcessor.java
+++ b/libs/klv/src/main/java/org/codice/alliance/libs/klv/SecurityClassificationKlvProcessor.java
@@ -13,11 +13,88 @@
  */
 package org.codice.alliance.libs.klv;
 
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.codice.alliance.catalog.core.internal.api.classification.SecurityClassificationService;
 import org.codice.alliance.libs.stanag4609.Stanag4609TransportStreamParser;
 
-public class SecurityClassificationKlvProcessor extends DistinctSingleKlvProcessor {
-    public SecurityClassificationKlvProcessor() {
-        super(AttributeNameConstants.SECURITY_CLASSIFICATION,
-                Stanag4609TransportStreamParser.SECURITY_CLASSIFICATION);
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+
+/**
+ * Classification mapping defined by http://www.gwg.nga.mil/misb//docs/standards/ST0102.7.pdf
+ * <p>
+ * 1 ==> unclassified
+ * 2 ==> restricted
+ * 3 ==> confidential
+ * 4 ==> secret
+ * 5 ==> top secret
+ */
+public class SecurityClassificationKlvProcessor extends MultipleFieldKlvProcessor {
+
+    private Map<Short, String> codeToSecurityClassification;
+
+    private String defaultSecurityClassification;
+
+    private SecurityClassificationService securityClassificationService;
+
+    /**
+     * @param codeToSecurityClassification  map of stanag security codes to classification strings
+     * @param defaultSecurityClassification classification string to be used if the map does not contain an entry for the stanag security code
+     */
+    public SecurityClassificationKlvProcessor(
+            SecurityClassificationService securityClassificationService,
+            Map<Short, String> codeToSecurityClassification, String defaultSecurityClassification) {
+        super(Collections.singletonList(Stanag4609TransportStreamParser.SECURITY_CLASSIFICATION));
+        this.securityClassificationService = securityClassificationService;
+        this.codeToSecurityClassification = new HashMap<>(codeToSecurityClassification);
+        this.defaultSecurityClassification = defaultSecurityClassification;
+    }
+
+    public void setSecurityClassification(Short code, String classification) {
+        codeToSecurityClassification.put(code, classification);
+    }
+
+    public void setDefaultSecurityClassification(String classification) {
+        defaultSecurityClassification = classification;
+    }
+
+    @Override
+    public void accept(Visitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    protected void doProcess(Attribute attribute, Metacard metacard) {
+
+        Comparator<String> comparator =
+                securityClassificationService.getSecurityClassificationComparator();
+
+        attribute.getValues()
+                .stream()
+                .filter(Short.class::isInstance)
+                .map(Short.class::cast)
+                .map(this::codeToClassification)
+                .max(comparator)
+                .ifPresent(classification -> {
+                    metacard.setAttribute(new AttributeImpl(AttributeNameConstants.SECURITY_CLASSIFICATION,
+                            classification));
+                });
+
+    }
+
+    private String codeToClassification(Short code) {
+        return codeToSecurityClassification.getOrDefault(code, defaultSecurityClassification);
+    }
+
+    @Override
+    public String toString() {
+        return "SecurityClassificationKlvProcessor{" + "codeToSecurityClassification="
+                + codeToSecurityClassification + ", defaultSecurityClassification='"
+                + defaultSecurityClassification + '\'' + '}';
     }
 }

--- a/libs/klv/src/test/java/org/codice/alliance/libs/klv/SecurityClassificationKlvProcessorTest.java
+++ b/libs/klv/src/test/java/org/codice/alliance/libs/klv/SecurityClassificationKlvProcessorTest.java
@@ -15,11 +15,20 @@ package org.codice.alliance.libs.klv;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
+import org.codice.alliance.catalog.core.internal.api.classification.SecurityClassificationService;
 import org.codice.alliance.libs.stanag4609.Stanag4609TransportStreamParser;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -27,21 +36,92 @@ import ddf.catalog.data.Attribute;
 
 public class SecurityClassificationKlvProcessorTest {
 
+    private static final String UNCLASSIFIED = "unclassified";
+
+    private static final String RESTRICTED = "restricted";
+
+    private static final String DEFAULT = "default";
+
+    private Map<Short, String> codes;
+
+    private SecurityClassificationService securityClassificationService;
+
+    @SuppressWarnings("unchecked")
+    @Before
+    public void setup() {
+        codes = new HashMap<>();
+        codes.put((short) 1, UNCLASSIFIED);
+        codes.put((short) 2, RESTRICTED);
+        securityClassificationService = mock(SecurityClassificationService.class);
+        Comparator<String> comparator = mock(Comparator.class);
+        when(comparator.compare(UNCLASSIFIED, UNCLASSIFIED)).thenReturn(0);
+        when(comparator.compare(UNCLASSIFIED, RESTRICTED)).thenReturn(-1);
+        when(securityClassificationService.getSecurityClassificationComparator()).thenReturn(
+                comparator);
+    }
+
     @Test
-    public void test() {
+    public void testSingleClassificationCode() {
 
-        Short id1 = 10;
+        Short id1 = 1;
 
-        ArgumentCaptor<Attribute> argumentCaptor =
-                KlvUtilities.testKlvProcessor(new SecurityClassificationKlvProcessor(),
-                        Stanag4609TransportStreamParser.SECURITY_CLASSIFICATION,
-                        Arrays.asList(id1, id1));
+        ArgumentCaptor<Attribute> argumentCaptor = callTest(Collections.singletonList(id1));
 
-        assertThat(argumentCaptor.getValue()
-                .getName(), is(AttributeNameConstants.SECURITY_CLASSIFICATION));
-        assertThat(argumentCaptor.getValue()
-                .getValues(), is(Collections.singletonList(id1)));
+        assertAttribute(argumentCaptor, UNCLASSIFIED);
 
     }
 
+    @Test
+    public void testMultipleIdenticalClassificationCodes() {
+
+        Short id1 = 1;
+        Short id2 = 1;
+
+        ArgumentCaptor<Attribute> argumentCaptor = callTest(Arrays.asList(id1, id2));
+
+        assertAttribute(argumentCaptor, UNCLASSIFIED);
+
+    }
+
+    /**
+     * Make sure that when multiple classification codes are found, that the code with the highest value is selected.
+     */
+    @Test
+    public void testMultipleDifferentClassificationCodes() {
+
+        Short id1 = 1;
+        Short id2 = 2;
+
+        ArgumentCaptor<Attribute> argumentCaptor = callTest(Arrays.asList(id1, id2));
+
+        assertAttribute(argumentCaptor, RESTRICTED);
+
+    }
+
+    @Test
+    public void testDefaultClassificationCodes() {
+
+        Short id1 = 999;
+
+        ArgumentCaptor<Attribute> argumentCaptor = callTest(Collections.singletonList(id1));
+
+        assertAttribute(argumentCaptor, DEFAULT);
+
+    }
+
+    private void assertAttribute(ArgumentCaptor<Attribute> argumentCaptor, String value) {
+        assertThat(argumentCaptor.getValue()
+                .getName(), is(AttributeNameConstants.SECURITY_CLASSIFICATION));
+        assertThat(argumentCaptor.getValue()
+                .getValues(), is(Collections.singletonList(value)));
+
+    }
+
+    private ArgumentCaptor<Attribute> callTest(List<Serializable> codeList) {
+        return KlvUtilities.testKlvProcessor(new SecurityClassificationKlvProcessor(
+                securityClassificationService,
+                codes,
+                DEFAULT), Stanag4609TransportStreamParser.SECURITY_CLASSIFICATION, codeList);
+    }
+    
 }


### PR DESCRIPTION
#### What does this PR do?

Add ability to map KLV security classification integers to security classification strings, for admins to configure the integer-to-string mapping, and for admins to control the sort order of classification strings so that the strictest classification is used when multiple classifications are present
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@bdeining 
@Lambeaux 
@kcwire 
@jlcsmith 
@stustison 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@beyelerb
@lessarderic
#### How should this be tested?
- Build and install Alliance
- configure a video stream
- use the sample-mpegts-streamgenerator to stream a video that contains security classification KLV data (ask me if you don't have a test video)
- Using the UI, check that the parent metacard and the chunk metacard contains an attribute value for "Security Classification" that says "unclassified" (assuming you used the default security mappings)
#### Any background context you want to provide?
#### What are the relevant tickets?

CAL-163
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

…
