### PR TITLE
CAL-170: Updated OpenSearch initialization to be correct so that the source starts correctly.

### DIFF
--- a/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/FederationTest.java
+++ b/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/FederationTest.java
@@ -16,6 +16,8 @@ package org.codice.alliance.test.itests;
 import static org.codice.ddf.itests.common.AbstractIntegrationTest.DynamicUrl.INSECURE_ROOT;
 import static org.codice.ddf.itests.common.csw.CswTestCommons.GMD_CSW_FEDERATED_SOURCE_FACTORY_PID;
 import static org.codice.ddf.itests.common.csw.CswTestCommons.getCswSourceProperties;
+import static org.codice.ddf.itests.common.opensearch.OpenSearchTestCommons.OPENSEARCH_FACTORY_PID;
+import static org.codice.ddf.itests.common.opensearch.OpenSearchTestCommons.getOpenSearchSourceProperties;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasXPath;
@@ -127,6 +129,13 @@ public class FederationTest extends AbstractAllianceIntegrationTest {
             configureFtpNsiliSource();
             configureMgmpSource();
 
+            Map<String, Object> openSearchProperties = getOpenSearchSourceProperties(
+                    OPENSEARCH_SOURCE_ID,
+                    OPENSEARCH_PATH.getUrl(),
+                    getServiceManager());
+            getServiceManager().createManagedService(OPENSEARCH_FACTORY_PID, openSearchProperties);
+
+            getCatalogBundle().waitForFederatedSource(OPENSEARCH_SOURCE_ID);
             getCatalogBundle().waitForFederatedSource(MGMP_SOURCE_ID);
 
             getServiceManager().waitForSourcesToBeAvailable(REST_PATH.getUrl(),


### PR DESCRIPTION
#### What does this PR do?
Fixes the OpenSearch initialization during FederationTest so that the test will completely correctly now that errors are no longer ignored. 

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@brendan-hofmann 
@bdeining 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@kcwire

#### How should this be tested?
Run the FederationTest integration test and verify it passes.

#### Any background context you want to provide?
This will fix the build failure on: 
https://codice.atlassian.net/builds/browse/AL-AL-414/log

#### What are the relevant tickets?
https://codice.atlassian.net/browse/CAL-170

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [X] Update / Add Integration Tests