### PR TITLE
CAL-134: Mapping of PIAIMC attributes to ext.nitf.* fields.

### DIFF
--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/PiaimcAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/PiaimcAttribute.java
@@ -25,22 +25,185 @@ import org.codice.alliance.catalog.core.api.types.Isr;
 import org.codice.imaging.nitf.core.tre.Tre;
 
 import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.AttributeType;
+import ddf.catalog.data.impl.BasicTypes;
 
 /**
  * TRE for "Profile for Imagery Access Image"
  */
-class PiaimcAttribute extends NitfAttributeImpl<Tre> {
+public class PiaimcAttribute extends NitfAttributeImpl<Tre> {
 
     private static final List<NitfAttribute<Tre>> ATTRIBUTES = new LinkedList<>();
-    
+
     public static final String CLOUDCVR_NAME = "CLOUDCVR";
 
-    public static final PiaimcAttribute CLOUDCVR = new PiaimcAttribute(Isr.CLOUD_COVER,
+    public static final String STANDARD_RADIOMETRIC_PRODUCT_NAME = "SRP";
+
+    public static final String SENSMODE_NAME = "SENSMODE";
+
+    public static final String SENSNAME_NAME = "SENSNAME";
+
+    public static final String SOURCE_NAME = "SOURCE";
+
+    public static final String COMGEN_NAME = "COMGEN";
+
+    public static final String SUBQUAL_NAME = "SUBQUAL";
+
+    public static final String PIAMSNNUM_NAME = "PIAMSNNUM";
+
+    public static final String CAMSPECS_NAME = "CAMSPECS";
+
+    public static final String PROJID_NAME = "PROJID";
+
+    public static final String GENERATION_NAME = "GENERATION";
+
+    public static final String EXPLOITATION_SUPPORT_DATA_NAME = "ESD";
+
+    public static final String OTHERCOND_NAME = "OTHERCOND";
+
+    public static final String MEANGSD_NAME = "MEANGSD";
+
+    public static final String IDATUM_NAME = "IDATUM";
+
+    public static final String IELLIP_NAME = "IELLIP";
+
+    public static final String PREPROC_NAME = "PREPROC";
+
+    public static final String IPROJ_NAME = "IPROJ";
+
+    public static final String SATTRACK_PATH_NAME = "SATTRACK_PATH";
+
+    public static final String SATTRACK_ROW_NAME = "SATTRACK_ROW";
+
+    public static final String ATTRIBUTE_NAME_PREFIX = "piaimc.";
+
+    static final PiaimcAttribute CLOUDCVR = new PiaimcAttribute(Isr.CLOUD_COVER,
             CLOUDCVR_NAME,
             PiaimcAttribute::getCloudCoverFunction,
             new IsrAttributes().getAttributeDescriptor(Isr.CLOUD_COVER),
             "cloudCvr",
-            "piaimc.");
+            ATTRIBUTE_NAME_PREFIX);
+
+    static final PiaimcAttribute SRP = new PiaimcAttribute("standard-radiometric-product",
+            STANDARD_RADIOMETRIC_PRODUCT_NAME,
+            tre -> TreUtility.convertYnToBoolean(tre, STANDARD_RADIOMETRIC_PRODUCT_NAME),
+            BasicTypes.BOOLEAN_TYPE,
+            ATTRIBUTE_NAME_PREFIX);
+
+    static final PiaimcAttribute SENSMODE = new PiaimcAttribute("sensor-mode",
+            SENSMODE_NAME,
+            tre -> TreUtility.convertToString(tre, SENSMODE_NAME),
+            BasicTypes.STRING_TYPE,
+            ATTRIBUTE_NAME_PREFIX);
+
+    static final PiaimcAttribute SENSNAME = new PiaimcAttribute("sensor-name",
+            SENSNAME_NAME,
+            tre -> TreUtility.convertToString(tre, SENSNAME_NAME),
+            BasicTypes.STRING_TYPE,
+            ATTRIBUTE_NAME_PREFIX);
+
+    static final PiaimcAttribute SOURCE = new PiaimcAttribute("source",
+            SOURCE_NAME,
+            tre -> TreUtility.convertToString(tre, SOURCE_NAME),
+            BasicTypes.STRING_TYPE,
+            ATTRIBUTE_NAME_PREFIX);
+
+    static final PiaimcAttribute COMGEN = new PiaimcAttribute("compression-generation",
+            COMGEN_NAME,
+            tre -> TreUtility.convertToInteger(tre, COMGEN_NAME),
+            BasicTypes.INTEGER_TYPE,
+            ATTRIBUTE_NAME_PREFIX);
+
+    static final PiaimcAttribute SUBQUAL = new PiaimcAttribute("subjective-quality",
+            SUBQUAL_NAME,
+            tre -> TreUtility.convertToString(tre, SUBQUAL_NAME),
+            BasicTypes.STRING_TYPE,
+            ATTRIBUTE_NAME_PREFIX);
+
+    static final PiaimcAttribute PIAMSNNUM = new PiaimcAttribute("pia-mission-num",
+            PIAMSNNUM_NAME,
+            tre -> TreUtility.convertToString(tre, PIAMSNNUM_NAME),
+            BasicTypes.STRING_TYPE,
+            ATTRIBUTE_NAME_PREFIX);
+
+    static final PiaimcAttribute CAMSPECS = new PiaimcAttribute("camera-specs",
+            CAMSPECS_NAME,
+            tre -> TreUtility.convertToString(tre, CAMSPECS_NAME),
+            BasicTypes.STRING_TYPE,
+            ATTRIBUTE_NAME_PREFIX);
+
+    static final PiaimcAttribute PROJID = new PiaimcAttribute("project-id-code",
+            PROJID_NAME,
+            tre -> TreUtility.convertToString(tre, PROJID_NAME),
+            BasicTypes.STRING_TYPE,
+            ATTRIBUTE_NAME_PREFIX);
+
+    static final PiaimcAttribute GENERATION = new PiaimcAttribute("generation",
+            GENERATION_NAME,
+            tre -> TreUtility.convertToInteger(tre, GENERATION_NAME),
+            BasicTypes.INTEGER_TYPE,
+            ATTRIBUTE_NAME_PREFIX);
+
+    static final PiaimcAttribute ESD = new PiaimcAttribute("exploitation-support-data",
+            EXPLOITATION_SUPPORT_DATA_NAME,
+            tre -> TreUtility.convertYnToBoolean(tre, EXPLOITATION_SUPPORT_DATA_NAME),
+            BasicTypes.BOOLEAN_TYPE,
+            ATTRIBUTE_NAME_PREFIX);
+
+    static final PiaimcAttribute OTHERCOND = new PiaimcAttribute("other-conditions",
+            OTHERCOND_NAME,
+            tre -> TreUtility.convertToString(tre, OTHERCOND_NAME),
+            BasicTypes.STRING_TYPE,
+            ATTRIBUTE_NAME_PREFIX);
+
+    static final PiaimcAttribute MEANGSD = new PiaimcAttribute("mean-gsd",
+            MEANGSD_NAME,
+            tre -> TreUtility.convertToFloat(tre, MEANGSD_NAME),
+            BasicTypes.FLOAT_TYPE,
+            ATTRIBUTE_NAME_PREFIX);
+
+    static final PiaimcAttribute IDATUM = new PiaimcAttribute("image-datum",
+            IDATUM_NAME,
+            tre -> TreUtility.convertToString(tre, IDATUM_NAME),
+            BasicTypes.STRING_TYPE,
+            ATTRIBUTE_NAME_PREFIX);
+
+    static final PiaimcAttribute IELLIP = new PiaimcAttribute("image-ellipsoid",
+            IELLIP_NAME,
+            tre -> TreUtility.convertToString(tre, IELLIP_NAME),
+            BasicTypes.STRING_TYPE,
+            ATTRIBUTE_NAME_PREFIX);
+
+    static final PiaimcAttribute PREPROC = new PiaimcAttribute("image-processing-level",
+            PREPROC_NAME,
+            tre -> TreUtility.convertToString(tre, PREPROC_NAME),
+            BasicTypes.STRING_TYPE,
+            ATTRIBUTE_NAME_PREFIX);
+
+    static final PiaimcAttribute IPROJ = new PiaimcAttribute("image-projection-system",
+            IPROJ_NAME,
+            tre -> TreUtility.convertToString(tre, IPROJ_NAME),
+            BasicTypes.STRING_TYPE,
+            ATTRIBUTE_NAME_PREFIX);
+
+    static final PiaimcAttribute SATTRACK_PATH = new PiaimcAttribute("satellite-track-path",
+            SATTRACK_PATH_NAME,
+            tre -> TreUtility.convertToInteger(tre, SATTRACK_PATH_NAME),
+            BasicTypes.INTEGER_TYPE,
+            ATTRIBUTE_NAME_PREFIX);
+
+    static final PiaimcAttribute SATTRACK_ROW = new PiaimcAttribute("satellite-track-row",
+            SATTRACK_ROW_NAME,
+            tre -> TreUtility.convertToInteger(tre, SATTRACK_ROW_NAME),
+            BasicTypes.INTEGER_TYPE,
+            ATTRIBUTE_NAME_PREFIX);
+
+    private PiaimcAttribute(String longName, String shortName,
+            Function<Tre, Serializable> accessorFunction, AttributeType attributeType,
+            String prefix) {
+        super(longName, shortName, accessorFunction, attributeType, prefix);
+        ATTRIBUTES.add(this);
+    }
 
     private PiaimcAttribute(String longName, String shortName,
             Function<Tre, Serializable> accessorFunction, AttributeDescriptor attributeDescriptor,

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/gmti/GmtiMetacardType.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/gmti/GmtiMetacardType.java
@@ -20,6 +20,7 @@ import org.codice.alliance.transformer.nitf.common.AcftbAttribute;
 import org.codice.alliance.transformer.nitf.common.CsdidaAttribute;
 import org.codice.alliance.transformer.nitf.common.CsexraAttribute;
 import org.codice.alliance.transformer.nitf.common.NitfHeaderAttribute;
+import org.codice.alliance.transformer.nitf.common.PiaimcAttribute;
 
 import ddf.catalog.data.impl.types.AssociationsAttributes;
 import ddf.catalog.data.impl.types.ContactAttributes;
@@ -52,6 +53,7 @@ public class GmtiMetacardType extends AbstractNitfMetacardType {
         descriptors.addAll(new ValidationAttributes().getAttributeDescriptors());
         descriptors.addAll(new IsrAttributes().getAttributeDescriptors());
         descriptors.addAll(new SecurityAttributes().getAttributeDescriptors());
+        descriptors.addAll(getDescriptors(PiaimcAttribute.getAttributes()));
         descriptors.addAll(getDescriptors(CsdidaAttribute.getAttributes()));
         descriptors.addAll(getDescriptors(CsexraAttribute.getAttributes()));
     }

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/ImageMetacardType.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/ImageMetacardType.java
@@ -21,6 +21,7 @@ import org.codice.alliance.transformer.nitf.common.AimidbAttribute;
 import org.codice.alliance.transformer.nitf.common.CsdidaAttribute;
 import org.codice.alliance.transformer.nitf.common.CsexraAttribute;
 import org.codice.alliance.transformer.nitf.common.NitfHeaderAttribute;
+import org.codice.alliance.transformer.nitf.common.PiaimcAttribute;
 import org.codice.alliance.transformer.nitf.gmti.IndexedMtirpbAttribute;
 import org.codice.alliance.transformer.nitf.gmti.MtirpbAttribute;
 
@@ -61,6 +62,7 @@ public class ImageMetacardType extends AbstractNitfMetacardType {
         descriptors.addAll(new ValidationAttributes().getAttributeDescriptors());
         descriptors.addAll(new IsrAttributes().getAttributeDescriptors());
         descriptors.addAll(new SecurityAttributes().getAttributeDescriptors());
+        descriptors.addAll(getDescriptors(PiaimcAttribute.getAttributes()));
         descriptors.addAll(getDescriptors(CsdidaAttribute.getAttributes()));
         descriptors.addAll(getDescriptors(CsexraAttribute.getAttributes()));
     }

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/PiaimcAttributeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/PiaimcAttributeTest.java
@@ -13,7 +13,6 @@
  */
 package org.codice.alliance.transformer.nitf.common;
 
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
@@ -39,10 +38,10 @@ public class PiaimcAttributeTest {
     @Test
     public void testCloudCover() throws NitfFormatException {
         for (int cloudCover = 0; cloudCover <= 100; cloudCover++) {
-            when(tre.getFieldValue(PiaimcAttribute.CLOUDCVR_NAME)).thenReturn(Integer.toString(cloudCover));
+            when(tre.getFieldValue(PiaimcAttribute.CLOUDCVR_NAME)).thenReturn(Integer.toString(
+                    cloudCover));
             Serializable actual = PiaimcAttribute.CLOUDCVR.getAccessorFunction()
                     .apply(tre);
-            assertThat(actual, is(instanceOf(Integer.class)));
             assertThat(actual, is(cloudCover));
         }
     }
@@ -52,7 +51,7 @@ public class PiaimcAttributeTest {
         when(tre.getIntValue(PiaimcAttribute.CLOUDCVR_NAME)).thenReturn(-10);
         Serializable actual = PiaimcAttribute.CLOUDCVR.getAccessorFunction()
                 .apply(tre);
-        assertThat(actual, nullValue());
+        assertThat(actual, is(nullValue()));
     }
 
     @Test
@@ -60,7 +59,7 @@ public class PiaimcAttributeTest {
         when(tre.getIntValue(PiaimcAttribute.CLOUDCVR_NAME)).thenReturn(110);
         Serializable actual = PiaimcAttribute.CLOUDCVR.getAccessorFunction()
                 .apply(tre);
-        assertThat(actual, nullValue());
+        assertThat(actual, is(nullValue()));
     }
 
     @SuppressWarnings("unchecked")
@@ -69,7 +68,377 @@ public class PiaimcAttributeTest {
         when(tre.getIntValue(PiaimcAttribute.CLOUDCVR_NAME)).thenThrow(NitfFormatException.class);
         Serializable actual = PiaimcAttribute.CLOUDCVR.getAccessorFunction()
                 .apply(tre);
-        assertThat(actual, nullValue());
+        assertThat(actual, is(nullValue()));
     }
 
+    @Test
+    public void testSrpTrue() throws NitfFormatException {
+        when(tre.getFieldValue(PiaimcAttribute.STANDARD_RADIOMETRIC_PRODUCT_NAME)).thenReturn("Y");
+        Serializable actual = PiaimcAttribute.SRP.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(true));
+    }
+
+    @Test
+    public void testSrpFalse() throws NitfFormatException {
+        when(tre.getFieldValue(PiaimcAttribute.STANDARD_RADIOMETRIC_PRODUCT_NAME)).thenReturn("N");
+        Serializable actual = PiaimcAttribute.SRP.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(false));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testSrpNotSet() throws NitfFormatException {
+        when(tre.getFieldValue(PiaimcAttribute.STANDARD_RADIOMETRIC_PRODUCT_NAME)).thenThrow(NitfFormatException.class);
+        Serializable actual = PiaimcAttribute.SRP.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(nullValue()));
+    }
+
+    @Test
+    public void testSenseModeSet() throws NitfFormatException {
+        when(tre.getFieldValue(PiaimcAttribute.SENSMODE_NAME)).thenReturn("PUSHBROOM");
+        Serializable actual = PiaimcAttribute.SENSMODE.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is("PUSHBROOM"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testSenseModeNotSet() throws NitfFormatException {
+        when(tre.getFieldValue(PiaimcAttribute.SENSMODE_NAME)).thenThrow(NitfFormatException.class);
+        Serializable actual = PiaimcAttribute.SENSMODE.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(nullValue()));
+    }
+
+    @Test
+    public void testSensorNameSet() throws NitfFormatException {
+        when(tre.getFieldValue(PiaimcAttribute.SENSNAME_NAME)).thenReturn("OrbView");
+        Serializable actual = PiaimcAttribute.SENSNAME.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is("OrbView"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testSensorNameNotSet() throws NitfFormatException {
+        when(tre.getFieldValue(PiaimcAttribute.SENSNAME_NAME)).thenThrow(NitfFormatException.class);
+        Serializable actual = PiaimcAttribute.SENSNAME.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(nullValue()));
+    }
+
+    @Test
+    public void testSourceSet() throws NitfFormatException {
+        when(tre.getFieldValue(PiaimcAttribute.SOURCE_NAME)).thenReturn("Test Source");
+        Serializable actual = PiaimcAttribute.SOURCE.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is("Test Source"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testSourceNotSet() throws NitfFormatException {
+        when(tre.getFieldValue(PiaimcAttribute.SOURCE_NAME)).thenThrow(NitfFormatException.class);
+        Serializable actual = PiaimcAttribute.SOURCE.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(nullValue()));
+    }
+
+    @Test
+    public void testComgenMin() throws NitfFormatException {
+        when(tre.getFieldValue(PiaimcAttribute.COMGEN_NAME)).thenReturn("0");
+        Serializable actual = PiaimcAttribute.COMGEN.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(0));
+    }
+
+    @Test
+    public void testComgenMax() throws NitfFormatException {
+        when(tre.getFieldValue(PiaimcAttribute.COMGEN_NAME)).thenReturn("99");
+        Serializable actual = PiaimcAttribute.COMGEN.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(99));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testComgenNotSet() throws NitfFormatException {
+        when(tre.getIntValue(PiaimcAttribute.COMGEN_NAME)).thenThrow(NitfFormatException.class);
+        Serializable actual = PiaimcAttribute.COMGEN.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(nullValue()));
+    }
+
+    @Test
+    public void testSubqualSet() throws NitfFormatException {
+        when(tre.getFieldValue(PiaimcAttribute.SUBQUAL_NAME)).thenReturn("G");
+        Serializable actual = PiaimcAttribute.SUBQUAL.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is("G"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testSubqualNotSet() throws NitfFormatException {
+        when(tre.getIntValue(PiaimcAttribute.SUBQUAL_NAME)).thenThrow(NitfFormatException.class);
+        Serializable actual = PiaimcAttribute.SUBQUAL.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(nullValue()));
+    }
+
+    @Test
+    public void testPiaMsnNumSet() throws NitfFormatException {
+        when(tre.getFieldValue(PiaimcAttribute.PIAMSNNUM_NAME)).thenReturn("TESTMSN");
+        Serializable actual = PiaimcAttribute.PIAMSNNUM.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is("TESTMSN"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testPiaMsnNumNotSet() throws NitfFormatException {
+        when(tre.getIntValue(PiaimcAttribute.PIAMSNNUM_NAME)).thenThrow(NitfFormatException.class);
+        Serializable actual = PiaimcAttribute.PIAMSNNUM.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(nullValue()));
+    }
+
+    @Test
+    public void testCameraSpecsSet() throws NitfFormatException {
+        when(tre.getFieldValue(PiaimcAttribute.CAMSPECS_NAME)).thenReturn("Test Camera Specs");
+        Serializable actual = PiaimcAttribute.CAMSPECS.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is("Test Camera Specs"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testCameraSpecsNotSet() throws NitfFormatException {
+        when(tre.getIntValue(PiaimcAttribute.CAMSPECS_NAME)).thenThrow(NitfFormatException.class);
+        Serializable actual = PiaimcAttribute.CAMSPECS.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(nullValue()));
+    }
+
+    @Test
+    public void testProjectIdSet() throws NitfFormatException {
+        when(tre.getFieldValue(PiaimcAttribute.PROJID_NAME)).thenReturn("AB");
+        Serializable actual = PiaimcAttribute.PROJID.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is("AB"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testProjectIdNotSet() throws NitfFormatException {
+        when(tre.getIntValue(PiaimcAttribute.PROJID_NAME)).thenThrow(NitfFormatException.class);
+        Serializable actual = PiaimcAttribute.PROJID.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(nullValue()));
+    }
+
+    @Test
+    public void testGenerationSet() throws NitfFormatException {
+        when(tre.getFieldValue(PiaimcAttribute.GENERATION_NAME)).thenReturn("1");
+        Serializable actual = PiaimcAttribute.GENERATION.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(1));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testGenerationNotSet() throws NitfFormatException {
+        when(tre.getIntValue(PiaimcAttribute.GENERATION_NAME)).thenThrow(NitfFormatException.class);
+        Serializable actual = PiaimcAttribute.GENERATION.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(nullValue()));
+    }
+
+    @Test
+    public void testEsdTrue() throws NitfFormatException {
+        when(tre.getFieldValue(PiaimcAttribute.EXPLOITATION_SUPPORT_DATA_NAME)).thenReturn("Y");
+        Serializable actual = PiaimcAttribute.ESD.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(true));
+    }
+
+    @Test
+    public void testEsdFalse() throws NitfFormatException {
+        when(tre.getFieldValue(PiaimcAttribute.EXPLOITATION_SUPPORT_DATA_NAME)).thenReturn("N");
+        Serializable actual = PiaimcAttribute.ESD.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(false));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testEsdNotSet() throws NitfFormatException {
+        when(tre.getIntValue(PiaimcAttribute.EXPLOITATION_SUPPORT_DATA_NAME)).thenThrow(NitfFormatException.class);
+        Serializable actual = PiaimcAttribute.ESD.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(nullValue()));
+    }
+
+    @Test
+    public void testOtherCondSet() throws NitfFormatException {
+        when(tre.getFieldValue(PiaimcAttribute.OTHERCOND_NAME)).thenReturn("AZ");
+        Serializable actual = PiaimcAttribute.OTHERCOND.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is("AZ"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testOtherCondNotSet() throws NitfFormatException {
+        when(tre.getIntValue(PiaimcAttribute.OTHERCOND_NAME)).thenThrow(NitfFormatException.class);
+        Serializable actual = PiaimcAttribute.OTHERCOND.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(nullValue()));
+    }
+
+    @Test
+    public void testMeanGsdMin() throws NitfFormatException {
+        when(tre.getFieldValue(PiaimcAttribute.MEANGSD_NAME)).thenReturn("00000.0");
+        Serializable actual = PiaimcAttribute.MEANGSD.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(0.0f));
+    }
+
+    @Test
+    public void testMeanGsdMax() throws NitfFormatException {
+        when(tre.getFieldValue(PiaimcAttribute.MEANGSD_NAME)).thenReturn("99999.9");
+        Serializable actual = PiaimcAttribute.MEANGSD.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(99999.9f));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testMeanGsdNotSet() throws NitfFormatException {
+        when(tre.getIntValue(PiaimcAttribute.MEANGSD_NAME)).thenThrow(NitfFormatException.class);
+        Serializable actual = PiaimcAttribute.MEANGSD.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(nullValue()));
+    }
+
+    @Test
+    public void testIdatumSet() throws NitfFormatException {
+        when(tre.getFieldValue(PiaimcAttribute.IDATUM_NAME)).thenReturn("WGS");
+        Serializable actual = PiaimcAttribute.IDATUM.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is("WGS"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testIdatumNotSet() throws NitfFormatException {
+        when(tre.getIntValue(PiaimcAttribute.IDATUM_NAME)).thenThrow(NitfFormatException.class);
+        Serializable actual = PiaimcAttribute.IDATUM.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(nullValue()));
+    }
+
+    @Test
+    public void testIellipSet() throws NitfFormatException {
+        when(tre.getFieldValue(PiaimcAttribute.IELLIP_NAME)).thenReturn("WGE");
+        Serializable actual = PiaimcAttribute.IELLIP.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is("WGE"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testIellipNotSet() throws NitfFormatException {
+        when(tre.getIntValue(PiaimcAttribute.IELLIP_NAME)).thenThrow(NitfFormatException.class);
+        Serializable actual = PiaimcAttribute.IELLIP.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(nullValue()));
+    }
+
+    @Test
+    public void testImageProcessingLevelSet() throws NitfFormatException {
+        when(tre.getFieldValue(PiaimcAttribute.PREPROC_NAME)).thenReturn("AA");
+        Serializable actual = PiaimcAttribute.PREPROC.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is("AA"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testImageProcessingLevelNotSet() throws NitfFormatException {
+        when(tre.getIntValue(PiaimcAttribute.PREPROC_NAME)).thenThrow(NitfFormatException.class);
+        Serializable actual = PiaimcAttribute.PREPROC.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(nullValue()));
+    }
+
+    @Test
+    public void testImageProjectionSystemSet() throws NitfFormatException {
+        when(tre.getFieldValue(PiaimcAttribute.IPROJ_NAME)).thenReturn("AA");
+        Serializable actual = PiaimcAttribute.IPROJ.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is("AA"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testImageProjectionSystemNotSet() throws NitfFormatException {
+        when(tre.getIntValue(PiaimcAttribute.IPROJ_NAME)).thenThrow(NitfFormatException.class);
+        Serializable actual = PiaimcAttribute.IPROJ.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(nullValue()));
+    }
+
+    @Test
+    public void testSatTrackPathSetMin() throws NitfFormatException {
+        when(tre.getFieldValue(PiaimcAttribute.SATTRACK_PATH_NAME)).thenReturn("0001");
+        Serializable actual = PiaimcAttribute.SATTRACK_PATH.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(1));
+    }
+
+    @Test
+    public void testSatTrackPathSetMax() throws NitfFormatException {
+        when(tre.getFieldValue(PiaimcAttribute.SATTRACK_PATH_NAME)).thenReturn("9999");
+        Serializable actual = PiaimcAttribute.SATTRACK_PATH.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(9999));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testSatTrackPathNotSet() throws NitfFormatException {
+        when(tre.getIntValue(PiaimcAttribute.SATTRACK_PATH_NAME)).thenThrow(NitfFormatException.class);
+        Serializable actual = PiaimcAttribute.SATTRACK_PATH.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(nullValue()));
+    }
+
+    @Test
+    public void testSatTrackRowSetMin() throws NitfFormatException {
+        when(tre.getFieldValue(PiaimcAttribute.SATTRACK_ROW_NAME)).thenReturn("0001");
+        Serializable actual = PiaimcAttribute.SATTRACK_ROW.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(1));
+    }
+
+    @Test
+    public void testSatTrackRowSetMax() throws NitfFormatException {
+        when(tre.getFieldValue(PiaimcAttribute.SATTRACK_ROW_NAME)).thenReturn("9999");
+        Serializable actual = PiaimcAttribute.SATTRACK_ROW.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(9999));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testSatTrackRowNotSet() throws NitfFormatException {
+        when(tre.getIntValue(PiaimcAttribute.SATTRACK_ROW_NAME)).thenThrow(NitfFormatException.class);
+        Serializable actual = PiaimcAttribute.SATTRACK_ROW.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(nullValue()));
+    }
 }

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageInputTransformerTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageInputTransformerTest.java
@@ -346,25 +346,25 @@ public class ImageInputTransformerTest {
         NitfHeader header = NitfHeaderFactory.getDefault(FileType.NITF_TWO_ONE);
         Tre piaimc = TreFactory.getDefault("PIAIMC", TreSource.ImageExtendedSubheaderData);
         piaimc.add(new TreEntry("CLOUDCVR", "070", "string"));
-        piaimc.add(new TreEntry("SRP", str(1), "string"));
+        piaimc.add(new TreEntry("SRP", "Y", "string"));
         piaimc.add(new TreEntry("SENSMODE", str(12), "string"));
         piaimc.add(new TreEntry("SENSNAME", str(18), "string"));
         piaimc.add(new TreEntry("SOURCE", str(255), "string"));
-        piaimc.add(new TreEntry("COMGEN", str(2), "string"));
+        piaimc.add(new TreEntry("COMGEN", "09", "string"));
         piaimc.add(new TreEntry("SUBQUAL", str(1), "string"));
         piaimc.add(new TreEntry("PIAMSNNUM", str(7), "string"));
         piaimc.add(new TreEntry("CAMSPECS", str(32), "string"));
         piaimc.add(new TreEntry("PROJID", str(2), "string"));
-        piaimc.add(new TreEntry("GENERATION", str(1), "string"));
-        piaimc.add(new TreEntry("ESD", str(1), "string"));
+        piaimc.add(new TreEntry("GENERATION", "8", "string"));
+        piaimc.add(new TreEntry("ESD", "Y", "string"));
         piaimc.add(new TreEntry("OTHERCOND", str(2), "string"));
-        piaimc.add(new TreEntry("MEANGSD", str(7), "string"));
+        piaimc.add(new TreEntry("MEANGSD", "00000.0", "string"));
         piaimc.add(new TreEntry("IDATUM", str(3), "string"));
         piaimc.add(new TreEntry("IELLIP", str(3), "string"));
         piaimc.add(new TreEntry("PREPROC", str(2), "string"));
         piaimc.add(new TreEntry("IPROJ", str(2), "string"));
-        piaimc.add(new TreEntry("SATTRACK_PATH", str(4), "string"));
-        piaimc.add(new TreEntry("SATTRACK_ROW", str(4), "string"));
+        piaimc.add(new TreEntry("SATTRACK_PATH", "0000", "string"));
+        piaimc.add(new TreEntry("SATTRACK_ROW", "0000", "string"));
 
         ImageSegment imageSegment = ImageSegmentFactory.getDefault(FileType.NITF_TWO_ONE);
         imageSegment.addImageBand(new ImageBand());
@@ -374,7 +374,6 @@ public class ImageInputTransformerTest {
         new NitfCreationFlow().fileHeader(() -> header)
                 .imageSegment(() -> imageSegment)
                 .write(file.getAbsolutePath());
-
     }
 
     @Test


### PR DESCRIPTION
#### What does this PR do?

CAL-134: Mapping of PIAIMC attributes to ext.nitf.\* fields.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@glenhein 
@bdeining
@peterhuffer
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@kcwire
@lessarderic
#### How should this be tested?

Run complete build with tests.
#### Any background context you want to provide?

The PR for CAL-134 will be broken out into multiple PRs.
#### What are the relevant tickets?

https://codice.atlassian.net/browse/CAL-134
This depends on: https://github.com/codice/alliance/pull/179
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
