### PR TITLE
CAL-134: Mapping of HISTOA attributes to ext.nitf.* fields.

### DIFF
--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/HistoaAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/HistoaAttribute.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.transformer.nitf.common;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Function;
+
+import org.codice.imaging.nitf.core.tre.Tre;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.AttributeType;
+import ddf.catalog.data.impl.BasicTypes;
+
+/**
+ * TRE for "Softcopy History Tagged Record Extension"
+ */
+public class HistoaAttribute extends NitfAttributeImpl<Tre> {
+
+    private static final List<NitfAttribute<Tre>> ATTRIBUTES = new LinkedList<>();
+
+    public static final String SYSTYPE_NAME = "SYSTYPE";
+
+    public static final String PRIOR_COMPRESSION_NAME = "PC";
+
+    public static final String PRIOR_ENHANCEMENTS_NAME = "PE";
+
+    public static final String REMAP_FLAG_NAME = "REMAP_FLAG";
+
+    public static final String LUTID_NAME = "LUTID";
+
+    public static final String ATTRIBUTE_NAME_PREFIX = "histoa.";
+
+    static final HistoaAttribute SYSTYPE = new HistoaAttribute("system-type",
+            SYSTYPE_NAME,
+            tre -> TreUtility.convertToString(tre, SYSTYPE_NAME),
+            BasicTypes.STRING_TYPE,
+            ATTRIBUTE_NAME_PREFIX);
+
+    static final HistoaAttribute PC = new HistoaAttribute("prior-compression",
+            PRIOR_COMPRESSION_NAME,
+            tre -> TreUtility.convertToString(tre, PRIOR_COMPRESSION_NAME),
+            BasicTypes.STRING_TYPE,
+            ATTRIBUTE_NAME_PREFIX);
+
+    static final HistoaAttribute PE = new HistoaAttribute("prior-enhancements",
+            PRIOR_ENHANCEMENTS_NAME,
+            tre -> TreUtility.convertToString(tre, PRIOR_ENHANCEMENTS_NAME),
+            BasicTypes.STRING_TYPE,
+            ATTRIBUTE_NAME_PREFIX);
+
+    static final HistoaAttribute REMAP_FLAG = new HistoaAttribute("system-specific-remap",
+            REMAP_FLAG_NAME,
+            tre -> TreUtility.convertToString(tre, REMAP_FLAG_NAME),
+            BasicTypes.STRING_TYPE,
+            ATTRIBUTE_NAME_PREFIX);
+
+    static final HistoaAttribute LUTID = new HistoaAttribute("data-mapping-id",
+            LUTID_NAME,
+            tre -> TreUtility.convertToInteger(tre, LUTID_NAME),
+            BasicTypes.INTEGER_TYPE,
+            ATTRIBUTE_NAME_PREFIX);
+
+    private HistoaAttribute(String longName, String shortName,
+            Function<Tre, Serializable> accessorFunction, AttributeType attributeType,
+            String prefix) {
+        super(longName, shortName, accessorFunction, attributeType, prefix);
+        ATTRIBUTES.add(this);
+    }
+
+    private HistoaAttribute(final String longName, final String shortName,
+            final Function<Tre, Serializable> accessorFunction,
+            AttributeDescriptor attributeDescriptor, String extNitfName, String prefix) {
+        super(longName, shortName, accessorFunction, attributeDescriptor, extNitfName, prefix);
+        ATTRIBUTES.add(this);
+    }
+
+    public static List<NitfAttribute<Tre>> getAttributes() {
+        return Collections.unmodifiableList(ATTRIBUTES);
+    }
+
+}

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/TreDescriptor.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/TreDescriptor.java
@@ -25,7 +25,8 @@ public enum TreDescriptor {
     MTIRPB(MtirpbAttribute.getAttributes()),
     CSEXRA(CsexraAttribute.getAttributes()),
     PIAIMC(PiaimcAttribute.getAttributes()),
-    CSDIDA(CsdidaAttribute.getAttributes());
+    CSDIDA(CsdidaAttribute.getAttributes()),
+    HISTOA(HistoaAttribute.getAttributes());
 
     private List<NitfAttribute<Tre>> nitfAttributes;
 

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/gmti/GmtiMetacardType.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/gmti/GmtiMetacardType.java
@@ -19,6 +19,7 @@ import org.codice.alliance.transformer.nitf.AbstractNitfMetacardType;
 import org.codice.alliance.transformer.nitf.common.AcftbAttribute;
 import org.codice.alliance.transformer.nitf.common.CsdidaAttribute;
 import org.codice.alliance.transformer.nitf.common.CsexraAttribute;
+import org.codice.alliance.transformer.nitf.common.HistoaAttribute;
 import org.codice.alliance.transformer.nitf.common.NitfHeaderAttribute;
 import org.codice.alliance.transformer.nitf.common.PiaimcAttribute;
 
@@ -56,5 +57,6 @@ public class GmtiMetacardType extends AbstractNitfMetacardType {
         descriptors.addAll(getDescriptors(PiaimcAttribute.getAttributes()));
         descriptors.addAll(getDescriptors(CsdidaAttribute.getAttributes()));
         descriptors.addAll(getDescriptors(CsexraAttribute.getAttributes()));
+        descriptors.addAll(getDescriptors(HistoaAttribute.getAttributes()));
     }
 }

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/ImageMetacardType.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/ImageMetacardType.java
@@ -20,6 +20,7 @@ import org.codice.alliance.transformer.nitf.common.AcftbAttribute;
 import org.codice.alliance.transformer.nitf.common.AimidbAttribute;
 import org.codice.alliance.transformer.nitf.common.CsdidaAttribute;
 import org.codice.alliance.transformer.nitf.common.CsexraAttribute;
+import org.codice.alliance.transformer.nitf.common.HistoaAttribute;
 import org.codice.alliance.transformer.nitf.common.NitfHeaderAttribute;
 import org.codice.alliance.transformer.nitf.common.PiaimcAttribute;
 import org.codice.alliance.transformer.nitf.gmti.IndexedMtirpbAttribute;
@@ -62,6 +63,7 @@ public class ImageMetacardType extends AbstractNitfMetacardType {
         descriptors.addAll(new ValidationAttributes().getAttributeDescriptors());
         descriptors.addAll(new IsrAttributes().getAttributeDescriptors());
         descriptors.addAll(new SecurityAttributes().getAttributeDescriptors());
+        descriptors.addAll(getDescriptors(HistoaAttribute.getAttributes()));
         descriptors.addAll(getDescriptors(PiaimcAttribute.getAttributes()));
         descriptors.addAll(getDescriptors(CsdidaAttribute.getAttributes()));
         descriptors.addAll(getDescriptors(CsexraAttribute.getAttributes()));

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/HistoaAttributeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/HistoaAttributeTest.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.transformer.nitf.common;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.Serializable;
+
+import org.codice.imaging.nitf.core.common.NitfFormatException;
+import org.codice.imaging.nitf.core.tre.Tre;
+import org.junit.Before;
+import org.junit.Test;
+
+public class HistoaAttributeTest {
+
+    private Tre tre;
+
+    @Before
+    public void setup() {
+        tre = mock(Tre.class);
+    }
+
+    @Test
+    public void testSystypeSet() throws NitfFormatException {
+        when(tre.getFieldValue(HistoaAttribute.SYSTYPE_NAME)).thenReturn("TestType");
+
+        Serializable actual = HistoaAttribute.SYSTYPE.getAccessorFunction()
+                .apply(tre);
+
+        assertThat(actual, is("TestType"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testSystypeNotSet() throws NitfFormatException {
+        when(tre.getIntValue(HistoaAttribute.SYSTYPE_NAME)).thenThrow(NitfFormatException.class);
+        Serializable actual = HistoaAttribute.SYSTYPE.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(nullValue()));
+    }
+
+    @Test
+    public void testPcSet() throws NitfFormatException {
+        when(tre.getFieldValue(HistoaAttribute.PRIOR_COMPRESSION_NAME)).thenReturn("TestPC");
+
+        Serializable actual = HistoaAttribute.PC.getAccessorFunction()
+                .apply(tre);
+
+        assertThat(actual, is("TestPC"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testPcNotSet() throws NitfFormatException {
+        when(tre.getIntValue(HistoaAttribute.PRIOR_COMPRESSION_NAME)).thenThrow(NitfFormatException.class);
+        Serializable actual = HistoaAttribute.PC.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(nullValue()));
+    }
+
+    @Test
+    public void testPeSet() throws NitfFormatException {
+        when(tre.getFieldValue(HistoaAttribute.PRIOR_ENHANCEMENTS_NAME)).thenReturn("TestPE");
+
+        Serializable actual = HistoaAttribute.PE.getAccessorFunction()
+                .apply(tre);
+
+        assertThat(actual, is("TestPE"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testPeNotSet() throws NitfFormatException {
+        when(tre.getIntValue(HistoaAttribute.PRIOR_ENHANCEMENTS_NAME)).thenThrow(NitfFormatException.class);
+        Serializable actual = HistoaAttribute.PE.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(nullValue()));
+    }
+
+    @Test
+    public void testRemapFlagSet() throws NitfFormatException {
+        when(tre.getFieldValue(HistoaAttribute.REMAP_FLAG_NAME)).thenReturn("N");
+
+        Serializable actual = HistoaAttribute.REMAP_FLAG.getAccessorFunction()
+                .apply(tre);
+
+        assertThat(actual, is("N"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testRemapFlagNotSet() throws NitfFormatException {
+        when(tre.getIntValue(HistoaAttribute.REMAP_FLAG_NAME)).thenThrow(NitfFormatException.class);
+        Serializable actual = HistoaAttribute.REMAP_FLAG.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(nullValue()));
+    }
+
+    @Test
+    public void testDataMappingIdSet() throws NitfFormatException {
+        when(tre.getFieldValue(HistoaAttribute.LUTID_NAME)).thenReturn("01");
+
+        Serializable actual = HistoaAttribute.LUTID.getAccessorFunction()
+                .apply(tre);
+
+        assertThat(actual, is(1));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testDataMappingFlagNotSet() throws NitfFormatException {
+        when(tre.getIntValue(HistoaAttribute.LUTID_NAME)).thenThrow(NitfFormatException.class);
+        Serializable actual = HistoaAttribute.LUTID.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(nullValue()));
+    }
+
+}


### PR DESCRIPTION
#### What does this PR do?

CAL-134: Mapping for non-taxonomy HISTOA NITF TRE fields.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@glenhein 
@bdeining
@peterhuffer
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@kcwire
@lessarderic
#### How should this be tested?

Run complete build with tests.
#### Any background context you want to provide?

The PR for CAL-134 will be broken out into multiple PRs.
#### What are the relevant tickets?

https://codice.atlassian.net/browse/CAL-134
This depends on: https://github.com/codice/alliance/pull/179
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
