### PR TITLE
CAL-131 0.1.x Backport - Updated Image Magnification to only set a double as per the NITF spec

### DIFF
--- a/catalog/imaging/imaging-transformer-nitf/pom.xml
+++ b/catalog/imaging/imaging-transformer-nitf/pom.xml
@@ -169,7 +169,7 @@
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.80</minimum>
+                                            <minimum>0.79</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/ImageAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/ImageAttribute.java
@@ -209,8 +209,8 @@ public enum ImageAttribute implements NitfAttribute<ImageSegment> {
             segment -> segment.getImageLocationRow() + "," + segment.getImageLocationColumn()),
     IMAGE_MAGNIFICATION("imageMagnification",
             "IMAG",
-            segment -> segment.getImageMagnification()
-                    .trim());
+            ImageSegment::getImageMagnificationAsDouble,
+            BasicTypes.DOUBLE_TYPE);
 
     public static final String ATTRIBUTE_NAME_PREFIX = "nitf.image.";
 

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/TestImageInputTransformer.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/TestImageInputTransformer.java
@@ -266,7 +266,7 @@ public class TestImageInputTransformer {
         assertThat(metacard.getAttribute("nitf.image." + ImageAttribute.IMAGE_LOCATION)
                 .getValue(), is("0,0"));
         assertThat(metacard.getAttribute("nitf.image." + ImageAttribute.IMAGE_MAGNIFICATION)
-                .getValue(), is("1.0"));
+                .getValue(), is(1.0));
     }
 
     private void validateDate(Metacard metacard, Date date, String expectedDate) {


### PR DESCRIPTION
#### What does this PR do?
Backport of CAL-131 https://github.com/codice/alliance/pull/166
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@peterhuffer @clockard 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@shaundmorris
#### How should this be tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
