### PR TITLE
CAL-172: Fixing IsrComments attribute to be built up with spaces between each comment.

### DIFF
--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/NitfImageTransformer.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/NitfImageTransformer.java
@@ -148,7 +148,7 @@ public class NitfImageTransformer extends SegmentHandler {
             StringBuilder sb = new StringBuilder();
             comments.forEach(comment -> {
                 if (StringUtils.isNotBlank(comment)) {
-                    sb.append(comment); // no delimiter
+                    sb.append(comment + " ");
                 }
             });
 

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageInputTransformerTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageInputTransformerTest.java
@@ -166,15 +166,15 @@ public class ImageInputTransformerTest {
     public void testHandleCommentsSuccessful() throws Exception {
         final String blockComment =
                 "The credit belongs to the man who is actually in the arena, whose face is marred"
-                        + " by dust and sweat and blood; who strives valiantly; who errs, who comes short a"
-                        + "gain and again, because there is no effort without error and shortcoming; but wh"
-                        + "o does actually strive to do the deeds.";
+                        + " by dust and sweat and blood; who strives valiantly; who errs, who comes short"
+                        + " again and again, because there is no effort without error and shortcoming; but"
+                        + " who does actually strive to do the deeds. ";
 
         List<String> commentsList = Arrays.asList(
                 "The credit belongs to the man who is actually in the arena, whose face is marred",
-                " by dust and sweat and blood; who strives valiantly; who errs, who comes short a",
-                "gain and again, because there is no effort without error and shortcoming; but wh",
-                "o does actually strive to do the deeds.");
+                "by dust and sweat and blood; who strives valiantly; who errs, who comes short",
+                "again and again, because there is no effort without error and shortcoming; but",
+                "who does actually strive to do the deeds.");
         Metacard metacard = metacardFactory.createMetacard("commentsTest");
         transformer.handleComments(metacard, commentsList);
         assertThat(metacard.getAttribute(Isr.COMMENTS)


### PR DESCRIPTION
#### What does this PR do?

Inserts spaces between each individual comment before setting on the `IsrComments` attribute.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@troymohl @peterhuffer @glenhein 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@kcwire 
@millerw8 
#### How should this be tested?
- Build and install Alliance.
- Ingest a ntf image.
- View the metacard and verify the `Isr Comments` field has no words that are mashed together (e.g. "inaccordance").
#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-172](https://codice.atlassian.net/browse/CAL-172)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
  - [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
