### PR TITLE
CAL-171 Add support for videos that contain Frame Center data, but not Corner or Offset Corner

### DIFF
--- a/libs/klv/src/main/java/org/codice/alliance/libs/klv/BaseKlvHandler.java
+++ b/libs/klv/src/main/java/org/codice/alliance/libs/klv/BaseKlvHandler.java
@@ -17,7 +17,9 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.BiConsumer;
 
 import ddf.catalog.data.Attribute;
 import ddf.catalog.data.impl.AttributeImpl;
@@ -48,5 +50,14 @@ public abstract class BaseKlvHandler implements KlvHandler {
                 .mapToInt(List::size)
                 .min()
                 .orElse(0);
+    }
+
+    protected void subsample(Map<String, List<Double>> data, int subsampleCount, int size,
+            BiConsumer<String, Double> biConsumer) {
+        data.forEach((key, value) -> {
+            for (int i = 0; i < subsampleCount; i++) {
+                biConsumer.accept(key, value.get(i * size / subsampleCount));
+            }
+        });
     }
 }

--- a/libs/klv/src/main/java/org/codice/alliance/libs/klv/GeoBoxHandler.java
+++ b/libs/klv/src/main/java/org/codice/alliance/libs/klv/GeoBoxHandler.java
@@ -151,6 +151,34 @@ public class GeoBoxHandler extends BaseKlvHandler implements Trimmable {
         return asAttribute(polygonsWkts);
     }
 
+    public GeoBoxHandler asSubsampledHandler(int subsampleCount) {
+
+        if (getRawGeoData().isEmpty()) {
+            return this;
+        }
+
+        int size = getRawGeoData().get(getLatitude1())
+                .size();
+
+        if (size <= subsampleCount) {
+            return this;
+        }
+
+        GeoBoxHandler out = new GeoBoxHandler(getAttributeName(),
+                getLatitude1(),
+                getLongitude1(),
+                getLatitude2(),
+                getLongitude2(),
+                getLatitude3(),
+                getLongitude3(),
+                getLatitude4(),
+                getLongitude4());
+
+        subsample(getRawGeoData(), subsampleCount, size, out::accept);
+
+        return out;
+    }
+
     /**
      * Trim the arrays of lat and lon values to the same length.
      */
@@ -165,10 +193,6 @@ public class GeoBoxHandler extends BaseKlvHandler implements Trimmable {
                                 list.subList(0, minListSize) :
                                 list));
 
-    }
-
-    private int getMinimumListSize() {
-        return getMinimumListSize(map.values());
     }
 
     @Override
@@ -195,4 +219,9 @@ public class GeoBoxHandler extends BaseKlvHandler implements Trimmable {
         map.get(name)
                 .add(value);
     }
+
+    private int getMinimumListSize() {
+        return getMinimumListSize(map.values());
+    }
+
 }

--- a/libs/klv/src/main/java/org/codice/alliance/libs/klv/LatitudeLongitudeHandler.java
+++ b/libs/klv/src/main/java/org/codice/alliance/libs/klv/LatitudeLongitudeHandler.java
@@ -76,8 +76,27 @@ public class LatitudeLongitudeHandler extends BaseKlvHandler implements Trimmabl
         return asAttribute(pairs);
     }
 
-    private int getMinimumListSize() {
-        return getMinimumListSize(map.values());
+    public LatitudeLongitudeHandler asSubsampledHandler(int subsampleCount) {
+
+        if (getRawGeoData().isEmpty()) {
+            return this;
+        }
+
+        int size = getRawGeoData().get(getLatitudeFieldName())
+                .size();
+
+        if (size <= subsampleCount) {
+            return this;
+        }
+
+        LatitudeLongitudeHandler out = new LatitudeLongitudeHandler(getAttributeName(),
+                getLatitudeFieldName(),
+                getLongitudeFieldName());
+
+        subsample(getRawGeoData(), subsampleCount, size, out::accept);
+
+        return out;
+
     }
 
     /**
@@ -111,6 +130,16 @@ public class LatitudeLongitudeHandler extends BaseKlvHandler implements Trimmabl
     @Override
     public void reset() {
         map.clear();
+    }
+
+    public void accept(String name, Double value) {
+        map.putIfAbsent(name, new ArrayList<>());
+        map.get(name)
+                .add(value);
+    }
+
+    private int getMinimumListSize() {
+        return getMinimumListSize(map.values());
     }
 
 }

--- a/libs/klv/src/test/java/org/codice/alliance/libs/klv/GeoBoxHandlerTest.java
+++ b/libs/klv/src/test/java/org/codice/alliance/libs/klv/GeoBoxHandlerTest.java
@@ -195,4 +195,103 @@ public class GeoBoxHandlerTest {
         assertThat(data.get(LON4)
                 .get(0), is(closeTo(8, EPSILON)));
     }
+
+    /**
+     * This test iterates through a wide range of subsample inputs to make sure they all reduce to the
+     * subsample target and that there are no rounding issues.
+     */
+    @Test
+    public void testGeoBoxSubsample() throws KlvDecodingException {
+
+        int subsampleCount = 50;
+
+        String lat1 = "lat1";
+        String lon1 = "lon1";
+        String lat2 = "lat2";
+        String lon2 = "lon2";
+        String lat3 = "lat3";
+        String lon3 = "lon3";
+        String lat4 = "lat4";
+        String lon4 = "lon4";
+
+        int start = subsampleCount + 1;
+        int end = subsampleCount * 10;
+
+        for (int originalSize = start; originalSize < end; originalSize++) {
+
+            for (int i = 0; i < originalSize; i++) {
+                geoBoxHandler.accept(KlvUtilities.createTestFloat(LAT1, i));
+                geoBoxHandler.accept(KlvUtilities.createTestFloat(LON1, i));
+                geoBoxHandler.accept(KlvUtilities.createTestFloat(LAT2, i));
+                geoBoxHandler.accept(KlvUtilities.createTestFloat(LON2, i));
+                geoBoxHandler.accept(KlvUtilities.createTestFloat(LAT3, i));
+                geoBoxHandler.accept(KlvUtilities.createTestFloat(LON3, i));
+                geoBoxHandler.accept(KlvUtilities.createTestFloat(LAT4, i));
+                geoBoxHandler.accept(KlvUtilities.createTestFloat(LON4, i));
+            }
+
+            GeoBoxHandler subsampledGeoBoxHandler =
+                    geoBoxHandler.asSubsampledHandler(subsampleCount);
+
+            Map<String, List<Double>> newRawData = subsampledGeoBoxHandler.getRawGeoData();
+
+            assertThatCount(newRawData, lat1, subsampleCount);
+            assertThatCount(newRawData, lon1, subsampleCount);
+            assertThatCount(newRawData, lat2, subsampleCount);
+            assertThatCount(newRawData, lon2, subsampleCount);
+            assertThatCount(newRawData, lat3, subsampleCount);
+            assertThatCount(newRawData, lon3, subsampleCount);
+            assertThatCount(newRawData, lat4, subsampleCount);
+            assertThatCount(newRawData, lon4, subsampleCount);
+
+        }
+    }
+
+    /**
+     * Test the condition where the subsample count is greater than the number of data points
+     * in the handler.
+     */
+    @Test
+    public void testGeoBoxSubsampleUnderflow() throws KlvDecodingException {
+
+        String lat1 = "lat1";
+        String lon1 = "lon1";
+        String lat2 = "lat2";
+        String lon2 = "lon2";
+        String lat3 = "lat3";
+        String lon3 = "lon3";
+        String lat4 = "lat4";
+        String lon4 = "lon4";
+
+        int count = 10;
+
+        for (int i = 0; i < count; i++) {
+            geoBoxHandler.accept(KlvUtilities.createTestFloat(LAT1, i));
+            geoBoxHandler.accept(KlvUtilities.createTestFloat(LON1, i));
+            geoBoxHandler.accept(KlvUtilities.createTestFloat(LAT2, i));
+            geoBoxHandler.accept(KlvUtilities.createTestFloat(LON2, i));
+            geoBoxHandler.accept(KlvUtilities.createTestFloat(LAT3, i));
+            geoBoxHandler.accept(KlvUtilities.createTestFloat(LON3, i));
+            geoBoxHandler.accept(KlvUtilities.createTestFloat(LAT4, i));
+            geoBoxHandler.accept(KlvUtilities.createTestFloat(LON4, i));
+        }
+
+        GeoBoxHandler subsampledGeoBoxHandler = geoBoxHandler.asSubsampledHandler(50);
+
+        Map<String, List<Double>> newRawData = subsampledGeoBoxHandler.getRawGeoData();
+
+        assertThatCount(newRawData, lat1, count);
+        assertThatCount(newRawData, lon1, count);
+        assertThatCount(newRawData, lat2, count);
+        assertThatCount(newRawData, lon2, count);
+        assertThatCount(newRawData, lat3, count);
+        assertThatCount(newRawData, lon3, count);
+        assertThatCount(newRawData, lat4, count);
+        assertThatCount(newRawData, lon4, count);
+
+    }
+
+    private void assertThatCount(Map<String, List<Double>> rawData, String name, int count) {
+        assertThat(rawData.get(name), hasSize(count));
+    }
 }

--- a/libs/klv/src/test/java/org/codice/alliance/libs/klv/GeometryUtilityTest.java
+++ b/libs/klv/src/test/java/org/codice/alliance/libs/klv/GeometryUtilityTest.java
@@ -150,4 +150,54 @@ public class GeometryUtilityTest {
 
     }
 
+    @Test
+    public void testAttributeToLineString() {
+
+        Attribute attribute = new AttributeImpl(FIELD,
+                Arrays.asList("POINT ( 0 0 )",
+                        "POINT ( 10 10 )"));
+
+        String lineString = GeometryUtility.attributeToLineString(attribute, GeometryOperator.IDENTITY);
+
+        assertThat(lineString, is("LINESTRING (0 0, 10 10)"));
+
+    }
+
+    @Test
+    public void testAttributeToLineStringWithSomeBadData() {
+
+        Attribute attribute = new AttributeImpl(FIELD,
+                Arrays.asList("POINT ( 0 0 )",
+                        "POINT ( xxx )"));
+
+        String lineString = GeometryUtility.attributeToLineString(attribute, GeometryOperator.IDENTITY);
+
+        assertThat(lineString, is("POINT (0 0)"));
+
+    }
+
+    @Test
+    public void testAttributeToLineStringWithBadData() {
+
+        Attribute attribute = new AttributeImpl(FIELD,
+                Arrays.asList("POINT ( yyy )",
+                        "POINT ( xxx )"));
+
+        String lineString = GeometryUtility.attributeToLineString(attribute, GeometryOperator.IDENTITY);
+
+        assertThat(lineString, is("LINESTRING EMPTY"));
+
+    }
+
+    @Test
+    public void testAttributeToLineStringWithEmptyData() {
+
+        Attribute attribute = new AttributeImpl(FIELD, Collections.emptyList());
+
+        String lineString = GeometryUtility.attributeToLineString(attribute, GeometryOperator.IDENTITY);
+
+        assertThat(lineString, is("LINESTRING EMPTY"));
+
+    }
+
 }

--- a/libs/klv/src/test/java/org/codice/alliance/libs/klv/LatitudeLongitudeHandlerTest.java
+++ b/libs/klv/src/test/java/org/codice/alliance/libs/klv/LatitudeLongitudeHandlerTest.java
@@ -128,4 +128,67 @@ public class LatitudeLongitudeHandlerTest {
         assertThat(data.get(LON)
                 .get(0), is(closeTo(lon, EPSILON)));
     }
+
+    @Test
+    public void testLatLonSubsample() throws KlvDecodingException {
+
+        int subsampleCount = 50;
+
+        String lat = "lat";
+        String lon = "lon";
+
+        int start = subsampleCount + 1;
+        int end = subsampleCount * 10;
+
+        for (int originalSize = start; originalSize < end; originalSize++) {
+
+            for (int i = 0; i < originalSize; i++) {
+                klvHandler.accept(KlvUtilities.createTestFloat(LAT, i));
+                klvHandler.accept(KlvUtilities.createTestFloat(LON, i));
+            }
+
+            LatitudeLongitudeHandler reducedLatLonHandler = klvHandler.asSubsampledHandler(
+                    subsampleCount);
+
+            Map<String, List<Double>> reducedRawData = reducedLatLonHandler.getRawGeoData();
+
+            assertThatCount(reducedRawData, lat, subsampleCount);
+            assertThatCount(reducedRawData, lon, subsampleCount);
+
+        }
+    }
+
+    /**
+     * Test the condition where the subsample count is greater than the number of data points
+     * in the handler.
+     */
+    @Test
+    public void testLatLonSubsampleUnderflow() throws KlvDecodingException {
+
+        int subsampleCount = 50;
+
+        String lat = "lat";
+        String lon = "lon";
+
+        int count = 10;
+
+        for (int i = 0; i < count; i++) {
+            klvHandler.accept(KlvUtilities.createTestFloat(LAT, i));
+            klvHandler.accept(KlvUtilities.createTestFloat(LON, i));
+        }
+
+        LatitudeLongitudeHandler reducedLatLonHandler = klvHandler.asSubsampledHandler(
+                subsampleCount);
+
+        Map<String, List<Double>> reducedRawData = reducedLatLonHandler.getRawGeoData();
+
+        assertThatCount(reducedRawData, lat, count);
+        assertThatCount(reducedRawData, lon, count);
+
+    }
+
+    private void assertThatCount(Map<String, List<Double>> rawData, String name, int count) {
+        assertThat(rawData.get(name), hasSize(count));
+    }
+
 }


### PR DESCRIPTION
#### What does this PR do?

Add fallback code to use Frame Center data for generating Core.LOCATION in cases when Corner and Offset Corner data is missing.

A video can now produce Core.LOCATION geographic data from three sources:

 * Corner data
 * Offset Corner and Frame Center, which when added together becomes Corner data
 * Frame Center, which results in the location being a line string

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@kcwire 
@bdeining 
@jlcsmith 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@lessarderic
#### How should this be tested?

1) Build and install Alliance.
2) Configure the video stream monitor (default values should be fine)
3) Start the stream monitor (click the "start" button)
4) Using distribution/sdk/sample-mpegts-streamgenerator, stream an MPEG-TS file that contains Frame Center, but not Corner or Offset Corner data. If you don't have a video, please contact me.
5) After ingesting the video, search for the video chunks in the UI. You should see that the location field is a line string based on the Frame Center data.

#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-171](https://codice.atlassian.net/browse/CAL-171)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

