### PR TITLE
CAL-173 Add thread locking to UDP video processing

### DIFF
--- a/distribution/sdk/sample-mpegts-streamgenerator/README.md
+++ b/distribution/sdk/sample-mpegts-streamgenerator/README.md
@@ -18,6 +18,6 @@
 Codice Alliance contains a sample MPEGTS UDP Stream Generator to be used for testing purposes.  This utility can be run from the command-line within the sample-mpegts-streamgenerator directory by using maven and specifying a file path.
 
 ```
-mvn -Pmpegts.stream -Dexec.args=<mpegPath>,<ip address>,<port>
-e.g. mvn -Pmpegts.stream -Dexec.args="/Users/johndoe/Documents/stream.ts,127.0.0.1,50000"
+mvn -Pmpegts.stream -Dexec.args=path=<mpegPath>,ip=<ip address>,port=<port>,datagramSize=<size|min-max>,fractionalTs=<yes|no>
+e.g. mvn -Pmpegts.stream -Dexec.args="path=/Users/johndoe/Documents/stream.ts,ip=127.0.0.1,port=50000,datagramSize=188-1500,fractionalTs=no"
 ```

--- a/distribution/sdk/sample-mpegts-streamgenerator/src/main/java/org/codice/alliance/distribution/sdk/video/stream/mpegts/MpegTsUdpClient.java
+++ b/distribution/sdk/sample-mpegts-streamgenerator/src/main/java/org/codice/alliance/distribution/sdk/video/stream/mpegts/MpegTsUdpClient.java
@@ -23,6 +23,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -32,7 +33,6 @@ import org.apache.commons.exec.DefaultExecutor;
 import org.apache.commons.exec.ExecuteWatchdog;
 import org.apache.commons.exec.Executor;
 import org.apache.commons.exec.PumpStreamHandler;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,27 +57,36 @@ public class MpegTsUdpClient {
 
     private static final Logger LOGGER;
 
-    static {
-        System.setProperty(org.slf4j.impl.SimpleLogger.DEFAULT_LOG_LEVEL_KEY, "TRACE");
-        LOGGER = LoggerFactory.getLogger(MpegTsUdpClient.class);
-    }
-
-    private static final int PACKET_SIZE = 188;
+    public static final int PACKET_SIZE = 188;
 
     private static final String DEFAULT_IP = "127.0.0.1";
 
     private static final int DEFAULT_PORT = 50000;
 
+    private static final int DISK_IO_BUFFER_SIZE = 4096;
+
+    private static final long PACKET_LOG_PERIOD = 10000;
+
+    private static final long BYTE_LOG_PERIOD = 10000000;
+
     private static final String SUPPRESS_PRINTING_BANNER_FLAG = "-hide_banner";
 
     private static final String USAGE_MESSAGE =
-            "mvn -Pmpegts.stream -Dexec.args=mpegPath,[ip address],[port]";
+            "mvn -Pmpegts.stream -Dexec.args=path=mpegPath,[ip=ip address],[port=port],[datagramSize=size|min-max],[fractionalTs=yes|no]";
 
     private static final String INPUT_FILE_FLAG = "-i";
 
     private static final boolean HANDLE_QUOTING = false;
 
+    static {
+        System.setProperty(org.slf4j.impl.SimpleLogger.DEFAULT_LOG_LEVEL_KEY, "TRACE");
+        LOGGER = LoggerFactory.getLogger(MpegTsUdpClient.class);
+    }
+
     public static void main(String[] args) {
+
+        LOGGER.info("args: {}", args[0]);
+
         String[] arguments = args[0].split(",");
 
         if (arguments.length < 1) {
@@ -86,34 +95,72 @@ public class MpegTsUdpClient {
             return;
         }
 
-        String videoFilePath = arguments[0];
-        if (StringUtils.isBlank(videoFilePath)) {
+        String ip = DEFAULT_IP;
+        int port = DEFAULT_PORT;
+        String videoFilePath = null;
+        int minDatagramSize = PACKET_SIZE;
+        int maxDatagramSize = PACKET_SIZE;
+        boolean fractionalTs = Boolean.FALSE;
+
+        for (String argument : arguments) {
+            String[] parts = argument.split("=");
+            switch (parts[0]) {
+            case "path":
+                videoFilePath = parts[1];
+                break;
+            case "ip":
+                ip = parts[1];
+                break;
+            case "port":
+                try {
+                    port = Integer.parseInt(parts[1]);
+                } catch (NumberFormatException e) {
+                    LOGGER.debug("Unable to parse specified port: {}. Using default: {}",
+                            parts[1],
+                            DEFAULT_PORT);
+                    port = DEFAULT_PORT;
+                }
+                break;
+            case "datagramSize":
+                try {
+                    if (parts[1].contains("-")) {
+                        int hyphenIndex = parts[1].indexOf("-");
+                        minDatagramSize = Integer.parseInt(parts[1].substring(0, hyphenIndex));
+                        maxDatagramSize = Integer.parseInt(parts[1].substring(hyphenIndex + 1));
+                    } else {
+                        minDatagramSize = Integer.parseInt(parts[1]);
+                        maxDatagramSize = minDatagramSize;
+                    }
+                } catch (NumberFormatException e) {
+                    LOGGER.debug("Unable to parse specified datagram size: {}. Using default: {}",
+                            parts[1],
+                            PACKET_SIZE);
+                    minDatagramSize = PACKET_SIZE;
+                    maxDatagramSize = PACKET_SIZE;
+                }
+                break;
+            case "fractionalTs":
+                switch (parts[1]) {
+                case "yes":
+                    fractionalTs = true;
+                    break;
+                case "no":
+                    fractionalTs = false;
+                    break;
+                default:
+                    fractionalTs = false;
+                }
+                break;
+            default:
+                LOGGER.error("unrecognized command-line option: {}", parts[0]);
+                return;
+            }
+        }
+
+        if (videoFilePath == null) {
             LOGGER.error("Unable to start stream: no video file path specified.");
             LOGGER.error(USAGE_MESSAGE);
             return;
-        }
-
-        String ip;
-        int port;
-
-        if (arguments.length == 1) {
-            ip = DEFAULT_IP;
-            port = DEFAULT_PORT;
-            LOGGER.debug("No IP or port provided. Using defaults: {}:{}", DEFAULT_IP, DEFAULT_PORT);
-        } else if (arguments.length == 2) {
-            ip = arguments[1];
-            port = DEFAULT_PORT;
-            LOGGER.debug("No port provided. Using default: {}", DEFAULT_PORT);
-        } else {
-            ip = arguments[1];
-            try {
-                port = Integer.parseInt(arguments[2]);
-            } catch (NumberFormatException e) {
-                LOGGER.debug("Unable to parse specified port: {}. Using default: {}",
-                        arguments[2],
-                        DEFAULT_PORT);
-                port = DEFAULT_PORT;
-            }
         }
 
         LOGGER.trace("Video file path: {}", videoFilePath);
@@ -129,11 +176,17 @@ public class MpegTsUdpClient {
 
         LOGGER.trace("Video Duration: {}", tsDurationMillis);
 
-        broadcastVideo(videoFilePath, ip, port, tsDurationMillis);
+        broadcastVideo(videoFilePath,
+                ip,
+                port,
+                tsDurationMillis,
+                minDatagramSize,
+                maxDatagramSize,
+                fractionalTs);
     }
 
     public static void broadcastVideo(String videoFilePath, String ip, int port,
-            long tsDurationMillis) {
+            long tsDurationMillis, int minDatagramSize, int maxDatagramSize, boolean fractionalTs) {
 
         EventLoopGroup eventLoopGroup = new NioEventLoopGroup();
         try {
@@ -172,33 +225,93 @@ public class MpegTsUdpClient {
 
             long startTime = System.currentTimeMillis();
 
-            int packetsSent = 0;
+            Random rand = new Random(0);
+
+            long nextPacketLog = PACKET_LOG_PERIOD;
+
+            long nextByteLog = BYTE_LOG_PERIOD;
 
             try (final InputStream fis = new BufferedInputStream(new FileInputStream(videoFile))) {
-                byte[] buffer = new byte[PACKET_SIZE];
-                int c;
-                while ((c = fis.read(buffer)) != -1) {
-                    bytesSent += c;
+                byte[] buffer = new byte[DISK_IO_BUFFER_SIZE];
 
-                    ChannelFuture cf = ch.writeAndFlush(new DatagramPacket(Unpooled.copiedBuffer(
-                            buffer), new InetSocketAddress(ip, port)));
+                int datagramSize = getPacketSize(rand,
+                        minDatagramSize,
+                        maxDatagramSize,
+                        fractionalTs);
 
-                    cf.await();
+                byte[] dgramBuffer = new byte[datagramSize];
 
-                    packetsSent++;
+                int writeStart = 0;
+                int writeEnd = datagramSize;
 
-                    if (packetsSent % 100 == 0) {
-                        Thread.sleep((long) (delayPerPacket * 100));
+                int readEnd;
+                while ((readEnd = fis.read(buffer)) != -1) {
+
+                    int readStart = 0;
+
+                    while (readStart < readEnd) {
+                        int bytesToCopy = Math.min(writeEnd - writeStart, readEnd - readStart);
+                        System.arraycopy(buffer, readStart, dgramBuffer, writeStart, bytesToCopy);
+                        readStart += bytesToCopy;
+                        writeStart += bytesToCopy;
+
+                        if (writeStart == writeEnd) {
+                            transmit(ch, dgramBuffer, ip, port);
+                            bytesSent += dgramBuffer.length;
+
+                            long packetsSent = bytesSent / PACKET_SIZE;
+
+                            long currentTime = System.currentTimeMillis();
+
+                            long elapsedTime = currentTime - startTime;
+
+                            double predictedTime = packetsSent * delayPerPacket;
+
+                            if ((predictedTime - elapsedTime) >= 50) {
+                                Thread.sleep((long) predictedTime - elapsedTime);
+                            }
+
+                            if (packetsSent >= nextPacketLog) {
+                                LOGGER.debug("Packets sent: {}, Bytes sent: {}",
+                                        packetsSent,
+                                        bytesSent);
+                                nextPacketLog += PACKET_LOG_PERIOD;
+                            }
+
+                            if (bytesSent >= nextByteLog) {
+                                LOGGER.debug("Packets sent: {}, Bytes sent: {}",
+                                        packetsSent,
+                                        bytesSent);
+                                nextByteLog += BYTE_LOG_PERIOD;
+                            }
+
+                            datagramSize = getPacketSize(rand,
+                                    minDatagramSize,
+                                    maxDatagramSize,
+                                    fractionalTs);
+
+                            dgramBuffer = new byte[datagramSize];
+                            writeStart = 0;
+                            writeEnd = datagramSize;
+                        }
+
                     }
-                    if (packetsSent % 10000 == 0) {
-                        LOGGER.trace("Packets sent: {}", packetsSent);
-                    }
+
                 }
+
+                if (writeStart > 0) {
+                    byte[] tmp = new byte[writeStart];
+                    System.arraycopy(dgramBuffer, 0, tmp, 0, tmp.length);
+                    transmit(ch, tmp, ip, port);
+                }
+
             }
 
             long endTime = System.currentTimeMillis();
 
             LOGGER.trace("Time Elapsed: {}", endTime - startTime);
+            LOGGER.trace("Elapsed Time minus predicted time: {}",
+                    (endTime - startTime) - tsDurationMillis);
 
             if (!ch.closeFuture()
                     .await(100)) {
@@ -212,6 +325,22 @@ public class MpegTsUdpClient {
             // Shut down the event loop to terminate all threads.
             eventLoopGroup.shutdownGracefully();
         }
+    }
+
+    private static int getPacketSize(Random rand, int minDatagramSize, int maxDatagramSize,
+            boolean fractionalTs) {
+        int datagramSize = rand.nextInt((maxDatagramSize - minDatagramSize) + 1) + minDatagramSize;
+        if (!fractionalTs) {
+            datagramSize = ((int) Math.floor(datagramSize / PACKET_SIZE)) * PACKET_SIZE;
+        }
+        return datagramSize;
+    }
+
+    private static void transmit(Channel ch, byte[] buf, String ip, int port)
+            throws InterruptedException {
+        ChannelFuture cf = ch.writeAndFlush(new DatagramPacket(Unpooled.copiedBuffer(buf),
+                new InetSocketAddress(ip, port)));
+        cf.await();
     }
 
     private static CommandLine getFFmpegInfoCommand(final String videoFilePath) {

--- a/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/VideoTest.java
+++ b/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/VideoTest.java
@@ -111,7 +111,10 @@ public class VideoTest extends AbstractAllianceIntegrationTest {
         MpegTsUdpClient.broadcastVideo(videoFilePath,
                 LOCALHOST,
                 udpPortNum,
-                NIGHTFLIGHT_DURATION_MS);
+                NIGHTFLIGHT_DURATION_MS,
+                MpegTsUdpClient.PACKET_SIZE,
+                MpegTsUdpClient.PACKET_SIZE,
+                false);
 
         expect("The parent and child metacards to be created").within(15, TimeUnit.SECONDS)
                 .checkEvery(1, TimeUnit.SECONDS)


### PR DESCRIPTION
#### What does this PR do?
Add thread locking around UDP buffer processing and improve exception logging when processing UDP packets.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@bdeining 
@jlcsmith 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire
#### How should this be tested?
Run within a window VM and stream with FFMPEG.
#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-173](https://codice.atlassian.net/browse/CAL-173)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

