### PR TITLE
CAL-189: JUnit tests for NITF metacard types to ensure correct attributes are present

### DIFF
--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/AbstractNitfMetacardType.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/AbstractNitfMetacardType.java
@@ -30,7 +30,7 @@ public abstract class AbstractNitfMetacardType extends MetacardTypeImpl {
 
     public abstract void initDescriptors();
 
-    protected Set<AttributeDescriptor> getDescriptors(NitfAttribute[] attributes) {
+    public static Set<AttributeDescriptor> getDescriptors(NitfAttribute[] attributes) {
         Set<AttributeDescriptor> descriptors = new HashSet<>();
         for (NitfAttribute attribute : attributes) {
             descriptors.addAll(attribute.getAttributeDescriptors());
@@ -38,7 +38,7 @@ public abstract class AbstractNitfMetacardType extends MetacardTypeImpl {
         return descriptors;
     }
 
-    protected <T> Set<AttributeDescriptor> getDescriptors(List<NitfAttribute<T>> attributes) {
+    public static <T> Set<AttributeDescriptor> getDescriptors(List<NitfAttribute<T>> attributes) {
         return getDescriptors(attributes.toArray(new NitfAttribute[attributes.size()]));
     }
 

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/gmti/GmtiMetacardTypeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/gmti/GmtiMetacardTypeTest.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.transformer.nitf.gmti;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+import java.util.Set;
+
+import org.codice.alliance.catalog.core.api.impl.types.IsrAttributes;
+import org.codice.alliance.catalog.core.api.impl.types.SecurityAttributes;
+import org.codice.alliance.transformer.nitf.AbstractNitfMetacardType;
+import org.codice.alliance.transformer.nitf.common.AcftbAttribute;
+import org.codice.alliance.transformer.nitf.common.CsdidaAttribute;
+import org.codice.alliance.transformer.nitf.common.CsexraAttribute;
+import org.codice.alliance.transformer.nitf.common.HistoaAttribute;
+import org.codice.alliance.transformer.nitf.common.NitfHeaderAttribute;
+import org.codice.alliance.transformer.nitf.common.PiaimcAttribute;
+import org.junit.Test;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.impl.types.AssociationsAttributes;
+import ddf.catalog.data.impl.types.ContactAttributes;
+import ddf.catalog.data.impl.types.CoreAttributes;
+import ddf.catalog.data.impl.types.DateTimeAttributes;
+import ddf.catalog.data.impl.types.LocationAttributes;
+import ddf.catalog.data.impl.types.MediaAttributes;
+import ddf.catalog.data.impl.types.ValidationAttributes;
+
+public class GmtiMetacardTypeTest {
+
+    @Test
+    public void testGmtiAttributes() {
+        GmtiMetacardType gmtiCardType = new GmtiMetacardType();
+        Set<AttributeDescriptor> descriptors =
+                AbstractNitfMetacardType.getDescriptors(NitfHeaderAttribute.getAttributes());
+        descriptors.addAll(AbstractNitfMetacardType.getDescriptors(AcftbAttribute.getAttributes()));
+        descriptors.addAll(AbstractNitfMetacardType.getDescriptors(IndexedMtirpbAttribute.getAttributes()));
+        descriptors.addAll(AbstractNitfMetacardType.getDescriptors(MtirpbAttribute.getAttributes()));
+        descriptors.addAll(new CoreAttributes().getAttributeDescriptors());
+        descriptors.addAll(new AssociationsAttributes().getAttributeDescriptors());
+        descriptors.addAll(new ContactAttributes().getAttributeDescriptors());
+        descriptors.addAll(new MediaAttributes().getAttributeDescriptors());
+        descriptors.addAll(new DateTimeAttributes().getAttributeDescriptors());
+        descriptors.addAll(new LocationAttributes().getAttributeDescriptors());
+        descriptors.addAll(new ValidationAttributes().getAttributeDescriptors());
+        descriptors.addAll(new IsrAttributes().getAttributeDescriptors());
+        descriptors.addAll(new SecurityAttributes().getAttributeDescriptors());
+        descriptors.addAll(AbstractNitfMetacardType.getDescriptors(PiaimcAttribute.getAttributes()));
+        descriptors.addAll(AbstractNitfMetacardType.getDescriptors(CsdidaAttribute.getAttributes()));
+        descriptors.addAll(AbstractNitfMetacardType.getDescriptors(CsexraAttribute.getAttributes()));
+        descriptors.addAll(AbstractNitfMetacardType.getDescriptors(HistoaAttribute.getAttributes()));
+        assertThat(gmtiCardType.getAttributeDescriptors(),
+                containsInAnyOrder(descriptors.toArray(new AttributeDescriptor[descriptors.size()])));
+    }
+}

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageMetacardTypeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageMetacardTypeTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.transformer.nitf.image;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+import java.util.Set;
+
+import org.codice.alliance.catalog.core.api.impl.types.IsrAttributes;
+import org.codice.alliance.catalog.core.api.impl.types.SecurityAttributes;
+import org.codice.alliance.transformer.nitf.AbstractNitfMetacardType;
+import org.codice.alliance.transformer.nitf.common.AcftbAttribute;
+import org.codice.alliance.transformer.nitf.common.AimidbAttribute;
+import org.codice.alliance.transformer.nitf.common.CsdidaAttribute;
+import org.codice.alliance.transformer.nitf.common.CsexraAttribute;
+import org.codice.alliance.transformer.nitf.common.HistoaAttribute;
+import org.codice.alliance.transformer.nitf.common.NitfHeaderAttribute;
+import org.codice.alliance.transformer.nitf.common.PiaimcAttribute;
+import org.codice.alliance.transformer.nitf.gmti.IndexedMtirpbAttribute;
+import org.codice.alliance.transformer.nitf.gmti.MtirpbAttribute;
+import org.junit.Test;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.impl.types.AssociationsAttributes;
+import ddf.catalog.data.impl.types.ContactAttributes;
+import ddf.catalog.data.impl.types.CoreAttributes;
+import ddf.catalog.data.impl.types.DateTimeAttributes;
+import ddf.catalog.data.impl.types.LocationAttributes;
+import ddf.catalog.data.impl.types.MediaAttributes;
+import ddf.catalog.data.impl.types.ValidationAttributes;
+
+public class ImageMetacardTypeTest {
+
+    @Test
+    public void testImageAttributes() {
+        ImageMetacardType imageCardType = new ImageMetacardType();
+        Set<AttributeDescriptor> descriptors =
+                AbstractNitfMetacardType.getDescriptors(GraphicAttribute.values());
+        descriptors.addAll(AbstractNitfMetacardType.getDescriptors(ImageAttribute.getAttributes()));
+        descriptors.addAll(AbstractNitfMetacardType.getDescriptors(LabelAttribute.values()));
+        descriptors.addAll(AbstractNitfMetacardType.getDescriptors(SymbolAttribute.values()));
+        descriptors.addAll(AbstractNitfMetacardType.getDescriptors(TextAttribute.values()));
+        descriptors.addAll(AbstractNitfMetacardType.getDescriptors(NitfHeaderAttribute.getAttributes()));
+        descriptors.addAll(AbstractNitfMetacardType.getDescriptors(AcftbAttribute.getAttributes()));
+        descriptors.addAll(AbstractNitfMetacardType.getDescriptors(AimidbAttribute.getAttributes()));
+        descriptors.addAll(AbstractNitfMetacardType.getDescriptors(IndexedMtirpbAttribute.getAttributes()));
+        descriptors.addAll(AbstractNitfMetacardType.getDescriptors(MtirpbAttribute.getAttributes()));
+        descriptors.addAll(new CoreAttributes().getAttributeDescriptors());
+        descriptors.addAll(new AssociationsAttributes().getAttributeDescriptors());
+        descriptors.addAll(new ContactAttributes().getAttributeDescriptors());
+        descriptors.addAll(new MediaAttributes().getAttributeDescriptors());
+        descriptors.addAll(new DateTimeAttributes().getAttributeDescriptors());
+        descriptors.addAll(new LocationAttributes().getAttributeDescriptors());
+        descriptors.addAll(new ValidationAttributes().getAttributeDescriptors());
+        descriptors.addAll(new IsrAttributes().getAttributeDescriptors());
+        descriptors.addAll(new SecurityAttributes().getAttributeDescriptors());
+        descriptors.addAll(AbstractNitfMetacardType.getDescriptors(HistoaAttribute.getAttributes()));
+        descriptors.addAll(AbstractNitfMetacardType.getDescriptors(PiaimcAttribute.getAttributes()));
+        descriptors.addAll(AbstractNitfMetacardType.getDescriptors(CsdidaAttribute.getAttributes()));
+        descriptors.addAll(AbstractNitfMetacardType.getDescriptors(CsexraAttribute.getAttributes()));
+        assertThat(imageCardType.getAttributeDescriptors(),
+                containsInAnyOrder(descriptors.toArray(new AttributeDescriptor[descriptors.size()])));
+    }
+}


### PR DESCRIPTION
#### What does this PR do?
Adds JUnit tests for ImageMetacardType and GmtiMetacardType to verify that they have the correct attributes present. 

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@glenhein 
@peterhuffer 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@lessarderic

#### How should this be tested?
Run build + JUnit tests

#### Any background context you want to provide?

#### What are the relevant tickets?
https://codice.atlassian.net/browse/CAL-189

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests