### PR TITLE
CAL-194: Upgrade frontend-maven-plugin from 0.0.28 to 1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -359,7 +359,7 @@
                 <plugin>
                     <groupId>com.github.eirslett</groupId>
                     <artifactId>frontend-maven-plugin</artifactId>
-                    <version>0.0.28</version>
+                    <version>1.2</version>
                     <executions>
                         <execution>
                             <id>install node and npm</id>


### PR DESCRIPTION
#### What does this PR do?
Upgraded the frontend-maven-plugin to version 1.2 (latest). This will also allow Windows to use parallel builds.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@emanns95 @Lambeaux 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@pklinef
@shaundmorris
#### How should this be tested?
#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-xxxx](https://codice.atlassian.net/browse/CAL-xxxx)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

Upgraded the frontend-maven-plugin to version 1.2 (latest). This will also allow Windows to use parallel builds.