### PR TITLE
CAL-195 Enable Chip Image action for remote NITF resources

### DIFF
--- a/catalog/imaging/imaging-actionprovider-chip/pom.xml
+++ b/catalog/imaging/imaging-actionprovider-chip/pom.xml
@@ -57,6 +57,16 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>${httpcore.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${httpclient.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.vividsolutions</groupId>
             <artifactId>jts</artifactId>
             <exclusions>
@@ -88,7 +98,7 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.90</minimum>
+                                            <minimum>0.89</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
@@ -137,7 +147,9 @@
                         <_wab>src/main/webapp,${project.build.directory}/webapp</_wab>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Embed-Dependency>
-                            commons-lang3
+                            commons-lang3,
+                            httpcore,
+                            httpclient
                         </Embed-Dependency>
                         <Export-Package />
                     </instructions>

--- a/catalog/imaging/imaging-actionprovider-chip/pom.xml
+++ b/catalog/imaging/imaging-actionprovider-chip/pom.xml
@@ -98,7 +98,7 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.89</minimum>
+                                            <minimum>0.90</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>

--- a/catalog/imaging/imaging-actionprovider-chip/src/main/java/org/codice/alliance/imaging/chip/actionprovider/ImagingChipActionProvider.java
+++ b/catalog/imaging/imaging-actionprovider-chip/src/main/java/org/codice/alliance/imaging/chip/actionprovider/ImagingChipActionProvider.java
@@ -17,6 +17,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -56,6 +57,8 @@ public class ImagingChipActionProvider implements MultiActionProvider {
     private static final String NITF_IMAGE_METACARD_TYPE = "isr.image";
 
     public static final String ORIGINAL_QUALIFIER = "original";
+
+    private static final String QUALIFIER_KEY = "qualifier";
 
     private GeometryFactory geometryFactory = new GeometryFactory();
 
@@ -156,9 +159,7 @@ public class ImagingChipActionProvider implements MultiActionProvider {
     }
 
     private String getQualifierForRemoteResource(String uriString) throws URISyntaxException {
-        final String QUALIFIER_KEY = "qualifier";
-
-        return URLEncodedUtils.parse(new URI(uriString), "UTF-8")
+        return URLEncodedUtils.parse(new URI(uriString), StandardCharsets.UTF_8.name())
                 .stream()
                 .filter(pair -> QUALIFIER_KEY.equals(pair.getName()))
                 .map(NameValuePair::getValue)

--- a/catalog/imaging/imaging-actionprovider-chip/src/test/java/org/codice/alliance/imaging/chip/actionprovider/ImageChipActionProviderTest.java
+++ b/catalog/imaging/imaging-actionprovider-chip/src/test/java/org/codice/alliance/imaging/chip/actionprovider/ImageChipActionProviderTest.java
@@ -97,6 +97,20 @@ public class ImageChipActionProviderTest {
     }
 
     @Test
+    public void testCanHandleOriginalDerivedResource() {
+        imageMetacard.setAttribute(new AttributeImpl(Core.DERIVED_RESOURCE_URI,
+                "https://example.com/download?transform=resource&qualifier=original"));
+        assertThat(imagingChipActionProvider.canHandle(imageMetacard), is(true));
+    }
+
+    @Test
+    public void testDoesNotHandleNonOverviewDerivedResource() {
+        imageMetacard.setAttribute(new AttributeImpl(Core.DERIVED_RESOURCE_URI,
+                "https://example.com/download?transform=resource&qualifier=notoriginal"));
+        assertThat(imagingChipActionProvider.canHandle(imageMetacard), is(false));
+    }
+
+    @Test
     public void testCanHandleImageryMetacard() {
         assertThat(imagingChipActionProvider.canHandle(imageMetacard), is(true));
     }

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,8 @@
         <gem-maven-plugin.version>1.0.5</gem-maven-plugin.version>
         <asciidoctorj-pdf.version>1.5.0-alpha.11</asciidoctorj-pdf.version>
         <asciidoctor.source.highlighter>coderay</asciidoctor.source.highlighter>
+        <httpcore.version>4.4.5</httpcore.version>
+        <httpclient.version>4.5.2</httpclient.version>
         <!-- output directory for reports -->
         <project.report.output.directory>project-info</project.report.output.directory>
         <joda-time.version>2.2</joda-time.version>


### PR DESCRIPTION
#### What does this PR do?
This PR adds custom checking on derived resource URI for remote resources, which are not formatted the same as local resources. Fixes issue where NITF actions list is missing `Chip Image` action only for remote NITFs, due to a logic error in `canHandle` for the action provider, when it is parsing the derived resource URI.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@bdeining @dcruver @glenhein 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl @jlcsmith 

#### How should this be tested?
 - Build and run Alliance.
 - Configure a CSW loopback source under `DDF Spatial` --> `CSW Specification Profile Federated Source` to mimic a remote source.
-- Add Source ID name
-- Change CSW URL to local: https://localhost:8993/services/csw
-- Change “Output Schema” to: urn:catalog:metacard
 - Ingest a NITF formatted file, then perform a search to find the ingested file.
 - Verify that the `Chip Image` action is available for the remote source.
_Note: remote image chipping does not work._

#### Any background context you want to provide?

#### What are the relevant tickets?
https://codice.atlassian.net/browse/CAL-195

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

