### PR TITLE
(0.1.x) CAL-191 Fixed sed block in video-admin-plugin

### DIFF
--- a/catalog/video/video-admin-plugin/Gruntfile.js
+++ b/catalog/video/video-admin-plugin/Gruntfile.js
@@ -28,8 +28,8 @@ module.exports = function (grunt) {
         sed: {
             imports: {
                 path: 'target/webapp/lib/bootswatch/flatly',
-                pattern: '@import url\\("//fonts.googleapis.com/css\\?family=Roboto:400,700"\\);',
-                replacement: '@import url("../../lato/css/lato.min.css");',
+                pattern: '@import url\\("//fonts.googleapis.com/css\\?family=Lato:400,700,400italic"\\);',
+                replacement: '',
                 recursive: true
             }
         },


### PR DESCRIPTION
#### What does this PR do?
This PR fixes the sed statement in the video admin plugin to prevent the browser from reaching out to google.apis
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@lcrosenbu @rzwiefel 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@pklinef
#### How should this be tested?
Build and install Alliance Experimental, navigate to the Video Admin Plugin and observe that it does not reach out to google.
#### Any background context you want to provide?
#### What are the relevant tickets?
[CAL-191](https://codice.atlassian.net/browse/CAL-191)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests