### PR TITLE
CAL-199 Changed mime type so jpg file extension is applied in a windows environment for image chips

### DIFF
--- a/catalog/imaging/imaging-transformer-chipping/src/main/java/org/codice/alliance/imaging/chip/transformer/CatalogOutputAdapter.java
+++ b/catalog/imaging/imaging-transformer-chipping/src/main/java/org/codice/alliance/imaging/chip/transformer/CatalogOutputAdapter.java
@@ -38,7 +38,7 @@ import ddf.catalog.transform.CatalogTransformerException;
  */
 public class CatalogOutputAdapter {
 
-    private static final String IMAGE_JPG = "image/jpg";
+    private static final String IMAGE_JPG = "image/jpeg";
 
     private static final String JPG = "jpg";
 


### PR DESCRIPTION
#### What does this PR do?
This PR fixes file extensions for image chips (jpeg) downloaded in windows.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@lcrosenbu @rzwiefel 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire
#### How should this be tested?
On windows : Build / Install / Ingest NITF / Download Chip and verify file extension
#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-199](https://codice.atlassian.net/browse/CAL-199)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests