### PR TITLE
CAL-201 Update VideographerClaimsHandler to only add claims for the VideographerPrincipal

### DIFF
--- a/catalog/video/video-security/src/main/java/org/codice/alliance/video/security/claims/videographer/VideographerClaimsHandler.java
+++ b/catalog/video/video-security/src/main/java/org/codice/alliance/video/security/claims/videographer/VideographerClaimsHandler.java
@@ -100,19 +100,21 @@ public class VideographerClaimsHandler implements ClaimsHandler, RealmSupport {
             ClaimsParameters parameters) {
         ProcessedClaimCollection claimsColl = new ProcessedClaimCollection();
         Principal principal = parameters.getPrincipal();
-        for (Claim claim : claims) {
-            URI claimType = claim.getClaimType();
-            List<String> value = claimsMap.get(claimType);
-            if (value != null) {
-                ProcessedClaim c = new ProcessedClaim();
-                c.setClaimType(claimType);
-                c.setPrincipal(principal);
-                value.forEach(c::addValue);
-                claimsColl.add(c);
-            }
-        }
 
         if (principal instanceof VideographerPrincipal) {
+
+            for (Claim claim : claims) {
+                URI claimType = claim.getClaimType();
+                List<String> value = claimsMap.get(claimType);
+                if (value != null) {
+                    ProcessedClaim c = new ProcessedClaim();
+                    c.setClaimType(claimType);
+                    c.setPrincipal(principal);
+                    value.forEach(c::addValue);
+                    claimsColl.add(c);
+                }
+            }
+
             String ipAddress = ((VideographerPrincipal) principal).getAddress();
             if (ipAddress != null) {
                 try {


### PR DESCRIPTION
#### What does this PR do?

Update VideographerClaimsHandler to only add claims for the VideographerPrincipal.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@kcwire 
@bdeining 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@lessarderic
#### How should this be tested?

1) Build Alliance
2) Enable security logging:

  log:set DEBUG ddf.security.service.impl

3) Complete install.
4) Look for the log line:

  Adding permission: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier : guest

An incorrect log line includes the videographer, eg:

 Adding permission: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier : videographer,guest

#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-201](https://codice.atlassian.net/browse/CAL-201)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
