### PR TITLE
[0.1.x]CAL-203: Adding profile for running dependency-check-maven (OWASP) plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -448,6 +448,56 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>owasp</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.owasp</groupId>
+                        <artifactId>dependency-check-maven</artifactId>
+                        <version>1.2.9</version>
+                        <configuration>
+                            <failBuildOnCVSS>7</failBuildOnCVSS>
+                            <format>ALL</format>
+                            <suppressionFile>dependency-check-maven-config.xml</suppressionFile>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <reporting>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-checkstyle-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.owasp</groupId>
+                        <artifactId>dependency-check-maven</artifactId>
+                        <version>1.2.9</version>
+                        <reportSets>
+                            <reportSet>
+                                <reports>
+                                    <report>aggregate</report>
+                                </reports>
+                            </reportSet>
+                        </reportSets>
+                    </plugin>
+                </plugins>
+            </reporting>
+        </profile>
     </profiles>
 
     <repositories>


### PR DESCRIPTION
#### What does this PR do?
Adds the profile that runs the OWASP plugin. This way, a nightly build can be created to run OWASP on alliance daily.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@figliold @Lambeaux 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic 
@shaundmorris 
#### How should this be tested?
Run 'mvn clean install -Powasp' and OWASP should fail on multiple dependencies because of vulnerabilities.
#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-203](https://codice.atlassian.net/browse/CAL-203)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests