### PR TITLE
CAL-207 Added mpg and mepg extensions to MPEG-TS Content Resolver

### DIFF
--- a/catalog/video/video-mpegts-transformer/src/main/resources/DDF_Custom_Mime_Type_Resolver.mpegts.config
+++ b/catalog/video/video-mpegts-transformer/src/main/resources/DDF_Custom_Mime_Type_Resolver.mpegts.config
@@ -1,4 +1,8 @@
-customMimeTypes=["ts\=video/mp2t"]
+customMimeTypes=[ \
+  "ts\=video/mp2t", \
+  "mpg\=video/mp2t", \
+  "mpeg\=video/mp2t", \
+  ]
 name="MPEG-TS\ Content\ Resolver"
 priority=I"10"
 service.factoryPid="DDF_Custom_Mime_Type_Resolver"


### PR DESCRIPTION
#### What does this PR do?
Maps .mpg and .mpeg to the video/mp2t mime type

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@bdeining @glenhein 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire 

#### How should this be tested?
1) Ingest .mpg and .mpeg files via the content directory monitor.  
2) Verify the resulting metacards have a metacard type of "isr:video".

#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-207](https://codice.atlassian.net/browse/CAL-207)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

