### PR TITLE
CAL-208 Set the datatype attribute to "Video" for MPEG-TS files.

### DIFF
--- a/catalog/video/video-mpegts-transformer/src/main/java/org/codice/alliance/transformer/video/MpegTsInputTransformer.java
+++ b/catalog/video/video-mpegts-transformer/src/main/java/org/codice/alliance/transformer/video/MpegTsInputTransformer.java
@@ -45,12 +45,15 @@ import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.data.types.Core;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.InputTransformer;
 
 public class MpegTsInputTransformer implements InputTransformer {
 
     public static final String CONTENT_TYPE = "video/mp2t";
+
+    public static final String DATA_TYPE = "Video";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MpegTsInputTransformer.class);
 
@@ -147,6 +150,8 @@ public class MpegTsInputTransformer implements InputTransformer {
             extractStanag4609Metadata(metacard, fileBackedOutputStream);
 
             extractMediaEncodings(metacard, fileBackedOutputStream);
+
+            metacard.setAttribute(Core.DATATYPE, DATA_TYPE);
 
             return metacard;
         }

--- a/catalog/video/video-mpegts-transformer/src/test/java/org/codice/alliance/transformer/video/MpegTsInputTransformerTest.java
+++ b/catalog/video/video-mpegts-transformer/src/test/java/org/codice/alliance/transformer/video/MpegTsInputTransformerTest.java
@@ -46,8 +46,10 @@ import org.slf4j.LoggerFactory;
 
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.data.impl.BasicTypes;
 import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.data.types.Core;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.InputTransformer;
 
@@ -118,6 +120,28 @@ public class MpegTsInputTransformerTest {
 
             assertThat(finalMetacard.getContentTypeName(), is(MpegTsInputTransformer.CONTENT_TYPE));
             assertThat(finalMetacard.getMetadata(), is("the metadata"));
+
+        }
+
+    }
+
+    @Test
+    public void testDataTypeField() throws Exception {
+
+        MpegTsInputTransformer t = new MpegTsInputTransformer(inputTransformer,
+                metacardTypes,
+                stanag4609Processor,
+                klvHandlerFactory,
+                defaultKlvHandler,
+                stanagParserFactory,
+                klvProcessor);
+
+        try (InputStream inputStream = new ByteArrayInputStream(new byte[] {})) {
+
+            Metacard finalMetacard = t.transform(inputStream);
+
+            assertThat(finalMetacard.getAttribute(Core.DATATYPE),
+                    is(new AttributeImpl(Core.DATATYPE, MpegTsInputTransformer.DATA_TYPE)));
 
         }
 


### PR DESCRIPTION
#### What does this PR do?

Set the datatype attribute to "Video" for MPEG-TS files.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@bdeining 
@jlcsmith 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@lessarderic
#### How should this be tested?

1) Build and install Alliance.
2) Upload an MPEG-TS file (.TS).
3) Confirm that the 'datatype' attribute it 'Video'.

![screen shot 2016-12-01 at 3 16 07 pm](https://cloud.githubusercontent.com/assets/17837152/20814976/297c2d86-b7d9-11e6-8636-bdde3357b3d4.png)

#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-208](https://codice.atlassian.net/browse/CAL-208)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

