### PR TITLE
CAL-211: Update NitfParserAdapter to only get headers when returning NitfSegmentsFlow.

### DIFF
--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/NitfParserAdapter.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/NitfParserAdapter.java
@@ -31,7 +31,7 @@ public class NitfParserAdapter {
         }
 
         return new NitfParserInputFlow().inputStream(inputStream)
-                .allData();
+                .headerOnly();
     }
 
     /**


### PR DESCRIPTION
#### What does this PR do?
Improves performance of the Nitf Storage by only getting headers of the NITF.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@dcruver @glenhein   

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire

#### How should this be tested?
Run the full build.
log:set DEBUG ddf.camel
Create a content directory monitor
Ingest a NITF. Verify the NITF ingests. Should see a metacard CREATED message in the logs.

#### Any background context you want to provide?
Previously this code was retrieving the full NITF data when only the header information was needed, causing un-necessary parsing overhead.

#### What are the relevant tickets?
https://codice.atlassian.net/browse/CAL-211

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
