### PR TITLE
CAL-216 Update imaging-nitf library dependency to version 0.6

### DIFF
--- a/catalog/imaging/pom.xml
+++ b/catalog/imaging/pom.xml
@@ -28,7 +28,7 @@
     <name>Alliance :: Imaging</name>
 
     <properties>
-        <nitf-imaging.version>0.5</nitf-imaging.version>
+        <nitf-imaging.version>0.6</nitf-imaging.version>
         <camel.version>2.16.1</camel.version>
         <jai-imageio-core.version>1.3.1</jai-imageio-core.version>
         <jpeg2000.version>1.3.1_CODICE_1</jpeg2000.version>


### PR DESCRIPTION
#### What does this PR do?
Updated dependency version number in catalog/imaging/pom.xml.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@glenhein 
@peterhuffer 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@jlcsmith
@kcwire

#### How should this be tested?
1) build the alliance imaging app
2) load alliance imaging app into a running DDF instance
3) upload some known-good test NITFs
  --verify the test NITFs are ingested as they were with imaging-nitf 0.5

#### Any background context you want to provide?
No API changes, only bug fixes and TRE parsing improvements.

#### What are the relevant tickets?
CAL-216 (https://codice.atlassian.net/browse/CAL-216)

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
