### PR TITLE
CAL-220 Fixed the creation of an empty content metacard when FMV streams are destroyed

### DIFF
--- a/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/netty/PacketBuffer.java
+++ b/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/netty/PacketBuffer.java
@@ -281,6 +281,10 @@ public class PacketBuffer {
         });
     }
 
+    private void flushAllData() throws IOException {
+        flushFrameset(frames.size() - 1);
+    }
+
     /**
      * @param index the index of the last frame of the last frameset
      * @throws IOException
@@ -368,7 +372,11 @@ public class PacketBuffer {
             }
 
             if (!frames.isEmpty()) {
-                flushFrameset(frames.size() - 1);
+                flushAllData();
+            }
+
+            if (bytesWrittenToTempFile == 0) {
+                return Optional.empty();
             }
 
             return rotate(ALWAYS_TRUE);


### PR DESCRIPTION
#### What does this PR do?
This PR prevents the creation of a child metacard with an empty temp file.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@glenhein @rzwiefel 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@kcwire
#### How should this be tested?
Build / Install Experimental / `log:set DEBUG org.codice.alliance` / Add video stream / Stream Video / Destroy Stream and observe correct behavior / Verify ingested video contents
#### Any background context you want to provide?
#### What are the relevant tickets?
[CAL-220](https://codice.atlassian.net/browse/CAL-220)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
