### PR TITLE
CAL-70 Removed Alliance from app names

### DIFF
--- a/catalog/imaging/imaging-app/src/main/resources/features.xml
+++ b/catalog/imaging/imaging-app/src/main/resources/features.xml
@@ -17,7 +17,7 @@
           xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
 
     <feature name="imaging-app" install="auto" version="${project.version}"
-             description="The Alliance Imaging Application provides support for ingesting and searching for NITF products.  ::Alliance Imaging">
+             description="The Imaging Application provides support for ingesting and searching for NITF products.::Imaging">
         <feature prerequisite="true">catalog-app</feature>
         <bundle dependency="true">mvn:org.codice.alliance.catalog.core/catalog-core-api/${project.version}</bundle>
         <bundle>mvn:org.codice.alliance.imaging/imaging-service-api/${project.version}</bundle>

--- a/catalog/nsili/nsili-app/src/main/resources/features.xml
+++ b/catalog/nsili/nsili-app/src/main/resources/features.xml
@@ -52,7 +52,7 @@
     </feature>
 
     <feature name="nsili-app" install="auto" version="${project.version}"
-             description="The Alliance NSILI App provides interoperability with STANAG 4559 compliant services. ::Alliance NSILI">
+             description="The NSILI App provides interoperability with STANAG 4559 compliant services.::NSILI">
         <feature prerequisite="true">catalog-app</feature>
         <bundle dependency="true">mvn:org.apache.commons/commons-lang3/${commons-lang3.version}</bundle>
         <feature>catalog-email</feature>

--- a/catalog/security/security-app/src/main/resources/features.xml
+++ b/catalog/security/security-app/src/main/resources/features.xml
@@ -33,7 +33,7 @@
     </feature>
 
     <feature name="security-app" install="auto" version="${project.version}"
-             description="The Alliance Security App provides features to enhance security. ::Alliance Security">
+             description="The IC Security App provides features to enhance security.::IC Security">
         <feature prerequisite="true">catalog-app</feature>
     </feature>
 

--- a/catalog/video/video-app/src/main/resources/features.xml
+++ b/catalog/video/video-app/src/main/resources/features.xml
@@ -38,7 +38,7 @@
     </feature>
 
     <feature name="video-app" install="auto" version="${project.version}"
-             description="The Alliance Video Application provides support for ingesting and searching for MPEG-TS products. :: Alliance Video">
+             description="The Video Application provides support for ingesting and searching for MPEG-TS products.::Video">
         <feature prerequisite="true">catalog-app</feature>
         <feature prerequisite="true">catalog-core-validator</feature>
         <feature prerequisite="true">catalog-core-validationparser</feature>

--- a/pom.xml
+++ b/pom.xml
@@ -90,17 +90,17 @@
         <variable-prefix>${</variable-prefix>
         <image-width>500</image-width>
         <!-- Individual application names -->
-        <ddf-admin>DDF Admin</ddf-admin>
-        <ddf-catalog>DDF Catalog</ddf-catalog>
-        <ddf-geowebcache>DDF GeoWebCache</ddf-geowebcache>
-        <ddf-platform>DDF Platform</ddf-platform>
-        <ddf-security>DDF Security</ddf-security>
-        <ddf-solr>DDF Solr</ddf-solr>
-        <ddf-spatial>DDF Spatial</ddf-spatial>
-        <ddf-ui>DDF Search UI</ddf-ui>
-        <alliance-imaging>Alliance Imaging</alliance-imaging>
-        <alliance-nsili>Alliance NSILI</alliance-nsili>
-        <alliance-video>Alliance Video</alliance-video>
+        <ddf-admin>Admin</ddf-admin>
+        <ddf-catalog>Catalog</ddf-catalog>
+        <ddf-geowebcache>GeoWebCache</ddf-geowebcache>
+        <ddf-platform>Platform</ddf-platform>
+        <ddf-security>Security</ddf-security>
+        <ddf-solr>Solr</ddf-solr>
+        <ddf-spatial>Spatial</ddf-spatial>
+        <ddf-ui>Search UI</ddf-ui>
+        <alliance-imaging>Imaging</alliance-imaging>
+        <alliance-nsili>NSILI</alliance-nsili>
+        <alliance-video>Video</alliance-video>
         <commons-configuration.version>1.10</commons-configuration.version>
         <javax-mail.version>1.4.4</javax-mail.version>
         <powermock.version>1.6.6</powermock.version>


### PR DESCRIPTION
#### What does this PR do?
Removes Alliance from app names. The Alliance Security app was not changed due to a collision with (DDF) Security.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@bdeining @clockard @gordocanchola @vinamartin @brianfelix @vinamartin @peterhuffer 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jlcsmith
@michaelmenousek
@shaundmorris 

#### How should this be tested?
Install DDF/Alliance and observe the app names in the admin ui.

#### Any background context you want to provide?
#### What are the relevant tickets?
[CAL-70](https://codice.atlassian.net/browse/CAL-70)

#### Screenshots (if appropriate)
![screen shot 2017-01-05 at 3 04 22 pm](https://cloud.githubusercontent.com/assets/11355332/21699390/bba981dc-d358-11e6-9781-fb0e3c38a478.png)

#### Checklist:
- [x] Documentation Updated
	- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
