### PR TITLE
CAL-215 Adds security audit plugin

### DIFF
--- a/catalog/plugin/catalog-plugin-security-audit/pom.xml
+++ b/catalog/plugin/catalog-plugin-security-audit/pom.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>plugin</artifactId>
+        <groupId>org.codice.alliance.catalog.plugin</groupId>
+        <version>0.2-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>bundle</packaging>
+
+    <properties>
+        <powermock.agent>
+            ${settings.localRepository}/org/powermock/powermock-module-javaagent/${powermock.version}/powermock-module-javaagent-${powermock.version}.jar
+        </powermock.agent>
+    </properties>
+
+
+    <name>Alliance :: Catalog :: Plugin :: Security Audit</name>
+    <artifactId>catalog-plugin-security-audit</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>ddf.security.core</groupId>
+            <artifactId>security-core-api</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <version>1.6.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+            <version>${ddf.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4-rule-agent</artifactId>
+            <version>1.6.6</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>${argLine} -javaagent:${powermock.agent} -Djava.awt.headless=true
+                        -noverify
+                    </argLine>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.85</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.76</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.36</minimum>
+                                        </limit>
+
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/catalog/plugin/catalog-plugin-security-audit/src/main/java/org/codice/alliance/catalog/plugin/security/audit/SecurityAuditPlugin.java
+++ b/catalog/plugin/catalog-plugin-security-audit/src/main/java/org/codice/alliance/catalog/plugin/security/audit/SecurityAuditPlugin.java
@@ -1,0 +1,183 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.alliance.catalog.plugin.security.audit;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import ddf.catalog.Constants;
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.operation.CreateRequest;
+import ddf.catalog.operation.DeleteRequest;
+import ddf.catalog.operation.DeleteResponse;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.QueryResponse;
+import ddf.catalog.operation.Request;
+import ddf.catalog.operation.ResourceRequest;
+import ddf.catalog.operation.ResourceResponse;
+import ddf.catalog.operation.UpdateRequest;
+import ddf.catalog.plugin.AccessPlugin;
+import ddf.catalog.plugin.StopProcessingException;
+import ddf.security.common.audit.SecurityLogger;
+
+/**
+ * SecurityAuditPlugin
+ * Allows changes to security attributes on a metacard to be audited
+ */
+public class SecurityAuditPlugin implements AccessPlugin {
+
+    private List<String> auditAttributes = new ArrayList<>();
+
+    @Override
+    public CreateRequest processPreCreate(CreateRequest createRequest)
+            throws StopProcessingException {
+        return createRequest;
+    }
+
+    @Override
+    public UpdateRequest processPreUpdate(UpdateRequest updateRequest,
+            Map<String, Metacard> existingMetacards) throws StopProcessingException {
+        if (updateRequest == null || !isLocal(updateRequest)
+                || MapUtils.isEmpty(existingMetacards)) {
+            return updateRequest;
+        }
+        for (Map.Entry<Serializable, Metacard> entry : updateRequest.getUpdates()) {
+            Metacard updateMetacard = entry.getValue();
+            Metacard existingMetacard = existingMetacards.get(entry.getKey()
+                    .toString());
+            Set<AttributeDescriptor> attributeDescriptors = updateMetacard.getMetacardType()
+                    .getAttributeDescriptors();
+
+            for (AttributeDescriptor descriptor : attributeDescriptors) {
+                String descriptorName = descriptor.getName();
+                if (auditAttributes.contains(descriptorName)) {
+                    if (hasAttributeValueChanged(existingMetacard.getAttribute(descriptorName),
+                            updateMetacard.getAttribute(descriptorName))) {
+                        String originalValue = getNonNullAttributeValues(existingMetacard,
+                                descriptorName);
+                        String updateValue = getNonNullAttributeValues(updateMetacard,
+                                descriptorName);
+                        SecurityLogger.audit(String.format(
+                                "Attribute %s on metacard %s with value(s) %s was updated to value(s) %s",
+                                descriptorName,
+                                updateMetacard.getId(),
+                                originalValue,
+                                updateValue));
+                    }
+                }
+            }
+        }
+
+        return updateRequest;
+    }
+
+    private boolean hasAttributeValueChanged(Attribute oldAttribute, Attribute newAttribute) {
+        if (oldAttribute == null && (newAttribute != null)) {
+            //The attribute was added and is not null
+            return true;
+        } else if (oldAttribute == null || CollectionUtils.isEmpty(oldAttribute.getValues())) {
+            //The old attribute is null
+            return false;
+        } else if (newAttribute == null || CollectionUtils.isEmpty(newAttribute.getValues())) {
+            //The attribute has been removed
+            return true;
+        }
+        //The attribute exists in both metacards, check their equality
+        return !CollectionUtils.isEqualCollection(oldAttribute.getValues(),
+                newAttribute.getValues());
+    }
+
+    private String getNonNullAttributeValues(Metacard metacard, String descriptorName) {
+        String value;
+        if (metacard.getAttribute(descriptorName) == null || metacard.getAttribute(descriptorName)
+                .getValues() == null) {
+            value = "[NO VALUE]";
+        } else {
+            value = StringUtils.join(metacard.getAttribute(descriptorName)
+                    .getValues(), ",");
+        }
+
+        return value;
+    }
+
+    @Override
+    public DeleteRequest processPreDelete(DeleteRequest deleteRequest)
+            throws StopProcessingException {
+        return deleteRequest;
+    }
+
+    @Override
+    public DeleteResponse processPostDelete(DeleteResponse deleteResponse)
+            throws StopProcessingException {
+        return deleteResponse;
+    }
+
+    @Override
+    public QueryRequest processPreQuery(QueryRequest queryRequest) throws StopProcessingException {
+        return queryRequest;
+    }
+
+    @Override
+    public QueryResponse processPostQuery(QueryResponse queryResponse)
+            throws StopProcessingException {
+        return queryResponse;
+    }
+
+    @Override
+    public ResourceRequest processPreResource(ResourceRequest resourceRequest)
+            throws StopProcessingException {
+        return resourceRequest;
+    }
+
+    @Override
+    public ResourceResponse processPostResource(ResourceResponse resourceResponse,
+            Metacard metacard) throws StopProcessingException {
+        return resourceResponse;
+    }
+
+    public void setAuditAttributes(List<String> auditAttributes) {
+        SecurityLogger.audit(String.format(
+                "Security Audit Plugin configuration changed to audit : %s",
+                StringUtils.join(auditAttributes, ",")));
+        this.auditAttributes = auditAttributes;
+    }
+
+    public void init() {
+        SecurityLogger.audit("Security Audit Plugin started");
+    }
+
+    public void destroy() {
+        SecurityLogger.audit("Security Audit Plugin stopped");
+    }
+
+    public static boolean isLocal(Request req) {
+        return req == null || !req.hasProperties() || isLocal(req.getProperties());
+    }
+
+    public static boolean isLocal(Map<String, Serializable> props) {
+        return props == null || props.get(Constants.LOCAL_DESTINATION_KEY) == null
+                || (boolean) props.get(Constants.LOCAL_DESTINATION_KEY);
+    }
+
+}

--- a/catalog/plugin/catalog-plugin-security-audit/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/plugin/catalog-plugin-security-audit/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<blueprint xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+           xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+
+    <bean id="securityAuditPlugin"
+          class="org.codice.alliance.catalog.plugin.security.audit.SecurityAuditPlugin"
+          init-method="init"
+          destroy-method="destroy">
+        <cm:managed-properties
+                persistent-id="org.codice.alliance.catalog.plugin.security.audit.SecurityAuditPlugin"
+                update-strategy="container-managed"/>
+        <property name="auditAttributes">
+            <list>
+                <value>security.access-groups</value>
+                <value>security.access-individuals</value>
+                <value>security.classification</value>
+                <value>security.classification-system</value>
+                <value>security.codewords</value>
+                <value>security.dissemination-controls</value>
+                <value>security.other-dissemination-controls</value>
+                <value>security.owner-producer</value>
+                <value>security.releasability</value>
+                <value>ext.metadata-originator-classification</value>
+                <value>ext.metadata-classification</value>
+                <value>ext.metadata-classification-system</value>
+                <value>ext.metadata-dissemination-controls</value>
+                <value>ext.metadata-releasability</value>
+                <value>ext.resource-originator-classification</value>
+                <value>ext.resource-classification</value>
+                <value>ext.resource-classification-system</value>
+                <value>ext.resource-releasability</value>
+                <value>ext.resource-dissemination-controls</value>
+            </list>
+        </property>
+    </bean>
+
+    <service ref="securityAuditPlugin" interface="ddf.catalog.plugin.AccessPlugin"/>
+
+</blueprint>

--- a/catalog/plugin/catalog-plugin-security-audit/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/plugin/catalog-plugin-security-audit/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
+
+    <OCD name="Security Audit Plugin"
+         id="org.codice.alliance.catalog.plugin.security.audit.SecurityAuditPlugin"
+         description="Plugin to audit security attribute changes">
+        <AD name="Security attributes to audit" id="auditAttributes"
+            required="true"
+            type="String"
+            cardinality="1000"
+            description="List of security attributes to audit when modified"
+            default="security.access-groups,security.access-individuals,security.classification,security.classification-system,security.codewords,security.dissemination-controls,security.other-dissemination-controls,security.owner-producer,security.releasability,ext.metadata-originator-classification,ext.metadata-classification,ext.metadata-classification-system,ext.metadata-dissemination-controls,ext.metadata-releasability,ext.resource-originator-classification,ext.resource-classification,ext.resource-classification-system,ext.resource-releasability,ext.resource-dissemination-controls">
+        </AD>
+    </OCD>
+
+    <Designate pid="org.codice.alliance.catalog.plugin.security.audit.SecurityAuditPlugin">
+        <Object ocdref="org.codice.alliance.catalog.plugin.security.audit.SecurityAuditPlugin"/>
+    </Designate>
+
+
+</metatype:MetaData>

--- a/catalog/plugin/catalog-plugin-security-audit/src/test/java/org/codice/alliance/catalog/plugin/security/audit/SecurityAuditPluginTest.java
+++ b/catalog/plugin/catalog-plugin-security-audit/src/test/java/org/codice/alliance/catalog/plugin/security/audit/SecurityAuditPluginTest.java
@@ -1,0 +1,311 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.alliance.catalog.plugin.security.audit;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import java.io.Serializable;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.rule.PowerMockRule;
+
+import ddf.catalog.Constants;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.operation.impl.UpdateRequestImpl;
+import ddf.catalog.plugin.StopProcessingException;
+import ddf.security.common.audit.SecurityLogger;
+
+@PrepareForTest({SecurityLogger.class})
+public class SecurityAuditPluginTest {
+
+    @Rule
+    public PowerMockRule rule = new PowerMockRule();
+
+    private SecurityAuditPlugin securityAuditPlugin;
+
+    private String metacardKey = "metacardKey";
+
+    private String auditMessageFormat =
+            "Attribute %s on metacard %s with value(s) %s was updated to value(s) %s";
+
+    @Before
+    public void setup() {
+        List<String> auditAttributes = new ArrayList<>();
+        auditAttributes.add(Metacard.TITLE);
+        securityAuditPlugin = new SecurityAuditPlugin();
+        securityAuditPlugin.setAuditAttributes(auditAttributes);
+    }
+
+    @Test
+    public void testChangedAttributeInAuditConfigIsAudited() throws StopProcessingException {
+        PowerMockito.mockStatic(SecurityLogger.class);
+
+        MetacardImpl existingMetacard = new MetacardImpl();
+        MetacardImpl updateMetacard = new MetacardImpl();
+
+        existingMetacard.setAttribute(Metacard.TITLE, "A");
+        updateMetacard.setAttribute(Metacard.TITLE, "1");
+        existingMetacard.setAttribute(Metacard.ID, "test");
+        updateMetacard.setAttribute(Metacard.ID, "test");
+
+        List<Map.Entry<Serializable, Metacard>> updateMetacards = new ArrayList<>();
+        updateMetacards.add(new AbstractMap.SimpleEntry<Serializable, Metacard>(metacardKey,
+                updateMetacard));
+
+        Map<String, Metacard> existingMetacards = new HashMap<>();
+        existingMetacards.put(metacardKey, existingMetacard);
+
+        UpdateRequestImpl updateRequest = new UpdateRequestImpl(updateMetacards,
+                Metacard.TITLE,
+                null);
+        securityAuditPlugin.processPreUpdate(updateRequest, existingMetacards);
+
+        PowerMockito.verifyStatic(times(1));
+        SecurityLogger.audit(String.format(auditMessageFormat, Metacard.TITLE, "test", "A", "1"));
+    }
+
+    @Test
+    public void testUnchangedAttributeInAuditConfigIsNotAudited() throws StopProcessingException {
+        PowerMockito.mockStatic(SecurityLogger.class);
+
+        MetacardImpl existingMetacard = new MetacardImpl();
+        MetacardImpl updateMetacard = new MetacardImpl();
+
+        existingMetacard.setAttribute(Metacard.TITLE, "B");
+        updateMetacard.setAttribute(Metacard.TITLE, "B");
+        existingMetacard.setAttribute(Metacard.ID, "test");
+        updateMetacard.setAttribute(Metacard.ID, "test");
+
+        List<Map.Entry<Serializable, Metacard>> updateMetacards = new ArrayList<>();
+        updateMetacards.add(new AbstractMap.SimpleEntry<Serializable, Metacard>(metacardKey,
+                updateMetacard));
+
+        Map<String, Metacard> existingMetacards = new HashMap<>();
+        existingMetacards.put(metacardKey, existingMetacard);
+
+        UpdateRequestImpl updateRequest = new UpdateRequestImpl(updateMetacards,
+                Metacard.TITLE,
+                null);
+        securityAuditPlugin.processPreUpdate(updateRequest, existingMetacards);
+
+        PowerMockito.verifyStatic(never());
+        SecurityLogger.audit(String.format(auditMessageFormat, Metacard.TITLE, "test", "B", "B"));
+    }
+
+    @Test
+    public void testChangedAttributeNotInAuditConfigIsNotAudited() throws StopProcessingException {
+        PowerMockito.mockStatic(SecurityLogger.class);
+
+        MetacardImpl existingMetacard = new MetacardImpl();
+        MetacardImpl updateMetacard = new MetacardImpl();
+
+        existingMetacard.setAttribute(Metacard.METADATA, "A test string");
+        updateMetacard.setAttribute(Metacard.METADATA, "A different test string");
+        existingMetacard.setAttribute(Metacard.ID, "test");
+        updateMetacard.setAttribute(Metacard.ID, "test");
+
+        List<Map.Entry<Serializable, Metacard>> updateMetacards = new ArrayList<>();
+        updateMetacards.add(new AbstractMap.SimpleEntry<Serializable, Metacard>(metacardKey,
+                updateMetacard));
+
+        Map<String, Metacard> existingMetacards = new HashMap<>();
+        existingMetacards.put(metacardKey, existingMetacard);
+
+        UpdateRequestImpl updateRequest = new UpdateRequestImpl(updateMetacards,
+                Metacard.METADATA,
+                null);
+        securityAuditPlugin.processPreUpdate(updateRequest, existingMetacards);
+
+        PowerMockito.verifyStatic(never());
+        SecurityLogger.audit(String.format(auditMessageFormat,
+                Metacard.METADATA,
+                "test",
+                "A test string",
+                "A different test string"));
+    }
+
+    @Test
+    public void testUnchangedAttributeNotInAuditConfigIsNotAudited()
+            throws StopProcessingException {
+        PowerMockito.mockStatic(SecurityLogger.class);
+
+        MetacardImpl existingMetacard = new MetacardImpl();
+        MetacardImpl updateMetacard = new MetacardImpl();
+
+        existingMetacard.setAttribute(Metacard.METADATA, "A test string");
+        updateMetacard.setAttribute(Metacard.METADATA, "A test string");
+        existingMetacard.setAttribute(Metacard.ID, "test");
+        updateMetacard.setAttribute(Metacard.ID, "test");
+
+        List<Map.Entry<Serializable, Metacard>> updateMetacards = new ArrayList<>();
+        updateMetacards.add(new AbstractMap.SimpleEntry<Serializable, Metacard>(metacardKey,
+                updateMetacard));
+
+        Map<String, Metacard> existingMetacards = new HashMap<>();
+        existingMetacards.put(metacardKey, existingMetacard);
+
+        UpdateRequestImpl updateRequest = new UpdateRequestImpl(updateMetacards,
+                Metacard.METADATA,
+                null);
+        securityAuditPlugin.processPreUpdate(updateRequest, existingMetacards);
+
+        PowerMockito.verifyStatic(never());
+        SecurityLogger.audit(String.format(auditMessageFormat,
+                Metacard.METADATA,
+                "test",
+                "A test string",
+                "A test string"));
+    }
+
+    @Test
+    public void testDeletedAttributeInAuditConfigIsAudited() throws StopProcessingException {
+        PowerMockito.mockStatic(SecurityLogger.class);
+
+        MetacardImpl existingMetacard = new MetacardImpl();
+        MetacardImpl updateMetacard = new MetacardImpl();
+
+        existingMetacard.setAttribute(Metacard.TITLE, "A test string");
+        existingMetacard.setAttribute(Metacard.ID, "test");
+        updateMetacard.setAttribute(Metacard.ID, "test");
+
+        List<Map.Entry<Serializable, Metacard>> updateMetacards = new ArrayList<>();
+        updateMetacards.add(new AbstractMap.SimpleEntry<Serializable, Metacard>(metacardKey,
+                updateMetacard));
+
+        Map<String, Metacard> existingMetacards = new HashMap<>();
+        existingMetacards.put(metacardKey, existingMetacard);
+
+        UpdateRequestImpl updateRequest = new UpdateRequestImpl(updateMetacards,
+                Metacard.TITLE,
+                null);
+        securityAuditPlugin.processPreUpdate(updateRequest, existingMetacards);
+
+        PowerMockito.verifyStatic(times(1));
+        SecurityLogger.audit(String.format(auditMessageFormat,
+                Metacard.TITLE,
+                "test",
+                "A test string",
+                "[NO VALUE]"));
+    }
+
+    @Test
+    public void testAddedAttributeInAuditConfigIsAudited() throws StopProcessingException {
+        PowerMockito.mockStatic(SecurityLogger.class);
+
+        MetacardImpl existingMetacard = new MetacardImpl();
+        MetacardImpl updateMetacard = new MetacardImpl();
+
+        updateMetacard.setAttribute(Metacard.TITLE, "A test string");
+        existingMetacard.setAttribute(Metacard.ID, "test");
+        updateMetacard.setAttribute(Metacard.ID, "test");
+
+        List<Map.Entry<Serializable, Metacard>> updateMetacards = new ArrayList<>();
+        updateMetacards.add(new AbstractMap.SimpleEntry<Serializable, Metacard>(metacardKey,
+                updateMetacard));
+
+        Map<String, Metacard> existingMetacards = new HashMap<>();
+        existingMetacards.put(metacardKey, existingMetacard);
+
+        UpdateRequestImpl updateRequest = new UpdateRequestImpl(updateMetacards,
+                Metacard.TITLE,
+                null);
+        securityAuditPlugin.processPreUpdate(updateRequest, existingMetacards);
+
+        PowerMockito.verifyStatic(times(1));
+        SecurityLogger.audit(String.format(auditMessageFormat,
+                Metacard.TITLE,
+                "test",
+                "[NO VALUE]",
+                "A test string"));
+    }
+
+    @Test
+    public void testNullAttributeInAuditConfigIsNotAudited() throws StopProcessingException {
+        PowerMockito.mockStatic(SecurityLogger.class);
+
+        MetacardImpl existingMetacard = new MetacardImpl();
+        MetacardImpl updateMetacard = new MetacardImpl();
+
+        existingMetacard.setAttribute(Metacard.ID, "test");
+        updateMetacard.setAttribute(Metacard.ID, "test");
+
+        List<Map.Entry<Serializable, Metacard>> updateMetacards = new ArrayList<>();
+        updateMetacards.add(new AbstractMap.SimpleEntry<Serializable, Metacard>(metacardKey,
+                updateMetacard));
+
+        Map<String, Metacard> existingMetacards = new HashMap<>();
+        existingMetacards.put(metacardKey, existingMetacard);
+
+        UpdateRequestImpl updateRequest = new UpdateRequestImpl(updateMetacards,
+                Metacard.TITLE,
+                null);
+        securityAuditPlugin.processPreUpdate(updateRequest, existingMetacards);
+
+        PowerMockito.verifyStatic(never());
+        SecurityLogger.audit(anyString());
+    }
+
+    @Test
+    public void testNullupdateRequest() throws StopProcessingException {
+        PowerMockito.mockStatic(SecurityLogger.class);
+
+        securityAuditPlugin.processPreUpdate(null, null);
+
+        PowerMockito.verifyStatic(never());
+        SecurityLogger.audit(anyString());
+    }
+
+    @Test
+    public void testNotLocalRequest() throws StopProcessingException {
+        PowerMockito.mockStatic(SecurityLogger.class);
+
+        MetacardImpl existingMetacard = new MetacardImpl();
+        MetacardImpl updateMetacard = new MetacardImpl();
+
+        existingMetacard.setAttribute(Metacard.ID, "test");
+        updateMetacard.setAttribute(Metacard.ID, "test");
+
+        List<Map.Entry<Serializable, Metacard>> updateMetacards = new ArrayList<>();
+        updateMetacards.add(new AbstractMap.SimpleEntry<Serializable, Metacard>(metacardKey,
+                updateMetacard));
+
+        Map<String, Metacard> existingMetacards = new HashMap<>();
+        existingMetacards.put(metacardKey, existingMetacard);
+
+        Map<String, Serializable> props = new HashMap<>();
+        props.put(Constants.LOCAL_DESTINATION_KEY, false);
+
+        UpdateRequestImpl updateRequest = new UpdateRequestImpl(updateMetacards,
+                Metacard.TITLE,
+                props);
+
+        securityAuditPlugin.processPreUpdate(updateRequest, existingMetacards);
+
+        PowerMockito.verifyStatic(never());
+        SecurityLogger.audit(anyString());
+    }
+}

--- a/catalog/plugin/pom.xml
+++ b/catalog/plugin/pom.xml
@@ -26,6 +26,7 @@
 
     <modules>
         <module>catalog-plugin-defaultsecurityattributevalues</module>
+        <module>catalog-plugin-security-audit</module>
     </modules>
 
 </project>

--- a/catalog/security/security-app/pom.xml
+++ b/catalog/security/security-app/pom.xml
@@ -12,21 +12,19 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>org.codice.alliance.security</groupId>
         <artifactId>security</artifactId>
         <version>0.2-SNAPSHOT</version>
     </parent>
-
     <artifactId>security-app</artifactId>
     <packaging>pom</packaging>
     <name>Alliance :: Security :: App</name>
-
     <dependencies>
         <dependency>
             <groupId>org.codice.alliance.catalog.core</groupId>
@@ -53,8 +51,12 @@
             <artifactId>catalog-core-classification-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.codice.alliance.catalog.plugin</groupId>
+            <artifactId>catalog-plugin-security-audit</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>

--- a/catalog/security/security-app/src/main/resources/features.xml
+++ b/catalog/security/security-app/src/main/resources/features.xml
@@ -31,6 +31,12 @@
         <feature prerequisite="true">alliance-catalog-core-api</feature>
         <bundle>mvn:org.codice.alliance.catalog.plugin/catalog-plugin-defaultsecurityattributevalues/${project.version}</bundle>
     </feature>
+    
+    <feature name="catalog-plugin-security-audit" install="auto" version="${project.version}"
+             description="Plugin to audit security changes on metacards.">
+        <feature prerequisite="true">alliance-catalog-core-api</feature>
+        <bundle>mvn:org.codice.alliance.catalog.plugin/catalog-plugin-security-audit/${project.version}</bundle>
+    </feature>
 
     <feature name="security-app" install="auto" version="${project.version}"
              description="The IC Security App provides features to enhance security.::IC Security">

--- a/distribution/docs/src/main/resources/_contents/_plugins/security-audit-plugin-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_plugins/security-audit-plugin-contents.adoc
@@ -1,0 +1,20 @@
+==== Security Audit Plugin
+
+The Security Audit Plugin is used to allow the auditing of specific metacard attributes.
+Any time a metacard attribute listed in the configuration is updated, a log will be generated in the security log.
+
+===== Installing the Security Audit Plugin
+
+The Security Audit Plugin is installed by default with a standard installation in the ${alliance-security} application.
+
+===== Configuring the Catalog Backup Plugin
+
+To configure the Catalog Backup Plugin:
+
+. Navigate to the *${admin-console}*.
+. Select *${alliance-security}* application.
+. Select *Configuration* tab.
+. Select *Security Audit Plugin*.
+
+Add the desired metacard attributes that will be audited when modified.
+

--- a/distribution/docs/src/main/resources/draft-documentation.adoc
+++ b/distribution/docs/src/main/resources/draft-documentation.adoc
@@ -577,6 +577,8 @@ include::{adoc-include}/_plugins/access-plugin-intro-contents.adoc[]
 include::{adoc-include}/_plugins/access-plugins-contents.adoc[]
 
 include::{adoc-include}/_plugins/operation-plugin-contents.adoc[]
+
+include::{adoc-include-cal}/_plugins/security-audit-plugin-contents.adoc[]
 //developing
 include::{adoc-include}/_plugins/developing-plugins-contents.adoc[]
 

--- a/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/SecurityAuditPluginTest.java
+++ b/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/SecurityAuditPluginTest.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.test.itests;
+
+import static org.codice.ddf.itests.common.catalog.CatalogTestCommons.deleteMetacard;
+import static org.codice.ddf.itests.common.catalog.CatalogTestCommons.ingest;
+import static org.codice.ddf.itests.common.catalog.CatalogTestCommons.update;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.io.IOUtils;
+import org.codice.alliance.test.itests.common.AbstractAllianceIntegrationTest;
+import org.codice.ddf.itests.common.WaitCondition;
+import org.codice.ddf.itests.common.annotations.BeforeExam;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.osgi.service.cm.Configuration;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public class SecurityAuditPluginTest extends AbstractAllianceIntegrationTest {
+    private static final String[] REQUIRED_APPS = {"catalog-app", "solr-app", "security-app"};
+
+    private String auditMessageFormat =
+            "Attribute %s on metacard %s with value(s) %s was updated to value(s) %s";
+
+    private String configUpdateMessage =
+            "Security Audit Plugin configuration changed to audit : description";
+
+    private String startedMessage = "Security Audit Plugin started";
+
+    private String stoppedMessage = "Security Audit Plugin stopped";
+
+    @BeforeExam
+    public void beforeExam() throws Exception {
+        basePort = getBasePort();
+        getAdminConfig().setLogLevels();
+
+        getServiceManager().waitForRequiredApps(REQUIRED_APPS);
+        getServiceManager().waitForAllBundles();
+        getCatalogBundle().waitForCatalogProvider();
+
+    }
+
+    @Test
+    public void testSecurityAuditPlugin() throws Exception {
+        Configuration config = configAdmin.getConfiguration(
+                "org.codice.alliance.catalog.plugin.security.audit.SecurityAuditPlugin",
+                null);
+        List attributes = new ArrayList<>();
+        attributes.add("description");
+        Dictionary properties = new Hashtable<>();
+        properties.put("auditAttributes", attributes);
+        config.update(properties);
+
+        String logFilePath = System.getProperty("karaf.data") + "/log/security.log";
+
+        WaitCondition.expect("Security log has log message: " + configUpdateMessage)
+                .within(2, TimeUnit.MINUTES)
+                .checkEvery(2, TimeUnit.SECONDS)
+                .until(() -> getFileFromAbsolutePath(logFilePath).contains(configUpdateMessage));
+
+        String id = ingest(getResourceAsString("metacard1.xml"), "text/xml");
+
+        update(id, getResourceAsString("metacard2.xml"), "text/xml");
+
+        String expectedLogMessage = String.format(auditMessageFormat,
+                "description",
+                id,
+                "My Description",
+                "My Description (Updated)");
+        WaitCondition.expect("Securitylog has log message: " + expectedLogMessage)
+                .within(2, TimeUnit.MINUTES)
+                .checkEvery(2, TimeUnit.SECONDS)
+                .until(() -> getFileFromAbsolutePath(logFilePath).contains(expectedLogMessage));
+
+        deleteMetacard(id);
+    }
+
+    @Test
+    public void testFeatureStartAndStop() throws Exception {
+        String logFilePath = System.getProperty("karaf.data") + "/log/security.log";
+        getServiceManager().stopFeature(true, "catalog-plugin-security-audit");
+        WaitCondition.expect("Securitylog has log message: " + stoppedMessage)
+                .within(2, TimeUnit.MINUTES)
+                .checkEvery(2, TimeUnit.SECONDS)
+                .until(() -> getFileFromAbsolutePath(logFilePath).contains(stoppedMessage));
+
+        getServiceManager().startFeature(true, "catalog-plugin-security-audit");
+        WaitCondition.expect("Securitylog has log message: " + startedMessage)
+                .within(2, TimeUnit.MINUTES)
+                .checkEvery(2, TimeUnit.SECONDS)
+                .until(() -> getFileFromAbsolutePath(logFilePath).contains(startedMessage));
+    }
+
+    private String getResourceAsString(String resourcePath) throws IOException {
+        InputStream inputStream = getClass().getClassLoader()
+                .getResourceAsStream(resourcePath);
+        return IOUtils.toString(inputStream);
+    }
+
+    private String getFileFromAbsolutePath(String filePath) throws IOException {
+        InputStream inputStream = new FileInputStream(new File(filePath));
+        return IOUtils.toString(inputStream);
+    }
+}

--- a/distribution/test/itests/test-itests-alliance/src/test/resources/metacard1.xml
+++ b/distribution/test/itests/test-itests-alliance/src/test/resources/metacard1.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<metacard xmlns="urn:catalog:metacard" xmlns:ns2="http://www.opengis.net/gml"
+          xmlns:ns3="http://www.w3.org/1999/xlink" xmlns:ns4="http://www.w3.org/2001/SMIL20/"
+          xmlns:ns5="http://www.w3.org/2001/SMIL20/Language">
+    <type>metacard</type>
+    <source>alliance</source>
+    <string name="metadata-content-type-version">
+        <value>myVersion</value>
+    </string>
+    <string name="title">
+        <value>Metacard-1</value>
+    </string>
+    <string name="description">
+        <value>My Description</value>
+    </string>
+    <geometry name="location">
+        <value>
+            <ns2:Point>
+                <ns2:pos>-74.0452177 40.6898329</ns2:pos>
+            </ns2:Point>
+        </value>
+    </geometry>
+    <dateTime name="created">
+        <value>2013-04-18T10:50:27.371-07:00</value>
+    </dateTime>
+    <dateTime name="modified">
+        <value>2013-04-18T10:50:27.371-07:00</value>
+    </dateTime>
+    <base64Binary name="thumbnail">
+        <value>/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAALAAgDASIAAhEBAxEB/8QAFgABAQEAAAAAAAAAAAAAAAAAAAUH/8QAJBAAAAQFAwUAAAAAAAAAAAAAABETFAEDBBIVAgUGISJRYZP/xAAVAQEBAAAAAAAAAAAAAAAAAAADBf/EABkRAAMAAwAAAAAAAAAAAAAAAAABAwISIv/aAAwDAQACEQMRAD8A3fRvVTHmTS+RjkUfbolC+fUBDhR0zXMN5WUyibqyClrhMj8WdoAtynSGLfJ//9k=</value>
+    </base64Binary>
+    <string name="metadata">
+        <value>&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;
+            &lt;Resource&gt;
+            &lt;name&gt;Lady Liberty&lt;/name&gt;
+            &lt;/Resource&gt;
+        </value>
+    </string>
+    <string name="metadata-content-type">
+        <value>myType</value>
+    </string>
+    <string name="resource-uri">
+        <value>" + uri + "</value>
+    </string>
+</metacard>

--- a/distribution/test/itests/test-itests-alliance/src/test/resources/metacard2.xml
+++ b/distribution/test/itests/test-itests-alliance/src/test/resources/metacard2.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- /**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/ -->
+<metacard xmlns="urn:catalog:metacard" xmlns:ns2="http://www.opengis.net/gml"
+>
+    <type>metacard</type>
+    <source>alliance</source>
+    <string name="metadata-content-type-version">
+        <value>myVersion</value>
+    </string>
+    <string name="title">
+        <value>Metacard-1</value>
+    </string>
+    <string name="description">
+        <value>My Description (Updated)</value>
+    </string>
+    <geometry name="location">
+        <value>
+            <ns2:Point>
+                <ns2:pos>-74.0452177 40.6898329</ns2:pos>
+            </ns2:Point>
+        </value>
+    </geometry>
+    <dateTime name="created">
+        <value>2013-04-18T10:50:27.371-07:00</value>
+    </dateTime>
+    <dateTime name="modified">
+        <value>2013-04-18T10:50:27.371-07:00</value>
+    </dateTime>
+    <base64Binary name="thumbnail">
+        <value>
+            /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAALAAgDASIAAhEBAxEB/8QAFgABAQEAAAAAAAAAAAAAAAAAAAUH/8QAJBAAAAQFAwUAAAAAAAAAAAAAABETFAEDBBIVAgUGISJRYZP/xAAVAQEBAAAAAAAAAAAAAAAAAAADBf/EABkRAAMAAwAAAAAAAAAAAAAAAAABAwISIv/aAAwDAQACEQMRAD8A3fRvVTHmTS+RjkUfbolC+fUBDhR0zXMN5WUyibqyClrhMj8WdoAtynSGLfJ//9k=
+        </value>
+    </base64Binary>
+    <string name="metadata">
+        <value>&lt;?xml version="1.0" encoding="UTF-8" standalone="yes"?&gt;
+            &lt;Resource&gt;
+            &lt;name&gt;Lady Liberty&lt;/name&gt;
+            &lt;/Resource&gt;
+        </value>
+    </string>
+    <string name="metadata-content-type">
+        <value>myType</value>
+    </string>
+    <string name="resource-uri">
+        <value>" + uri + "</value>
+    </string>
+</metacard>

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
         <alliance-imaging>Imaging</alliance-imaging>
         <alliance-nsili>NSILI</alliance-nsili>
         <alliance-video>Video</alliance-video>
+        <alliance-security>IC Security</alliance-security>
         <commons-configuration.version>1.10</commons-configuration.version>
         <javax-mail.version>1.4.4</javax-mail.version>
         <powermock.version>1.6.6</powermock.version>


### PR DESCRIPTION
#### What does this PR do?
Adds a security audit plugin with a configuration for security attributes that should be audited when changed.

Looking for feedback on the audit message, specifically, whether or not it should say something else and in addition if there seems there is anything missing from the configuration file. 

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@codice/security 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic 
@stustison

#### How should this be tested?
Ingest anything into the catalog and then change a security attribute (this is easier with the Catalog UI in DDF). Verify the change was audited. 

#### What are the relevant tickets?
[CAL-215](https://codice.atlassian.net/browse/CAL-215)
#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
