### PR TITLE
CAL-232 reordered Using section in documentation

### DIFF
--- a/distribution/docs/src/main/resources/draft-documentation.adoc
+++ b/distribution/docs/src/main/resources/draft-documentation.adoc
@@ -178,6 +178,10 @@ include::{adoc-include}/_using/using-intro-contents.adoc[]
 
 include::{adoc-include}/_using/using-landing-page-contents.adoc[]
 
+== Using the Catalog Search
+
+include::{adoc-include}/_using/using-catalog-search-ui-contents.adoc[]
+
 == Using the Simple Search
 
 include::{adoc-include}/_using/using-simple-search-ui-contents.adoc[]
@@ -185,10 +189,6 @@ include::{adoc-include}/_using/using-simple-search-ui-contents.adoc[]
 == Using the Standard Search
 
 include::${project.build.directory}/doc-contents/ui-help/standard-${ddf.version}/help-contents.adoc[]
-
-== Using the Catalog Search
-
-include::{adoc-include}/_using/using-catalog-search-ui-contents.adoc[]
 
 '''
 


### PR DESCRIPTION
#### What does this PR do?

Reorders the "Using" sections for UIs to match the DDF doc outline and prioritize Catalog UI as the default. 

#### Who is reviewing it?

@lcrosenbu @emmberk @vinamartin @mcalcote @jrnorth @Lambeaux 

#### Choose 2 committers to review/merge the PR.

@jlcsmith
@kcwire
@pklinef
@shaundmorris

#### How should this be tested?

builds successfully. 

#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-232](https://codice.atlassian.net/browse/CAL-232)
[DDF-2651](https://codice.atlassian.net/browse/DDF-2651)

#### Screenshots (if appropriate)

n/a

#### Checklist:
- [x] Documentation Updated
	- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
