### PR TITLE
CAL-224 added docs for neutral taxonomy

### DIFF
--- a/distribution/docs/src/main/resources/_contents/_data/extended-attributes-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_data/extended-attributes-table-contents.adoc
@@ -1,0 +1,72 @@
+
+.[[_extended_attributes_table]]Extended Attributes:
+Attributes in this group relate to intelligence, search, and reconnaissance.
+[cols="1,2,1,1,1" options="header"]
+|===
+|Term
+|Definition
+|Datatype
+|Constraints
+|Example Value
+
+|ext.metadata-originator-classification
+|Attribute name for accessing the metadata originator classification.
+|String
+|
+|
+
+|ext.metadata-classification
+|Attribute name for accessing the metadata classification.
+|String
+|
+|
+
+|ext.metadata-classification-system
+|Attribute name for accessing the security classification system for the metadata.
+|String
+|
+|
+
+|ext.metadata-dissemination-controls
+|Attribute name for accessing the metadata dissemination controls.
+|String
+|
+|
+
+|ext.metadata-releasability
+|Attribute name for accessing the metadata releasability.
+|String
+|
+|
+
+|ext.resource-releasability
+|Attribute name for accessing the resource releasability.
+|String
+|
+|
+
+|ext.resource-originator-classification
+|Attribute name for accessing the resource originator classification.
+|String
+|
+|
+
+|ext.resource-dissemination-controls
+|Attribute name for accessing the resource dissemination controls.
+|String
+|
+|
+
+|ext.resource-classification-system
+|Attribute name for accessing the security classification system for the resource.
+|String
+|
+|
+
+|ext.resource-classification
+|Attribute name for accessing the resource classification.
+|String
+|
+|
+
+|===

--- a/distribution/docs/src/main/resources/_contents/_data/isr-attributes-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_data/isr-attributes-table-contents.adoc
@@ -1,0 +1,344 @@
+
+.[[_isr_attributes_table]]ISR: Attributes in this group relate to intelligence, search, and reconnaissance.
+[cols="1,2,1,1,1" options="header"]
+|===
+|Term
+|Definition
+|Datatype
+|Constraints
+|Example Value
+
+|isr.frequency-hertz
+|A frequency observation, typically of radio waves.
+|Float
+|normalized to Hz
+|
+
+|isr.target-id
+|A target identifier.
+|String
+|< 1024 characters
+|
+
+|isr.target-category-code
+|A STANAG 3596 target category.
+|String
+|One of the values enumerated in STANAG 3596
+|
+
+|isr.platform-id
+|A platform identifier.
+|String
+|< 1024 characters
+|
+
+|isr.original-source
+|A STANAG 4545 ISOURCE.
+|String
+|ISOURCE per STANAG 4545
+|
+
+|isr.organizational-unit
+|An organizational unit.
+|String
+|< 1024 characters
+|
+
+|isr.niirs
+|The quality or detail level of an image. (National Imagery Interpretability Rating Scale)
+|Integer
+|1-9
+|
+
+|isr.nato-reporting-code
+|A reporting code as defined in STANAG 4545.
+|String
+|One of the values in STANAG 4545
+|
+
+|isr.mission-id
+|A mission identifier.
+|String
+|< 1024 characters
+|
+
+|isr.sensor-type
+|A STANAG 4545 sensor type.
+|STANAG 4545 ACFTB TRE
+|String
+|
+
+|isr.sensor-id
+|A STANAG 4545 sensor identifier.
+|String
+|STANAG 4545 ACFTB TRE
+|
+
+|isr.cloud-cover
+|An imagery cloud cover percentage.
+|Integer
+|0-100
+|
+
+|isr.category
+|A STANAG 4559 image or video category.
+|String
+|
+|
+
+|isr.image-id
+|An ISR imagery identifier.
+|
+|
+|
+
+|isr.comments
+|An ISR comment.
+|
+|
+|
+
+|isr.jc3iedm-id
+|A command and control interoperability identifier.
+|
+|
+|
+
+|isr.platform-name
+|An ISR platform name.
+|
+|
+|
+
+|isr.exploitation-level
+|The degree of exploitation performed on the original data. A value of '0' means that the product is not exploited.
+|Integer
+|0..9
+|
+
+|isr.exploitation-auto-generated
+|A flag indicating if the exploitation was automatically generated
+|Boolean
+|
+|
+
+|isr.exploitation-subjective-quality-code
+|A subjective ISR quality code.
+|String
+|EXCELLENT, FAIR, GOOD, POOR
+|
+
+|isr.vmti-processed
+|Whether or not the video has been processed for moving target indicators.
+|Boolean
+|
+|
+
+|isr.report-serial-number
+|Based on the originators request serial number STANAG 3277
+|String
+|< 1024 characters
+|
+
+|isr.report-type
+|The type of the report.
+|String
+|IQREP, ISRSPOTREP, MIEXREP, MTIEXREP, RECCEXREP, WLEXREP, PENTAGRAM, INTREP, INTSUM, HUMINTREP
+|
+
+|isr.report-info-rating
+|The info rating of the report.
+|String
+|< 1024 characters
+|
+
+|isr.report-priority
+|The priority of the report.
+|String
+|ROUTINE, PRIORITY, IMMEDIATE, FLASH
+|
+
+|isr.report-situation-type
+|The intel situation type.
+|String
+|GENERAL, MILITARY, LAND, MARITIME, AIR, SPACE, CI/SECURITY, OTHER
+|
+
+
+|isr.report-entity-type
+|The type of the entity in the report.
+|String
+|PLACE, EVENT, BIOGRAPHICS, ORGANISATION, EQUIPMENT
+|
+
+|isr.report-entity-name
+|The name of the entity in the report.
+|String
+|< 1024 characters
+|
+
+|isr.report-entity-alias
+|The alias of the entity in the report.
+|String
+|< 1024 characters
+|
+
+|isr.rfi-for-action
+|A nation, command, agency, organization or unit requested to provide a response. (STANAG 4559, STANAG 2149 edition 6)
+|String
+|<= 50 characters
+|
+
+|isr.rfi-for-information
+|A multi-valued attribute identifying nations, commands, agencies, organizations and units which may have an interest in the response. (STANAG 4559, STANAG 2149 (edition 6))
+|String
+|<= 200 characters
+|
+
+|isr.rfi-serial-number
+|An attribute for a unique human readable string identifying the RFI instance.
+|String
+|<= 30 characters
+|
+
+|isr.rfi-status
+|An attribute identifying the status of the RFI.
+|String
+|APPROVED, INACTION, STOPPED, FULFILLED
+|
+
+|isr.rfi-workflow-status
+|An attribute identifying the workflow status of the RFI.
+|String
+|NEW, ACCEPTED, DENIED, CANCELLED, COMPLETED
+|
+
+|isr.task-comments
+|An attribute identifying comments related to the task.
+|String
+|<= 255 characters
+|
+
+|isr.task-status
+|An attribute identifying the status of the task.
+|String
+|PLANNED, ACKNOWLEDGED, ONGOING, ACCOMPLISHED, INTERRUPTED, INFEASIBLE, CANCELLED
+|
+
+|isr.task-id
+|An attribute for the task identifier.
+|String
+|
+|
+
+|isr.cbrn-operation-name
+|The Chemical, Biological, Radiological & Nuclear (CBRN) Exercise Identification or Operation Code Word.
+|String
+|<= 56 characters
+|
+
+|isr.cbrn-incident-number
+|The Chemical, Biological, Radiological & Nuclear (CBRN) Incident Number typically based on the concatenation of ALFA1, ALFA2, ALFA3, and ALFA4. The concatenation format is : ALPHA1 + space + ALPHA2 + space + ALPHA3 + space + ALPHA4.
+|String
+|<= 26 characters
+|'CA 938JTF 231 C' where :
+
+ALPHA1='CA'
+
+ALPHA2='938JTF'
+
+ALPHA3='231'
+
+ALPHA4='C'
+
+|isr.cbrn-type
+|Type of Chemical, Biological, Radiological & Nuclear (CBRN) event enumeration description.
+|String
+|CHEMICAL, BIOLOGICAL, RADIOLOGICAL, NUCLEAR, NOT KNOWN
+|
+
+|isr.cbrn-category
+|The Chemical, Biological, Radiological & Nuclear (CBRN) report type or plot type.
+|String
+|<= 100 characters
+|
+
+|isr.cbrn-substance
+|Description of Chemical, Biological, Radiological & Nuclear (CBRN) substance.
+|String
+|<= 7 characters
+|
+
+|isr.cbrn-alarm-classification
+|Classification of a Chemical, Biological, Radiological & Nuclear (CBRN) sensor alarm
+|String
+|ABOVE THRESHOLD, BELOW THRESHOLD
+|
+
+|isr.tdl-activity
+|A number that together with the platform number defines the identity of a track.
+|Short
+| 0 .. 127
+|
+
+|isr.tdl-message-number
+|The Link 16 J Series message number.
+|String
+|J2.2, J2.3, J2.5, J3.0, J3.2, J3.3, J3.5, J3.7, J7.0, J7.1, J7.2, J7.3, J14.0, J14.2
+|
+
+|isr.tdl-track-number
+|Link 16 J Series track number for the track found in the product. The track number shall be in the decoded 5-character format (e.g. EK627).
+|String
+|<= 10 characters
+|
+
+|isr.video-mism-level
+|The "Motion Imagery Systems (Spatial and Temporal) Matrix" (MISM) defines an ENGINEERING GUIDELINE for the simple identification of broad categories of Motion Imagery Systems. The intent of the MISM is to give user communities an easy to use, common shorthand reference language to describe the fundamental technical capabilities of NATO motion imagery systems.
+|Integer
+|0 - 12
+|
+
+|isr.dwell-location
+|The geospatial location of the dwell area.
+|Geometry
+|
+|
+
+|isr.target-report-count
+|The count of the target reports in the dwell.
+|Integer
+|
+|
+
+|isr.mti-job-id
+|A platform assigned number identifying the specific request or task to which thee dwell pertains.
+|Long
+|
+|
+
+|isr.tdl-platform-number
+|A number that together with the 'activity' number defines the identity of a track
+|Short
+|0 .. 63
+|
+
+|isr.snow-cover
+|The existence of snow. TRUE if snow is present, FALSE otherwise.
+|Boolean
+|
+|
+
+|isr.snow-depth-min-centimeters
+|The minimum depth of snow measured in centimeters.
+|Integer
+|
+|
+
+|isr.snow-depth-max-centimeters
+|The maximum depth of snow measured in centimeters.
+|Integer
+|
+|
+
+|===

--- a/distribution/docs/src/main/resources/_contents/_data/neutral-taxonomy-categories-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_data/neutral-taxonomy-categories-contents.adoc
@@ -1,0 +1,5 @@
+
+<<_isr_attributes_table,ISR Attributes>>:: Intelligence, search, and reconnaissance attributes.
+<<_additional_security_attributes_table,Additional Security Attributes>>:: Security of the resource and metadata.
+<<_extended_attributes_table,Extended Attributes>>:: Intelligence, search, and reconnaissance attributes.
+

--- a/distribution/docs/src/main/resources/_contents/_data/security-attributes-table-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_data/security-attributes-table-contents.adoc
@@ -1,0 +1,53 @@
+
+.[[_additional_security_attributes_table]]Additional Securtity Attributes: Attributes in this group relate to security of the resource and metadata.
+[cols="1,2,1,1,1" options="header"]
+|===
+|Term
+|Definition
+|Datatype
+|Constraints
+|Example Value
+
+|security.classification
+|The overall classification of the metadata and resource.
+|String
+|
+|
+
+|security.releasability
+|Identifies the country, countries, or organizations to which classified information may be released.
+|String
+|ISO_3166-1 alpha-3 codes or country/organization tetragraphs per CAPCO Register Annex A.
+|
+
+|security.classification-system
+|This attribute indicates the national or multinational security system used to classify the resource and its metadata.
+|String
+|ISO_3166-1 alpha-3 codes
+|
+
+|security.owner-producer
+|Attribute identifying the national government or international organization owner(s) and/or producer(s) of the information.
+|String
+|ISO_3166-1 alpha-3 codes
+|
+
+|security.dissemination-controls
+|This attribute is used to identify the expansion or limitation on the distribution of the information.
+|String
+|
+|
+
+|security.codewords
+|This attribute provide further restrictions to the information based on controlled markings.
+|String
+|
+|
+
+|security.other-dissemination-controls
+|This attribute is used to identify the expansion or limitation on the distribution of the information outside of its organization or community.
+|String
+|
+|
+
+|===

--- a/distribution/docs/src/main/resources/draft-documentation.adoc
+++ b/distribution/docs/src/main/resources/draft-documentation.adoc
@@ -210,6 +210,40 @@ include::{adoc-include}/_validation/validation-intro-contents.adoc[]
 
 include::{adoc-include}/_validation/schematron-intro-contents.adoc[]
 
+=== Neutral Taxonomy
+
+include::{adoc-include}/_data/neutral-taxonomy-intro-contents.adoc[]
+
+include::{adoc-include}/_data/neutral-taxonomy-categories-contents.adoc[]
+include::{adoc-include-cal}/_data/neutral-taxonomy-categories-contents.adoc[]
+
+include::{adoc-include}/_data/core-attributes-table-contents.adoc[]
+
+include::{adoc-include}/_data/metacard-attributes-table-contents.adoc[]
+
+include::{adoc-include}/_data/history-attributes-table-contents.adoc[]
+
+include::{adoc-include}/_data/associations-attributes-table-contents.adoc[]
+
+include::{adoc-include}/_data/datetime-attributes-table-contents.adoc[]
+
+include::{adoc-include}/_data/contact-attributes-table-contents.adoc[]
+
+include::{adoc-include}/_data/location-attributes-table-contents.adoc[]
+
+include::{adoc-include}/_data/media-attributes-table-contents.adoc[]
+
+include::{adoc-include}/_data/security-attributes-table-contents.adoc[]
+
+include::{adoc-include-cal}/_data/security-attributes-table-contents.adoc[]
+
+include::{adoc-include}/_data/topic-attributes-table-contents.adoc[]
+
+include::{adoc-include}/_data/validation-attributes-table-contents.adoc[]
+
+include::{adoc-include-cal}/_data/isr-attributes-table-contents.adoc[]
+include::{adoc-include-cal}/_data/extended-attributes-table-contents.adoc[]
+
 == Endpoints
 
 include::{adoc-include}/_endpoints/endpoints-intro-contents.adoc[]


### PR DESCRIPTION
#### What does this PR do?

adds documentation for neutral taxonomy to `draft-documentation`

#### Who is reviewing it?

@brendan-hofmann @emanns95 @AzGoalie
#### Choose 2 committers to review/merge the PR.

@jlcsmith
@kcwire
@pklinef
@shaundmorris

#### How should this be tested?

- review content of tables
- builds successfully.

#### What are the relevant tickets?

[CAL-224](https://codice.atlassian.net/browse/CAL-224)
[DDF-2682](https://codice.atlassian.net/browse/DDF-2682)

#### Screenshots (if appropriate)

[draft-documentation.pdf](https://github.com/codice/alliance/files/712000/draft-documentation.pdf)

#### Checklist:
- [x] Documentation Updated
	- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
