### PR TITLE
CAL-234: Default security attributes get set on metacards if they contain no highwater security markings, regardless of policy

### DIFF
--- a/catalog/plugin/catalog-plugin-defaultsecurityattributevalues/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/plugin/catalog-plugin-defaultsecurityattributevalues/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -15,21 +15,30 @@
 <blueprint xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
            xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 
-    <bean id="securityAttributes" class="org.codice.alliance.catalog.core.api.impl.types.SecurityAttributes"/>
+    <bean id="securityAttributes"
+          class="org.codice.alliance.catalog.core.api.impl.types.SecurityAttributes"/>
 
     <bean id="defaultMarkingsPlugin"
           class="org.codice.alliance.catalog.plugin.defaultsecurity.DefaultSecurityAttributeValuesPlugin">
-        <cm:managed-properties persistent-id="org.codice.alliance.catalog.plugin.defaultsecurity.DefaultSecurityAttributeValuesPlugin"
-                               update-strategy="container-managed"/>
+        <cm:managed-properties
+                persistent-id="org.codice.alliance.catalog.plugin.defaultsecurity.DefaultSecurityAttributeValuesPlugin"
+                update-strategy="component-managed" update-method="update"/>
         <argument ref="securityAttributes"/>
-        <property name="classification" value="classification"/>
-        <property name="releasability" value="CountryOfAffiliation"/>
-        <property name="codewords" value="FineAccessControls"/>
-        <property name="disseminationControls" value="disseminationControls"/>
-        <property name="otherDisseminationControls" value="otherDisseminationControls"/>
-        <property name="ownerProducer" value="ownerProducer" />
+        <argument>
+            <map>
+                <entry key="classification" value="classification"/>
+                <entry key="releasability" value="CountryOfAffiliation"/>
+                <entry key="codewords" value="FineAccessControls"/>
+                <entry key="disseminationControls" value="disseminationControls"/>
+                <entry key="otherDisseminationControls" value="otherDisseminationControls"/>
+                <entry key="ownerProducer" value="ownerProducer"/>
+            </map>
+        </argument>
     </bean>
 
-    <service ranking="99" ref="defaultMarkingsPlugin" interface="ddf.catalog.plugin.PreIngestPlugin"/>
+    <!-- Service ranking is here to ensure plugin gets run last during processing -->
+    <!-- See: https://github.com/codice/alliance/pull/235#discussion_r97089202 -->
+    <service ranking="99" ref="defaultMarkingsPlugin"
+             interface="ddf.catalog.plugin.PreIngestPlugin"/>
 
 </blueprint>


### PR DESCRIPTION
#### What does this PR do?
Updates the `DefaultSecurityAttributeValuesPlugin` to no longer skip setting defaults when metacards have a non-empty policy. This change was needed due to the introduction of the `ResourceUriPolicy` plugin. 

#### Who is reviewing it?
@shaundmorris 
@brendan-hofmann 
@ryeats 

#### Choose 2 committers to review/merge the PR.
@kcwire 
@stustison

#### How should this be tested?
Ingest a variety of test data, of different formats, and ensure that everything receives security attributes where appropriate. The attributes should render in the UI when inspecting a metacard. 

#### What are the relevant tickets?
[CAL-234](https://codice.atlassian.net/browse/CAL-234)

#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
