### PR TITLE
CAL-235 Populated metacard effective attribute with date and time of first image in NITF

### DIFF
--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/NitfHeaderAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/NitfHeaderAttribute.java
@@ -240,12 +240,6 @@ public class NitfHeaderAttribute extends NitfAttributeImpl<NitfHeader> {
             NitfHeader::getComplexityLevel,
             BasicTypes.INTEGER_TYPE);
 
-    public static final NitfHeaderAttribute FILE_DATE_AND_TIME_ATTRIBUTE  = new NitfHeaderAttribute(
-            FILE_DATE_AND_TIME,
-            "FDT",
-            header -> convertNitfDate(header.getFileDateTime()),
-            BasicTypes.DATE_TYPE);
-
     public static final NitfHeaderAttribute STANDARD_TYPE_ATTRIBUTE  = new NitfHeaderAttribute(
             STANDARD_TYPE,
             "STYPE",

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/ImageAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/ImageAttribute.java
@@ -36,7 +36,6 @@ import org.slf4j.LoggerFactory;
 import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.AttributeType;
 import ddf.catalog.data.impl.BasicTypes;
-import ddf.catalog.data.impl.types.DateTimeAttributes;
 import ddf.catalog.data.impl.types.MediaAttributes;
 import ddf.catalog.data.types.Media;
 
@@ -159,13 +158,6 @@ public class ImageAttribute extends NitfAttributeImpl<ImageSegment> {
      * appropriate
      */
 
-    public static final ImageAttribute IMAGE_DATE_AND_TIME_ATTRIBUTE =
-            new ImageAttribute(ddf.catalog.data.types.DateTime.START,
-                    "IDATIM",
-                    segment -> convertNitfDate(segment.getImageDateTime()),
-                    new DateTimeAttributes().getAttributeDescriptor(ddf.catalog.data.types.DateTime.START),
-                    IMAGE_DATE_AND_TIME);
-
     public static final ImageAttribute IMAGE_IDENTIFIER_2_ATTRIBUTE =
             new ImageAttribute(Isr.IMAGE_ID,
                     "IID2",
@@ -225,6 +217,12 @@ public class ImageAttribute extends NitfAttributeImpl<ImageSegment> {
     /*
      * Non normalized attributes
      */
+
+    public static final ImageAttribute IMAGE_DATE_AND_TIME_ATTRIBUTE = new ImageAttribute(
+            IMAGE_DATE_AND_TIME,
+            "IDATIM",
+            segment -> convertNitfDate(segment.getImageDateTime()),
+            BasicTypes.DATE_TYPE);
 
     public static final ImageAttribute IMAGE_IDENTIFIER_1_ATTRIBUTE = new ImageAttribute(
             IMAGE_IDENTIFIER_1,
@@ -512,7 +510,7 @@ public class ImageAttribute extends NitfAttributeImpl<ImageSegment> {
         return null;
     }
 
-    private static Date convertNitfDate(DateTime nitfDateTime) {
+    public static Date convertNitfDate(DateTime nitfDateTime) {
         if (nitfDateTime == null || nitfDateTime.getZonedDateTime() == null) {
             return null;
         }

--- a/catalog/imaging/imaging-transformer-nitf/src/test/groovy/NitfPreStoragePluginTest.groovy
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/groovy/NitfPreStoragePluginTest.groovy
@@ -11,9 +11,10 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
+
+import org.codice.alliance.transformer.nitf.image.NitfPreStoragePlugin
 import spock.lang.Specification
 import spock.lang.Unroll
-import org.codice.alliance.transformer.nitf.image.NitfPreStoragePlugin
 
 @Unroll
 class NitfPreStoragePluginTest extends Specification {

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/TreTestUtility.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/TreTestUtility.java
@@ -149,13 +149,17 @@ public class TreTestUtility {
     }
 
     public static NitfHeader createFileHeader() {
+        return createFileHeader(DateTime.getNitfDateTimeForNow());
+    }
+
+    public static NitfHeader createFileHeader(DateTime fileDateTime) {
         TreCollection treCollection = new TreCollection();
         FileSecurityMetadata securityMetadata = createSecurityMetadata();
         NitfHeader nitfHeader = mock(NitfHeader.class);
         when(nitfHeader.getFileTitle()).thenReturn("TEST NITF");
         when(nitfHeader.getFileType()).thenReturn(FileType.NITF_TWO_ONE);
         when(nitfHeader.getComplexityLevel()).thenReturn(1);
-        when(nitfHeader.getFileDateTime()).thenReturn(DateTime.getNitfDateTimeForNow());
+        when(nitfHeader.getFileDateTime()).thenReturn(fileDateTime);
         when(nitfHeader.getOriginatingStationId()).thenReturn("LOCALHOST");
         when(nitfHeader.getStandardType()).thenReturn("BF01");
         when(nitfHeader.getFileBackgroundColour()).thenReturn(new RGBColour((byte) 0,
@@ -193,6 +197,10 @@ public class TreTestUtility {
     }
 
     public static ImageSegment createImageSegment() {
+        return createImageSegment(DateTime.getNitfDateTimeForNow());
+    }
+
+    public static ImageSegment createImageSegment(DateTime imageDateTime) {
         SecurityMetadata securityMetadata = createSecurityMetadata();
         ImageBand imageBand = createImageBand();
         ImageSegment imageSegment = mock(ImageSegment.class);
@@ -202,7 +210,7 @@ public class TreTestUtility {
         when(imageSegment.getNumBands()).thenReturn(3);
         when(imageSegment.getActualBitsPerPixelPerBand()).thenReturn(8);
         when(imageSegment.getIdentifier()).thenReturn("12345");
-        when(imageSegment.getImageDateTime()).thenReturn(DateTime.getNitfDateTimeForNow());
+        when(imageSegment.getImageDateTime()).thenReturn(imageDateTime);
         when(imageSegment.getImageTargetId()).thenReturn(new TargetId());
         when(imageSegment.getImageIdentifier2()).thenReturn("");
         when(imageSegment.getSecurityMetadata()).thenReturn(securityMetadata);


### PR DESCRIPTION
#### What does this PR do?
This PR populates `effective` in the metacard with the date and time of the first image in the metacard. This PR also sets `datetime.start` and `datetime.end` from the image segments.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@clockard @dcruver @mcalcote @glenhein 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire 
@shaundmorris
#### How should this be tested?
- Ingest an image nitf.
  - Confirm that the `dateTime` attributes are populated correctly in the metacard.
    - `datetime.start` = `effective` = date and time of the first image segment
    - `ext.nitf.image.image-date-and-time` = date and time of each image segment
    - `datetime.end` = date and time of the last image segment
    - `created` = `modified` = `ext.nitf.file-date-and-time` = file date and time of the header
    - `metacard.created` = `metacard.modified` = time of ingest
  - Confirm that attributes have as many values as expected. Only attributes prefixed with `ext.nitf.image.` should have as many values as image segments in the nitf.
- Confirm unit tests succeed.

For example, see [attached TEXT_NITF.ntf](https://codice.atlassian.net/browse/CAL-235) that is generated from `ImageInputTransformerTest`.
- file date and time of the header = `2016-01-01T00:00:00.000+00:00`
- first image date and time = `2001-01-01T00:00:00.000+00:00`
- second image date and time = `2002-01-01T00:00:00.000+00:00`
- third/last image date and time = `2003-01-01T00:00:00.000+00:00`
#### Any background context you want to provide?
#### What are the relevant tickets?
[CAL-235](https://codice.atlassian.net/browse/CAL-235)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
