### PR TITLE
CAL-244 Add thread pool for video chunk rollover actions

### DIFF
--- a/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/plugins/RolloverThreadPoolStreamCreationPlugin.java
+++ b/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/plugins/RolloverThreadPoolStreamCreationPlugin.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.video.stream.mpegts.plugins;
+
+import java.util.concurrent.Executors;
+
+import org.codice.alliance.video.stream.mpegts.Context;
+
+public class RolloverThreadPoolStreamCreationPlugin extends BaseStreamCreationPlugin {
+
+    private static final int ROLLOVER_THREAD_POOL_THREAD_COUNT = 10;
+
+    @Override
+    protected void doOnCreate(Context context) throws StreamCreationException {
+        context.getUdpStreamProcessor()
+                .setRolloverThreadPool(Executors.newFixedThreadPool(
+                        ROLLOVER_THREAD_POOL_THREAD_COUNT));
+    }
+}

--- a/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/plugins/ShutdownRolloverThreadPoolPlugin.java
+++ b/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/plugins/ShutdownRolloverThreadPoolPlugin.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.video.stream.mpegts.plugins;
+
+import java.util.concurrent.ExecutorService;
+
+import org.codice.alliance.video.stream.mpegts.Context;
+
+/**
+ * Shutdown the rollover thread pool. Waits for rollover tasks to complete.
+ */
+public class ShutdownRolloverThreadPoolPlugin extends BaseStreamShutdownPlugin {
+
+    @Override
+    protected void doOnShutdown(Context context) throws StreamShutdownException {
+        ExecutorService executorService = context.getUdpStreamProcessor()
+                .getRolloverThreadPool();
+
+        if (executorService != null) {
+            executorService.shutdown();
+        }
+    }
+}

--- a/catalog/video/video-mpegts-stream/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/video/video-mpegts-stream/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -95,6 +95,7 @@
                                 <argument ref="metacardTypeList"/>
                             </bean>
                             <bean class="org.codice.alliance.video.stream.mpegts.plugins.RolloverStreamCreationPlugin"/>
+                            <bean class="org.codice.alliance.video.stream.mpegts.plugins.RolloverThreadPoolStreamCreationPlugin"/>
                             <bean class="org.codice.alliance.video.stream.mpegts.plugins.TimerStreamCreationPlugin">
                                 <argument>
                                     <bean class="org.codice.alliance.video.stream.mpegts.plugins.TimerFactory"/>
@@ -114,6 +115,7 @@
                         <list>
                             <!-- note: order matters -->
                             <bean class="org.codice.alliance.video.stream.mpegts.plugins.TimerStreamShutdownPlugin"/>
+                            <bean class="org.codice.alliance.video.stream.mpegts.plugins.ShutdownRolloverThreadPoolPlugin"/>
                             <bean class="org.codice.alliance.video.stream.mpegts.plugins.FlushPacketBufferStreamShutdownPlugin"/>
                             <bean class="org.codice.alliance.video.stream.mpegts.plugins.ResetPacketBufferStreamShutdownPlugin"/>
                         </list>

--- a/catalog/video/video-mpegts-stream/src/test/java/org/codice/alliance/video/stream/mpegts/netty/UdpStreamProcessorTest.java
+++ b/catalog/video/video-mpegts-stream/src/test/java/org/codice/alliance/video/stream/mpegts/netty/UdpStreamProcessorTest.java
@@ -16,18 +16,24 @@ package org.codice.alliance.video.stream.mpegts.netty;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.File;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
 
 import org.codice.alliance.video.stream.mpegts.SimpleSubject;
 import org.codice.alliance.video.stream.mpegts.StreamMonitor;
 import org.codice.alliance.video.stream.mpegts.filename.FilenameGenerator;
 import org.codice.alliance.video.stream.mpegts.metacard.MetacardUpdater;
 import org.codice.alliance.video.stream.mpegts.plugins.StreamShutdownPlugin;
+import org.codice.alliance.video.stream.mpegts.rollover.RolloverAction;
+import org.codice.alliance.video.stream.mpegts.rollover.RolloverActionException;
 import org.codice.alliance.video.stream.mpegts.rollover.RolloverCondition;
 import org.junit.Test;
 
@@ -64,6 +70,23 @@ public class UdpStreamProcessorTest {
         } finally {
             udpStreamProcessor.shutdown();
         }
+    }
+
+    @Test
+    public void testDoRollover()
+            throws RolloverActionException, ExecutionException, InterruptedException {
+        StreamMonitor streamMonitor = mock(StreamMonitor.class);
+        UdpStreamProcessor udpStreamProcessor = new UdpStreamProcessor(streamMonitor);
+        RolloverAction rolloverAction = mock(RolloverAction.class);
+        udpStreamProcessor.setRolloverAction(rolloverAction);
+        udpStreamProcessor.setRolloverThreadPool(Executors.newSingleThreadExecutor());
+
+        File file = mock(File.class);
+
+        udpStreamProcessor.doRollover(file).get();
+
+        verify(rolloverAction).doAction(file);
+
     }
 
 }

--- a/catalog/video/video-mpegts-stream/src/test/java/org/codice/alliance/video/stream/mpegts/plugins/ShutdownRolloverThreadPoolPluginTest.java
+++ b/catalog/video/video-mpegts-stream/src/test/java/org/codice/alliance/video/stream/mpegts/plugins/ShutdownRolloverThreadPoolPluginTest.java
@@ -13,46 +13,30 @@
  */
 package org.codice.alliance.video.stream.mpegts.plugins;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Optional;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.ExecutorService;
 
 import org.codice.alliance.video.stream.mpegts.Context;
-import org.codice.alliance.video.stream.mpegts.netty.PacketBuffer;
 import org.codice.alliance.video.stream.mpegts.netty.UdpStreamProcessor;
 import org.junit.Test;
 
-public class FlushPacketBufferStreamShutdownPluginTest {
+public class ShutdownRolloverThreadPoolPluginTest {
 
     @Test
-    public void testOnShutdown()
-            throws StreamShutdownException, IOException, ExecutionException, InterruptedException {
+    public void testShutdown() throws StreamShutdownException {
 
         Context context = mock(Context.class);
         UdpStreamProcessor udpStreamProcessor = mock(UdpStreamProcessor.class);
-        Future<Void> future = mock(Future.class);
-        when(future.get()).thenReturn(null);
-        when(udpStreamProcessor.doRollover(any())).thenReturn(future);
-        PacketBuffer packetBuffer = mock(PacketBuffer.class);
-        File file = mock(File.class);
-
         when(context.getUdpStreamProcessor()).thenReturn(udpStreamProcessor);
-        when(udpStreamProcessor.getPacketBuffer()).thenReturn(packetBuffer);
-        when(packetBuffer.flushAndRotate()).thenReturn(Optional.of(file));
+        ExecutorService executorService = mock(ExecutorService.class);
+        when(udpStreamProcessor.getRolloverThreadPool()).thenReturn(executorService);
 
-        FlushPacketBufferStreamShutdownPlugin flushPacketBufferStreamShutdownPlugin =
-                new FlushPacketBufferStreamShutdownPlugin();
+        new ShutdownRolloverThreadPoolPlugin().doOnShutdown(context);
 
-        flushPacketBufferStreamShutdownPlugin.onShutdown(context);
-
-        verify(udpStreamProcessor).doRollover(file);
+        verify(executorService).shutdown();
 
     }
 


### PR DESCRIPTION
#### What does this PR do?
Add thread pool for rollover actions and improve logging around rollover execution.

The timer thread that executes the rollover for video chunks can block if ingest is delayed or the system is too busy. By adding the rollover action to a thread pool, the timer thread is allowed to check for rollovers and a more consistent rate.

The extra logging will allow the admin to determine if delays in the rollover action/ingest is the cause for irregular sized video chunks.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@jlcsmith 
@rzwiefel 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@lessarderic
#### How should this be tested?
For a basic test, ingesting a streaming video is sufficient. For a more advanced test, enable the extra logging:

log:set DEBUG org.codice.alliance.video.stream.mpegts.netty

You will be looking for the log entries:
  "submitting rollover task to thread pool: submitted task count={} running task count={}"
  "performing video chunk rollover: tempFile={} submitted task count={} running task count={}"
  "done processing rollover chunk: submitted task count={} running task count={}"

This will tell you how many rollover actions have been submitted and how many are running. For a smoothly running system, these values should be "1". As a system becomes busier, there will be occasionally two or more submitted actions. Note: These counts are logged for each individual stream being recorded. 

Increase the system load by ingesting 3 or more stream simultaneously. 

If the above counts are steadily increasing, then the system is falling behind. An easy way to trigger this is to set the "distance tolerance" in the video app configuration to 0.0001 or smaller for videos with location data. A very small tolerance will cause the geometry calculations to grower more complex and cause the ingest performance to suffer.


#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-244](https://codice.atlassian.net/browse/CAL-244)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [x] Update / Add Integration Tests
