### PR TITLE
CAL-246 change the default distance tolerance to 0.01

### DIFF
--- a/catalog/video/video-admin-plugin/src/main/webapp/js/view/StreamMonitor.view.js
+++ b/catalog/video/video-admin-plugin/src/main/webapp/js/view/StreamMonitor.view.js
@@ -115,7 +115,8 @@ define([
                 this.setupPopOver('[data-toggle="max-size-popover"]', 'Maximum file size (MB) before rollover. Must be >=1.');
                 this.setupPopOver('[data-toggle="file-templ-popover"]', 'Filename template for each chunk. The template may contain any number of the sequence "%{date=FORMAT}" where FORMAT is a Java SimpleDateFormat. Must be non-blank.');
                 this.setupPopOver('[data-toggle="delay-popover"]', 'Delay updates when creating metacards to avoid retries. Slower systems require a longer delay. The minimum value is 0 seconds and the maximum value is 60 seconds. (seconds)');
-                this.setupPopOver('[data-toggle="distance-tolerance-popover"]', 'Distance tolerance used to simplify geospatial metadata during video stream processing. The tolerance must be non-negative and the units are degrees.');
+                this.setupPopOver('[data-toggle="distance-tolerance-popover"]', 'Distance tolerance used to simplify geospatial metadata during video stream processing. The tolerance must be non-negative and the units are degrees. ' +
+                    'Large values for distance tolerance will reduce the accuracy of the geometric data. Extremely small values for distance tolerance can adversely affect system performance. The recommended range is [0.001,0.1].');
                 this.setupPopOver('[data-toggle="network-interface-popover"]', 'Select the network interface to use when receiving multicast.');
                 if(typeof this.configuration !== "undefined") {
                     this.renderFields();
@@ -132,7 +133,7 @@ define([
                 this.$(".feedMaxClipSize").val(10);
                 this.$(".feedFileNameTemplate").val("mpegts-stream-%{date=yyyy-MM-dd_hh:mm:ss}");
                 this.$(".feedInitialDelay").val(2);
-                this.$(".feedDistanceTolerance").val(0.0001);
+                this.$(".feedDistanceTolerance").val(0.01);
             },
             renderFields: function() {
                 this.$(".feedName").val(this.configuration.title);

--- a/catalog/video/video-admin-plugin/src/main/webapp/templates/addConfigurationModal.handlebars
+++ b/catalog/video/video-admin-plugin/src/main/webapp/templates/addConfigurationModal.handlebars
@@ -32,7 +32,7 @@
                 <div class="actionitem">Maximum Clip Size (MB) <i class="glyphicon glyphicon-question-sign" data-toggle="max-size-popover"></i></div><div class="actionitem"><input class="inputnum feedMaxClipSize" step="1" type="number"></div>
                 <div class="actionitem">Filename Template <i class="glyphicon glyphicon-question-sign" data-toggle="file-templ-popover"></i></div><div class="actionitem"><input class="inputtext feedFileNameTemplate" type="text"></div>
                 <div class="actionitem">Metacard Update Initial Delay <i class="glyphicon glyphicon-question-sign" data-toggle="delay-popover"></i></div><div class="actionitem"><input class="inputnum feedInitialDelay" step="1" type="number"></div>
-                <div class="actionitem">Distance Tolerance <i class="glyphicon glyphicon-question-sign" data-toggle="distance-tolerance-popover"></i></div><div class="actionitem"><input class="inputnum feedDistanceTolerance" step="0.0001" type="number"></div>
+                <div class="actionitem">Distance Tolerance <i class="glyphicon glyphicon-question-sign" data-toggle="distance-tolerance-popover"></i></div><div class="actionitem"><input class="inputnum feedDistanceTolerance" step="0.01" type="number"></div>
         </div>
         <div class="modal-footer">
             <div class="btn-group uploadFields">

--- a/catalog/video/video-mpegts-stream/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/video/video-mpegts-stream/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -33,7 +33,7 @@
         <argument>
             <list>
                 <bean class="org.codice.alliance.libs.klv.SimplifyGeometryFunction">
-                    <argument value="0.0001"/>
+                    <argument value="0.01"/>
                 </bean>
                 <bean class="org.codice.alliance.libs.klv.NormalizeGeometry"/>
             </list>

--- a/catalog/video/video-mpegts-stream/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/video/video-mpegts-stream/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -54,9 +54,9 @@
                 type="Long" default="2"/>
 
         <AD
-                description="Distance tolerance used to simplify geospatial metadata during video stream processing. The tolerance must be non-negative and the units are degrees."
+                description="Distance tolerance used to simplify geospatial metadata during video stream processing. The tolerance must be non-negative and the units are degrees. Large values for distance tolerance will reduce the accuracy of the geometric data. Extremely small values for distance tolerance can adversely affect system performance. The recommended range is [0.001,0.1]."
                 name="Distance Tolerance" id="distanceTolerance" required="false"
-                type="Double" default="0.0001"/>
+                type="Double" default="0.01"/>
 
         <AD
                 description="Start the UDP Stream Monitor immediately upon creation."


### PR DESCRIPTION
#### What does this PR do?
Change the default distance tolerance to 0.01.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@bdeining 
@jlcsmith 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@lessarderic
#### How should this be tested?
Configure a new stream through the FMV Stream Management and MPEG-TS UDP Stream Monitor. Note that the default value in both places is 0.01.

#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-246](https://codice.atlassian.net/browse/CAL-246)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
