### PR TITLE
CAL-250 (Backport 0.2.x) Prevent parse exceptions from occurring when ingesting NITFs that have TRE fields with values equal to empty string

### DIFF
--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/CsexraAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/CsexraAttribute.java
@@ -24,6 +24,7 @@ import java.util.regex.Pattern;
 import javax.measure.converter.MultiplyConverter;
 import javax.measure.converter.UnitConverter;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.codice.alliance.catalog.core.api.impl.types.IsrAttributes;
@@ -343,7 +344,7 @@ public class CsexraAttribute extends NitfAttributeImpl<Tre> {
 
         Serializable value = TreUtility.getTreValue(tre, PREDICTED_NIIRS_SHORT_NAME);
 
-        if (value instanceof String) {
+        if (value instanceof String && StringUtils.isNotEmpty((String) value)) {
             return parseNiirs((String) value);
         }
 
@@ -360,6 +361,7 @@ public class CsexraAttribute extends NitfAttributeImpl<Tre> {
         return tre -> Optional.ofNullable(TreUtility.getTreValue(tre, SNOW_DEPTH_CAT_SHORT_NAME))
                 .filter(String.class::isInstance)
                 .map(String.class::cast)
+                .filter(StringUtils::isNotEmpty)
                 .map(Integer::valueOf)
                 .map(CsexraAttribute::convertSnowDepthCat)
                 .map(pair -> pair.map(pairFunction)

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/PiaimcAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/PiaimcAttribute.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
+import org.apache.commons.lang3.StringUtils;
 import org.codice.alliance.catalog.core.api.impl.types.IsrAttributes;
 import org.codice.alliance.catalog.core.api.types.Isr;
 import org.codice.alliance.transformer.nitf.ExtNitfUtility;
@@ -236,9 +237,9 @@ public class PiaimcAttribute extends NitfAttributeImpl<Tre> {
         return Optional.ofNullable(TreUtility.getTreValue(tre, CLOUDCVR_SHORT_NAME))
                 .filter(String.class::isInstance)
                 .map(String.class::cast)
+                .filter(StringUtils::isNotEmpty)
                 .map(Integer::valueOf)
-                .filter(value -> value >= 0)
-                .filter(value -> value <= 100)
+                .filter(value -> value >= 0 && value <= 100)
                 .orElse(null);
     }
 

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/TreUtility.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/TreUtility.java
@@ -20,6 +20,7 @@ import java.util.TimeZone;
 
 import javax.annotation.Nullable;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.FastDateFormat;
 import org.codice.imaging.nitf.core.common.NitfFormatException;
 import org.codice.imaging.nitf.core.tre.Tre;
@@ -32,7 +33,8 @@ public final class TreUtility {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TreUtility.class);
 
-    private static final FastDateFormat DATE_FORMATTER = FastDateFormat.getInstance(TRE_DATE_FORMAT, TimeZone.getTimeZone("GMT"));
+    private static final FastDateFormat DATE_FORMATTER = FastDateFormat.getInstance(TRE_DATE_FORMAT,
+            TimeZone.getTimeZone("GMT"));
 
     private TreUtility() {
     }
@@ -62,7 +64,7 @@ public final class TreUtility {
     @Nullable
     public static Integer convertToInteger(Tre tre, String fieldName) {
         String value = TreUtility.getTreValue(tre, fieldName);
-        if (value != null) {
+        if (StringUtils.isNotEmpty(value)) {
             return Integer.valueOf(value);
         } else {
             return null;
@@ -81,7 +83,7 @@ public final class TreUtility {
     @Nullable
     public static Float convertToFloat(Tre tre, String fieldName) {
         String value = TreUtility.getTreValue(tre, fieldName);
-        if (value != null) {
+        if (StringUtils.isNotEmpty(value)) {
             return Float.valueOf(value);
         } else {
             return null;
@@ -101,7 +103,7 @@ public final class TreUtility {
     @Nullable
     public static Date convertToDate(Tre tre, String fieldName) {
         String value = TreUtility.getTreValue(tre, fieldName);
-        if (value != null) {
+        if (StringUtils.isNotEmpty(value)) {
             try {
                 return DATE_FORMATTER.parse(value);
             } catch (ParseException e) {

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/CsexraAttributeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/CsexraAttributeTest.java
@@ -93,6 +93,16 @@ public class CsexraAttributeTest {
 
     }
 
+    @Test
+    public void testNiirsEmptyString() throws NitfFormatException {
+        when(tre.getFieldValue(CsexraAttribute.PREDICTED_NIIRS_SHORT_NAME)).thenReturn("");
+
+        Serializable actual = CsexraAttribute.PREDICTED_NIIRS_ATTRIBUTE.getAccessorFunction()
+                .apply(tre);
+
+        assertThat(actual, nullValue());
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     public void testNiirsNotSet() throws NitfFormatException {
@@ -153,6 +163,16 @@ public class CsexraAttributeTest {
                 .apply(tre);
 
         assertThat(actual, is(nullValue()));
+    }
+
+    @Test
+    public void testSnowDepthMinCategoryEmptyString() throws NitfFormatException {
+        when(tre.getFieldValue(CsexraAttribute.SNOW_DEPTH_CAT_SHORT_NAME)).thenReturn("");
+
+        Serializable actual = CsexraAttribute.SNOW_DEPTH_MIN_ATTRIBUTE.getAccessorFunction()
+                .apply(tre);
+
+        assertThat(actual, nullValue());
     }
 
     @SuppressWarnings("unchecked")

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/PiaimcAttributeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/PiaimcAttributeTest.java
@@ -72,6 +72,14 @@ public class PiaimcAttributeTest {
     }
 
     @Test
+    public void testCloudCoverEmptyString() throws NitfFormatException {
+        when(tre.getFieldValue(PiaimcAttribute.CLOUDCVR_SHORT_NAME)).thenReturn("");
+        Serializable actual = PiaimcAttribute.CLOUDCVR_ATTRIBUTE.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, nullValue());
+    }
+
+    @Test
     public void testSrpTrue() throws NitfFormatException {
         when(tre.getFieldValue(PiaimcAttribute.STANDARD_RADIOMETRIC_PRODUCT_SHORT_NAME)).thenReturn("Y");
         Serializable actual = PiaimcAttribute.SRP_ATTRIBUTE.getAccessorFunction()


### PR DESCRIPTION
#### What does this PR do?
Backport CAL-250 to 0.2.x
See (https://github.com/codice/alliance/pull/248) for more information. 