### PR TITLE
CAL-251 Add support for the PIATGB TRE

### DIFF
--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/AbstractNitfMetacardType.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/AbstractNitfMetacardType.java
@@ -17,15 +17,35 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.codice.alliance.catalog.core.api.impl.types.IsrAttributes;
+import org.codice.alliance.catalog.core.api.impl.types.SecurityAttributes;
+import org.codice.alliance.transformer.nitf.common.AcftbAttribute;
+import org.codice.alliance.transformer.nitf.common.AimidbAttribute;
+import org.codice.alliance.transformer.nitf.common.CsdidaAttribute;
+import org.codice.alliance.transformer.nitf.common.CsexraAttribute;
+import org.codice.alliance.transformer.nitf.common.HistoaAttribute;
 import org.codice.alliance.transformer.nitf.common.NitfAttribute;
+import org.codice.alliance.transformer.nitf.common.NitfHeaderAttribute;
+import org.codice.alliance.transformer.nitf.common.PiaimcAttribute;
+import org.codice.alliance.transformer.nitf.common.PiatgbAttribute;
+import org.codice.alliance.transformer.nitf.gmti.IndexedMtirpbAttribute;
+import org.codice.alliance.transformer.nitf.gmti.MtirpbAttribute;
 
 import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.impl.MetacardTypeImpl;
+import ddf.catalog.data.impl.types.AssociationsAttributes;
+import ddf.catalog.data.impl.types.ContactAttributes;
+import ddf.catalog.data.impl.types.CoreAttributes;
+import ddf.catalog.data.impl.types.DateTimeAttributes;
+import ddf.catalog.data.impl.types.LocationAttributes;
+import ddf.catalog.data.impl.types.MediaAttributes;
+import ddf.catalog.data.impl.types.ValidationAttributes;
 
 public abstract class AbstractNitfMetacardType extends MetacardTypeImpl {
 
     public AbstractNitfMetacardType(String name, Set<AttributeDescriptor> descriptors) {
         super(name, descriptors);
+        setDefaultDescriptors();
     }
 
     public abstract void initDescriptors();
@@ -40,6 +60,28 @@ public abstract class AbstractNitfMetacardType extends MetacardTypeImpl {
 
     public static <T> Set<AttributeDescriptor> getDescriptors(List<NitfAttribute<T>> attributes) {
         return getDescriptors(attributes.toArray(new NitfAttribute[attributes.size()]));
+    }
+
+    private void setDefaultDescriptors() {
+        descriptors.addAll(getDescriptors(NitfHeaderAttribute.getAttributes()));
+        descriptors.addAll(getDescriptors(AcftbAttribute.getAttributes()));
+        descriptors.addAll(getDescriptors(AimidbAttribute.getAttributes()));
+        descriptors.addAll(getDescriptors(CsdidaAttribute.getAttributes()));
+        descriptors.addAll(getDescriptors(CsexraAttribute.getAttributes()));
+        descriptors.addAll(getDescriptors(HistoaAttribute.getAttributes()));
+        descriptors.addAll(getDescriptors(IndexedMtirpbAttribute.getAttributes()));
+        descriptors.addAll(getDescriptors(MtirpbAttribute.getAttributes()));
+        descriptors.addAll(getDescriptors(PiaimcAttribute.getAttributes()));
+        descriptors.addAll(getDescriptors(PiatgbAttribute.getAttributes()));
+        descriptors.addAll(new CoreAttributes().getAttributeDescriptors());
+        descriptors.addAll(new AssociationsAttributes().getAttributeDescriptors());
+        descriptors.addAll(new ContactAttributes().getAttributeDescriptors());
+        descriptors.addAll(new MediaAttributes().getAttributeDescriptors());
+        descriptors.addAll(new DateTimeAttributes().getAttributeDescriptors());
+        descriptors.addAll(new LocationAttributes().getAttributeDescriptors());
+        descriptors.addAll(new ValidationAttributes().getAttributeDescriptors());
+        descriptors.addAll(new IsrAttributes().getAttributeDescriptors());
+        descriptors.addAll(new SecurityAttributes().getAttributeDescriptors());
     }
 
 }

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/PiatgbAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/PiatgbAttribute.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.transformer.nitf.common;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Function;
+
+import org.codice.alliance.transformer.nitf.ExtNitfUtility;
+import org.codice.imaging.nitf.core.tre.Tre;
+
+import ddf.catalog.data.AttributeType;
+import ddf.catalog.data.impl.BasicTypes;
+
+/**
+ * TRE for "Imagery Access Target"
+ */
+public class PiatgbAttribute extends NitfAttributeImpl<Tre> {
+
+    private static final List<NitfAttribute<Tre>> ATTRIBUTES = new LinkedList<>();
+
+    private static final String PREFIX = ExtNitfUtility.EXT_NITF_PREFIX + "piatgb.";
+
+    public static final String TARGET_UTM = PREFIX + "target-utm";
+
+    public static final String PIA_TARGET_IDENTIFICATION = PREFIX + "target-identification";
+
+    public static final String PIA_COUNTRY = PREFIX + "country-code";
+
+    public static final String PIA_CATEGORY = PREFIX + "category-code";
+
+    public static final String TARGET_GEOGRAPHIC_COORDINATES =
+            PREFIX + "target-geographic-coordinates";
+
+    public static final String TARGET_COORDINATE_DATUM = PREFIX + "target-coordinate-datum";
+
+    public static final String TARGET_NAME = PREFIX + "target-name";
+
+    public static final String PERCENTAGE_OF_COVERAGE = PREFIX + "percentage-of-coverage";
+
+    public static final String TARGET_LATITUDE = PREFIX + "target-latitude";
+
+    public static final String TARGET_LONGITUDE = PREFIX + "target-longitude";
+
+    /*
+     * Non-normalized attributes
+     */
+    public static final PiatgbAttribute TARGET_UTM_ATTRIBUTE = new PiatgbAttribute(TARGET_UTM,
+            "TGTUTM",
+            tre -> TreUtility.getTreValue(tre, "TGTUTM"),
+            BasicTypes.STRING_TYPE);
+
+    public static final PiatgbAttribute PIA_TARGET_IDENTIFICATION_ATTRIBUTE = new PiatgbAttribute(
+            PIA_TARGET_IDENTIFICATION,
+            "PIATGAID",
+            tre -> TreUtility.getTreValue(tre, "PIATGAID"),
+            BasicTypes.STRING_TYPE);
+
+    public static final PiatgbAttribute PIA_COUNTRY_ATTRIBUTE = new PiatgbAttribute(PIA_COUNTRY,
+            "PIACTRY",
+            tre -> TreUtility.getTreValue(tre, "PIACTRY"),
+            BasicTypes.STRING_TYPE);
+
+    public static final PiatgbAttribute PIA_CATEGORY_ATTRIBUTE = new PiatgbAttribute(PIA_CATEGORY,
+            "PIACAT",
+            tre -> TreUtility.getTreValue(tre, "PIACAT"),
+            BasicTypes.STRING_TYPE);
+
+    public static final PiatgbAttribute TARGET_GEOGRAPHIC_COORDINATES_ATTRIBUTE =
+            new PiatgbAttribute(TARGET_GEOGRAPHIC_COORDINATES,
+                    "TGTGEO",
+                    tre -> TreUtility.getTreValue(tre, "TGTGEO"),
+                    BasicTypes.STRING_TYPE);
+
+    public static final PiatgbAttribute TARGET_COORDINATE_DATUM_ATTRIBUTE = new PiatgbAttribute(
+            TARGET_COORDINATE_DATUM,
+            "DATUM",
+            tre -> TreUtility.convertToString(tre, "DATUM"),
+            BasicTypes.STRING_TYPE);
+
+    public static final PiatgbAttribute TARGET_NAME_ATTRIBUTE = new PiatgbAttribute(TARGET_NAME,
+            "TGTNAME",
+            tre -> TreUtility.getTreValue(tre, "TGTNAME"),
+            BasicTypes.STRING_TYPE);
+
+    public static final PiatgbAttribute PERCENTAGE_OF_COVERAGE_ATTRIBUTE = new PiatgbAttribute(
+            PERCENTAGE_OF_COVERAGE,
+            "PERCOVER",
+            tre -> TreUtility.convertToInteger(tre, "PERCOVER"),
+            BasicTypes.INTEGER_TYPE);
+
+    public static final PiatgbAttribute TARGET_LATITUDE_ATTRIBUTE = new PiatgbAttribute(
+            TARGET_LATITUDE,
+            "TGTLAT",
+            tre -> TreUtility.convertToFloat(tre, "TGTLAT"),
+            BasicTypes.FLOAT_TYPE);
+
+    public static final PiatgbAttribute TARGET_LONGITUDE_ATTRIBUTE = new PiatgbAttribute(
+            TARGET_LONGITUDE,
+            "TGTLON",
+            tre -> TreUtility.convertToFloat(tre, "TGTLON"),
+            BasicTypes.FLOAT_TYPE);
+
+    private PiatgbAttribute(String longName, String shortName,
+            Function<Tre, Serializable> accessorFunction, AttributeType attributeType) {
+        super(longName, shortName, accessorFunction, attributeType);
+        ATTRIBUTES.add(this);
+    }
+
+    public static List<NitfAttribute<Tre>> getAttributes() {
+        return Collections.unmodifiableList(ATTRIBUTES);
+    }
+
+}

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/TreDescriptor.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/TreDescriptor.java
@@ -26,7 +26,8 @@ public enum TreDescriptor {
     CSEXRA(CsexraAttribute.getAttributes()),
     PIAIMC(PiaimcAttribute.getAttributes()),
     CSDIDA(CsdidaAttribute.getAttributes()),
-    HISTOA(HistoaAttribute.getAttributes());
+    HISTOA(HistoaAttribute.getAttributes()),
+    PIATGB(PiatgbAttribute.getAttributes());
 
     private List<NitfAttribute<Tre>> nitfAttributes;
 

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/gmti/GmtiMetacardType.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/gmti/GmtiMetacardType.java
@@ -13,23 +13,7 @@
  */
 package org.codice.alliance.transformer.nitf.gmti;
 
-import org.codice.alliance.catalog.core.api.impl.types.IsrAttributes;
-import org.codice.alliance.catalog.core.api.impl.types.SecurityAttributes;
 import org.codice.alliance.transformer.nitf.AbstractNitfMetacardType;
-import org.codice.alliance.transformer.nitf.common.AcftbAttribute;
-import org.codice.alliance.transformer.nitf.common.CsdidaAttribute;
-import org.codice.alliance.transformer.nitf.common.CsexraAttribute;
-import org.codice.alliance.transformer.nitf.common.HistoaAttribute;
-import org.codice.alliance.transformer.nitf.common.NitfHeaderAttribute;
-import org.codice.alliance.transformer.nitf.common.PiaimcAttribute;
-
-import ddf.catalog.data.impl.types.AssociationsAttributes;
-import ddf.catalog.data.impl.types.ContactAttributes;
-import ddf.catalog.data.impl.types.CoreAttributes;
-import ddf.catalog.data.impl.types.DateTimeAttributes;
-import ddf.catalog.data.impl.types.LocationAttributes;
-import ddf.catalog.data.impl.types.MediaAttributes;
-import ddf.catalog.data.impl.types.ValidationAttributes;
 
 public class GmtiMetacardType extends AbstractNitfMetacardType {
     private static final String NAME = "isr.gmti";
@@ -41,22 +25,5 @@ public class GmtiMetacardType extends AbstractNitfMetacardType {
 
     @Override
     public void initDescriptors() {
-        descriptors.addAll(getDescriptors(NitfHeaderAttribute.getAttributes()));
-        descriptors.addAll(getDescriptors(AcftbAttribute.getAttributes()));
-        descriptors.addAll(getDescriptors(IndexedMtirpbAttribute.getAttributes()));
-        descriptors.addAll(getDescriptors(MtirpbAttribute.getAttributes()));
-        descriptors.addAll(new CoreAttributes().getAttributeDescriptors());
-        descriptors.addAll(new AssociationsAttributes().getAttributeDescriptors());
-        descriptors.addAll(new ContactAttributes().getAttributeDescriptors());
-        descriptors.addAll(new MediaAttributes().getAttributeDescriptors());
-        descriptors.addAll(new DateTimeAttributes().getAttributeDescriptors());
-        descriptors.addAll(new LocationAttributes().getAttributeDescriptors());
-        descriptors.addAll(new ValidationAttributes().getAttributeDescriptors());
-        descriptors.addAll(new IsrAttributes().getAttributeDescriptors());
-        descriptors.addAll(new SecurityAttributes().getAttributeDescriptors());
-        descriptors.addAll(getDescriptors(PiaimcAttribute.getAttributes()));
-        descriptors.addAll(getDescriptors(CsdidaAttribute.getAttributes()));
-        descriptors.addAll(getDescriptors(CsexraAttribute.getAttributes()));
-        descriptors.addAll(getDescriptors(HistoaAttribute.getAttributes()));
     }
 }

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/ImageMetacardType.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/ImageMetacardType.java
@@ -13,26 +13,7 @@
  */
 package org.codice.alliance.transformer.nitf.image;
 
-import org.codice.alliance.catalog.core.api.impl.types.IsrAttributes;
-import org.codice.alliance.catalog.core.api.impl.types.SecurityAttributes;
 import org.codice.alliance.transformer.nitf.AbstractNitfMetacardType;
-import org.codice.alliance.transformer.nitf.common.AcftbAttribute;
-import org.codice.alliance.transformer.nitf.common.AimidbAttribute;
-import org.codice.alliance.transformer.nitf.common.CsdidaAttribute;
-import org.codice.alliance.transformer.nitf.common.CsexraAttribute;
-import org.codice.alliance.transformer.nitf.common.HistoaAttribute;
-import org.codice.alliance.transformer.nitf.common.NitfHeaderAttribute;
-import org.codice.alliance.transformer.nitf.common.PiaimcAttribute;
-import org.codice.alliance.transformer.nitf.gmti.IndexedMtirpbAttribute;
-import org.codice.alliance.transformer.nitf.gmti.MtirpbAttribute;
-
-import ddf.catalog.data.impl.types.AssociationsAttributes;
-import ddf.catalog.data.impl.types.ContactAttributes;
-import ddf.catalog.data.impl.types.CoreAttributes;
-import ddf.catalog.data.impl.types.DateTimeAttributes;
-import ddf.catalog.data.impl.types.LocationAttributes;
-import ddf.catalog.data.impl.types.MediaAttributes;
-import ddf.catalog.data.impl.types.ValidationAttributes;
 
 public class ImageMetacardType extends AbstractNitfMetacardType {
     private static final String NAME = "isr.image";
@@ -49,23 +30,5 @@ public class ImageMetacardType extends AbstractNitfMetacardType {
         descriptors.addAll(getDescriptors(LabelAttribute.values()));
         descriptors.addAll(getDescriptors(SymbolAttribute.values()));
         descriptors.addAll(getDescriptors(TextAttribute.values()));
-        descriptors.addAll(getDescriptors(NitfHeaderAttribute.getAttributes()));
-        descriptors.addAll(getDescriptors(AcftbAttribute.getAttributes()));
-        descriptors.addAll(getDescriptors(AimidbAttribute.getAttributes()));
-        descriptors.addAll(getDescriptors(IndexedMtirpbAttribute.getAttributes()));
-        descriptors.addAll(getDescriptors(MtirpbAttribute.getAttributes()));
-        descriptors.addAll(new CoreAttributes().getAttributeDescriptors());
-        descriptors.addAll(new AssociationsAttributes().getAttributeDescriptors());
-        descriptors.addAll(new ContactAttributes().getAttributeDescriptors());
-        descriptors.addAll(new MediaAttributes().getAttributeDescriptors());
-        descriptors.addAll(new DateTimeAttributes().getAttributeDescriptors());
-        descriptors.addAll(new LocationAttributes().getAttributeDescriptors());
-        descriptors.addAll(new ValidationAttributes().getAttributeDescriptors());
-        descriptors.addAll(new IsrAttributes().getAttributeDescriptors());
-        descriptors.addAll(new SecurityAttributes().getAttributeDescriptors());
-        descriptors.addAll(getDescriptors(HistoaAttribute.getAttributes()));
-        descriptors.addAll(getDescriptors(PiaimcAttribute.getAttributes()));
-        descriptors.addAll(getDescriptors(CsdidaAttribute.getAttributes()));
-        descriptors.addAll(getDescriptors(CsexraAttribute.getAttributes()));
     }
 }

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/AcftbAttributeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/AcftbAttributeTest.java
@@ -11,12 +11,11 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package org.codice.alliance.transformer.nitf;
+package org.codice.alliance.transformer.nitf.common;
 
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertThat;
 
-import org.codice.alliance.transformer.nitf.common.AcftbAttribute;
 import org.codice.imaging.nitf.core.common.NitfFormatException;
 import org.junit.Test;
 

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/AimidbAttributeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/AimidbAttributeTest.java
@@ -11,7 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package org.codice.alliance.transformer.nitf;
+package org.codice.alliance.transformer.nitf.common;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -19,7 +19,6 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.codice.alliance.transformer.nitf.common.AimidbAttribute;
 import org.codice.imaging.nitf.core.common.NitfFormatException;
 import org.codice.imaging.nitf.core.tre.Tre;
 import org.junit.Before;

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/PiatgbAttributeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/PiatgbAttributeTest.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.transformer.nitf.common;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.Serializable;
+
+import org.codice.imaging.nitf.core.common.NitfFormatException;
+import org.codice.imaging.nitf.core.tre.Tre;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PiatgbAttributeTest {
+
+    private Tre tre;
+
+    @Before
+    public void setup() {
+        tre = mock(Tre.class);
+    }
+
+    @Test
+    public void testTargetUtm() throws NitfFormatException {
+        when(tre.getFieldValue(PiatgbAttribute.TARGET_UTM_ATTRIBUTE.getShortName())).thenReturn(
+                "55HFA9359093610");
+        Serializable actual = PiatgbAttribute.TARGET_UTM_ATTRIBUTE.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is("55HFA9359093610"));
+    }
+
+    @Test
+    public void testPiaTargetIdentification() throws NitfFormatException {
+        when(tre.getFieldValue(PiatgbAttribute.PIA_TARGET_IDENTIFICATION_ATTRIBUTE.
+                getShortName())).thenReturn("ABCDEFGHIJUVWXY");
+        Serializable actual =
+                PiatgbAttribute.PIA_TARGET_IDENTIFICATION_ATTRIBUTE.getAccessorFunction()
+                        .apply(tre);
+        assertThat(actual, is("ABCDEFGHIJUVWXY"));
+    }
+
+    @Test
+    public void testPiaCountry() throws NitfFormatException {
+        when(tre.getFieldValue(PiatgbAttribute.PIA_COUNTRY_ATTRIBUTE.getShortName())).thenReturn(
+                "AS");
+        Serializable actual = PiatgbAttribute.PIA_COUNTRY_ATTRIBUTE.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is("AS"));
+    }
+
+    @Test
+    public void testPiaCategory() throws NitfFormatException {
+        when(tre.getFieldValue(PiatgbAttribute.PIA_CATEGORY_ATTRIBUTE.getShortName())).thenReturn(
+                "702XX");
+        Serializable actual = PiatgbAttribute.PIA_CATEGORY_ATTRIBUTE.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is("702XX"));
+    }
+
+    @Test
+    public void testTargetGeographicCoordinates() throws NitfFormatException {
+        when(tre.getFieldValue(PiatgbAttribute.TARGET_GEOGRAPHIC_COORDINATES_ATTRIBUTE.
+                getShortName())).thenReturn("351655S1490742E");
+        Serializable actual =
+                PiatgbAttribute.TARGET_GEOGRAPHIC_COORDINATES_ATTRIBUTE.getAccessorFunction()
+                        .apply(tre);
+        assertThat(actual, is("351655S1490742E"));
+    }
+
+    @Test
+    public void testTargetCoordinateDatum() throws NitfFormatException {
+        when(tre.getFieldValue(PiatgbAttribute.TARGET_COORDINATE_DATUM_ATTRIBUTE.getShortName())).thenReturn(
+                "WGE");
+        Serializable actual =
+                PiatgbAttribute.TARGET_COORDINATE_DATUM_ATTRIBUTE.getAccessorFunction()
+                        .apply(tre);
+        assertThat(actual, is("WGE"));
+    }
+
+    @Test
+    public void testTargetName() throws NitfFormatException {
+        when(tre.getFieldValue(PiatgbAttribute.TARGET_NAME_ATTRIBUTE.getShortName())).thenReturn(
+                "Canberra Hill                         ");
+        Serializable actual = PiatgbAttribute.TARGET_NAME_ATTRIBUTE.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is("Canberra Hill"));
+    }
+
+    @Test
+    public void testPercentageOfCoverage() throws NitfFormatException {
+        when(tre.getFieldValue(PiatgbAttribute.PERCENTAGE_OF_COVERAGE_ATTRIBUTE.
+                getShortName())).thenReturn("57");
+        Integer percentageOfCoverage =
+                (Integer) PiatgbAttribute.PERCENTAGE_OF_COVERAGE_ATTRIBUTE.getAccessorFunction()
+                        .apply(tre);
+        assertThat(percentageOfCoverage, is(57));
+    }
+
+    @Test
+    public void testTargetLatitude() throws NitfFormatException {
+        when(tre.getFieldValue(PiatgbAttribute.TARGET_LATITUDE_ATTRIBUTE.getShortName())).thenReturn(
+                "-35.30812 ");
+        Float targetLatitude =
+                (Float) PiatgbAttribute.TARGET_LATITUDE_ATTRIBUTE.getAccessorFunction()
+                        .apply(tre);
+        assertThat(targetLatitude, is(-35.30812F));
+    }
+
+    @Test
+    public void testTargetLongitude() throws NitfFormatException {
+        when(tre.getFieldValue(PiatgbAttribute.TARGET_LONGITUDE_ATTRIBUTE.getShortName())).thenReturn(
+                "+149.12447 ");
+        Float targetLongitude =
+                (Float) PiatgbAttribute.TARGET_LONGITUDE_ATTRIBUTE.getAccessorFunction()
+                        .apply(tre);
+        assertThat(targetLongitude, is(149.12447F));
+    }
+}

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/gmti/GmtiMetacardTypeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/gmti/GmtiMetacardTypeTest.java
@@ -22,11 +22,13 @@ import org.codice.alliance.catalog.core.api.impl.types.IsrAttributes;
 import org.codice.alliance.catalog.core.api.impl.types.SecurityAttributes;
 import org.codice.alliance.transformer.nitf.AbstractNitfMetacardType;
 import org.codice.alliance.transformer.nitf.common.AcftbAttribute;
+import org.codice.alliance.transformer.nitf.common.AimidbAttribute;
 import org.codice.alliance.transformer.nitf.common.CsdidaAttribute;
 import org.codice.alliance.transformer.nitf.common.CsexraAttribute;
 import org.codice.alliance.transformer.nitf.common.HistoaAttribute;
 import org.codice.alliance.transformer.nitf.common.NitfHeaderAttribute;
 import org.codice.alliance.transformer.nitf.common.PiaimcAttribute;
+import org.codice.alliance.transformer.nitf.common.PiatgbAttribute;
 import org.junit.Test;
 
 import ddf.catalog.data.AttributeDescriptor;
@@ -43,9 +45,10 @@ public class GmtiMetacardTypeTest {
     @Test
     public void testGmtiAttributes() {
         GmtiMetacardType gmtiCardType = new GmtiMetacardType();
-        Set<AttributeDescriptor> descriptors =
-                AbstractNitfMetacardType.getDescriptors(NitfHeaderAttribute.getAttributes());
+        Set<AttributeDescriptor> descriptors = AbstractNitfMetacardType.getDescriptors(
+                NitfHeaderAttribute.getAttributes());
         descriptors.addAll(AbstractNitfMetacardType.getDescriptors(AcftbAttribute.getAttributes()));
+        descriptors.addAll(AbstractNitfMetacardType.getDescriptors(AimidbAttribute.getAttributes()));
         descriptors.addAll(AbstractNitfMetacardType.getDescriptors(IndexedMtirpbAttribute.getAttributes()));
         descriptors.addAll(AbstractNitfMetacardType.getDescriptors(MtirpbAttribute.getAttributes()));
         descriptors.addAll(new CoreAttributes().getAttributeDescriptors());
@@ -61,6 +64,7 @@ public class GmtiMetacardTypeTest {
         descriptors.addAll(AbstractNitfMetacardType.getDescriptors(CsdidaAttribute.getAttributes()));
         descriptors.addAll(AbstractNitfMetacardType.getDescriptors(CsexraAttribute.getAttributes()));
         descriptors.addAll(AbstractNitfMetacardType.getDescriptors(HistoaAttribute.getAttributes()));
+        descriptors.addAll(AbstractNitfMetacardType.getDescriptors(PiatgbAttribute.getAttributes()));
         assertThat(gmtiCardType.getAttributeDescriptors(),
                 containsInAnyOrder(descriptors.toArray(new AttributeDescriptor[descriptors.size()])));
     }

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageMetacardTypeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageMetacardTypeTest.java
@@ -28,6 +28,7 @@ import org.codice.alliance.transformer.nitf.common.CsexraAttribute;
 import org.codice.alliance.transformer.nitf.common.HistoaAttribute;
 import org.codice.alliance.transformer.nitf.common.NitfHeaderAttribute;
 import org.codice.alliance.transformer.nitf.common.PiaimcAttribute;
+import org.codice.alliance.transformer.nitf.common.PiatgbAttribute;
 import org.codice.alliance.transformer.nitf.gmti.IndexedMtirpbAttribute;
 import org.codice.alliance.transformer.nitf.gmti.MtirpbAttribute;
 import org.junit.Test;
@@ -70,6 +71,7 @@ public class ImageMetacardTypeTest {
         descriptors.addAll(AbstractNitfMetacardType.getDescriptors(PiaimcAttribute.getAttributes()));
         descriptors.addAll(AbstractNitfMetacardType.getDescriptors(CsdidaAttribute.getAttributes()));
         descriptors.addAll(AbstractNitfMetacardType.getDescriptors(CsexraAttribute.getAttributes()));
+        descriptors.addAll(AbstractNitfMetacardType.getDescriptors(PiatgbAttribute.getAttributes()));
         assertThat(imageCardType.getAttributeDescriptors(),
                 containsInAnyOrder(descriptors.toArray(new AttributeDescriptor[descriptors.size()])));
     }

--- a/distribution/docs/src/main/resources/_contents/_formats/supported-file-formats-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_formats/supported-file-formats-contents.adoc
@@ -99,6 +99,18 @@ ${branding} has the capability to extract ISR-specific metadata from supported f
 ** `ext.nitf.piaimc.satellite-track-path`
 ** `ext.nitf.piaimc.satellite-track-row`
 
+* NITF Profile For Imagery Access Target (PIATGB) Extended Attributes
+** `ext.nitf.piatgb.target-utm`
+** `ext.nitf.piatgb.target-identification`
+** `ext.nitf.piatgb.country-code`
+** `ext.nitf.piatgb.category-code`
+** `ext.nitf.piatgb.target-geographic-coordinates`
+** `ext.nitf.piatgb.target-coordinate-datum`
+** `ext.nitf.piatgb.target-name`
+** `ext.nitf.piatgb.percentage-of-coverage`
+** `ext.nitf.piatgb.target-latitude`
+** `ext.nitf.piatgb.target-longitude`
+
 * NITF Moving Target Indiciator Report (MTIRPB) Extended Attributes
 ** `ext.nitf.mtirpb.target-classification-category`
 ** `ext.nitf.mtirpb.target-amplitude`


### PR DESCRIPTION
#### What does this PR do?
-Adds support for populating the metacard with PIATGB TRE data when ingesting a NITF.
-Adds common attribute descriptors between the ImageMetcardType and the GmtiMetacardType into the AbstractNitfMetacardType to prevent code duplication.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@harrison-tarr 
@dcruver 
@bdeining 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jaymcnallie
@jlcsmith
#### How should this be tested?
Ingest a NITF containing the PIATGB TRE, perform a query and verify in the search UI that the TRE data shows up in the metacard.
#### Any background context you want to provide?
#### What are the relevant tickets?
[CAL-251](https://codice.atlassian.net/browse/CAL-251)
#### Screenshots (if appropriate)
#### Checklist:
- [X] Documentation Updated
	- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [N/A] Update / Add Integration Tests
