### PR TITLE
CAL-255 Improve FMV ingest performance.

### DIFF
--- a/catalog/core/catalog-core-api-impl/pom.xml
+++ b/catalog/core/catalog-core-api-impl/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice.alliance.catalog</groupId>
         <artifactId>core</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <groupId>org.codice.alliance.catalog.core</groupId>
     <artifactId>catalog-core-api-impl</artifactId>

--- a/catalog/core/catalog-core-api/pom.xml
+++ b/catalog/core/catalog-core-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice.alliance.catalog</groupId>
         <artifactId>core</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <groupId>org.codice.alliance.catalog.core</groupId>
     <artifactId>catalog-core-api</artifactId>

--- a/catalog/core/catalog-core-classification-api/pom.xml
+++ b/catalog/core/catalog-core-classification-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice.alliance.catalog</groupId>
         <artifactId>core</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <groupId>org.codice.alliance.catalog.core</groupId>
     <artifactId>catalog-core-classification-api</artifactId>

--- a/catalog/core/catalog-core-classification-impl/pom.xml
+++ b/catalog/core/catalog-core-classification-impl/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice.alliance.catalog</groupId>
         <artifactId>core</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <groupId>org.codice.alliance.catalog.core</groupId>
     <artifactId>catalog-core-classification-impl</artifactId>

--- a/catalog/core/catalog-core-metacardtypes/pom.xml
+++ b/catalog/core/catalog-core-metacardtypes/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice.alliance.catalog</groupId>
         <artifactId>core</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <groupId>org.codice.alliance.catalog.core</groupId>
     <artifactId>catalog-core-metacardtypes</artifactId>

--- a/catalog/core/catalog-email-api/pom.xml
+++ b/catalog/core/catalog-email-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice.alliance.catalog</groupId>
         <artifactId>core</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <groupId>org.codice.alliance.catalog.core</groupId>
     <artifactId>catalog-email-api</artifactId>

--- a/catalog/core/catalog-email-impl/pom.xml
+++ b/catalog/core/catalog-email-impl/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.codice.alliance.catalog</groupId>
         <artifactId>core</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Alliance :: Catalog :: Email :: Impl</name>

--- a/catalog/core/pom.xml
+++ b/catalog/core/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>catalog</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <groupId>org.codice.alliance.catalog</groupId>
     <artifactId>core</artifactId>

--- a/catalog/imaging/imaging-actionprovider-chip/pom.xml
+++ b/catalog/imaging/imaging-actionprovider-chip/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice.alliance.imaging</groupId>
         <artifactId>imaging</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>imaging-actionprovider-chip</artifactId>

--- a/catalog/imaging/imaging-app/pom.xml
+++ b/catalog/imaging/imaging-app/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice.alliance.imaging</groupId>
         <artifactId>imaging</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>imaging-app</artifactId>
     <packaging>pom</packaging>

--- a/catalog/imaging/imaging-service-api/pom.xml
+++ b/catalog/imaging/imaging-service-api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>imaging</artifactId>
         <groupId>org.codice.alliance.imaging</groupId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>imaging-service-api</artifactId>

--- a/catalog/imaging/imaging-service-impl/pom.xml
+++ b/catalog/imaging/imaging-service-impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>imaging</artifactId>
         <groupId>org.codice.alliance.imaging</groupId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>imaging-service-impl</artifactId>

--- a/catalog/imaging/imaging-transformer-chipping/pom.xml
+++ b/catalog/imaging/imaging-transformer-chipping/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice.alliance.imaging</groupId>
         <artifactId>imaging</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>imaging-transformer-chipping</artifactId>

--- a/catalog/imaging/imaging-transformer-nitf/pom.xml
+++ b/catalog/imaging/imaging-transformer-nitf/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>imaging</artifactId>
         <groupId>org.codice.alliance.imaging</groupId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>imaging-transformer-nitf</artifactId>
     <packaging>bundle</packaging>

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/CsexraAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/CsexraAttribute.java
@@ -24,6 +24,7 @@ import java.util.regex.Pattern;
 import javax.measure.converter.MultiplyConverter;
 import javax.measure.converter.UnitConverter;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.codice.alliance.catalog.core.api.impl.types.IsrAttributes;
@@ -343,7 +344,7 @@ public class CsexraAttribute extends NitfAttributeImpl<Tre> {
 
         Serializable value = TreUtility.getTreValue(tre, PREDICTED_NIIRS_SHORT_NAME);
 
-        if (value instanceof String) {
+        if (value instanceof String && StringUtils.isNotEmpty((String) value)) {
             return parseNiirs((String) value);
         }
 
@@ -360,6 +361,7 @@ public class CsexraAttribute extends NitfAttributeImpl<Tre> {
         return tre -> Optional.ofNullable(TreUtility.getTreValue(tre, SNOW_DEPTH_CAT_SHORT_NAME))
                 .filter(String.class::isInstance)
                 .map(String.class::cast)
+                .filter(StringUtils::isNotEmpty)
                 .map(Integer::valueOf)
                 .map(CsexraAttribute::convertSnowDepthCat)
                 .map(pair -> pair.map(pairFunction)

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/PiaimcAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/PiaimcAttribute.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
+import org.apache.commons.lang3.StringUtils;
 import org.codice.alliance.catalog.core.api.impl.types.IsrAttributes;
 import org.codice.alliance.catalog.core.api.types.Isr;
 import org.codice.alliance.transformer.nitf.ExtNitfUtility;
@@ -236,9 +237,9 @@ public class PiaimcAttribute extends NitfAttributeImpl<Tre> {
         return Optional.ofNullable(TreUtility.getTreValue(tre, CLOUDCVR_SHORT_NAME))
                 .filter(String.class::isInstance)
                 .map(String.class::cast)
+                .filter(StringUtils::isNotEmpty)
                 .map(Integer::valueOf)
-                .filter(value -> value >= 0)
-                .filter(value -> value <= 100)
+                .filter(value -> value >= 0 && value <= 100)
                 .orElse(null);
     }
 

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/TreUtility.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/TreUtility.java
@@ -20,6 +20,7 @@ import java.util.TimeZone;
 
 import javax.annotation.Nullable;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.FastDateFormat;
 import org.codice.imaging.nitf.core.common.NitfFormatException;
 import org.codice.imaging.nitf.core.tre.Tre;
@@ -32,7 +33,8 @@ public final class TreUtility {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TreUtility.class);
 
-    private static final FastDateFormat DATE_FORMATTER = FastDateFormat.getInstance(TRE_DATE_FORMAT, TimeZone.getTimeZone("GMT"));
+    private static final FastDateFormat DATE_FORMATTER = FastDateFormat.getInstance(TRE_DATE_FORMAT,
+            TimeZone.getTimeZone("GMT"));
 
     private TreUtility() {
     }
@@ -62,7 +64,7 @@ public final class TreUtility {
     @Nullable
     public static Integer convertToInteger(Tre tre, String fieldName) {
         String value = TreUtility.getTreValue(tre, fieldName);
-        if (value != null) {
+        if (StringUtils.isNotEmpty(value)) {
             return Integer.valueOf(value);
         } else {
             return null;
@@ -81,7 +83,7 @@ public final class TreUtility {
     @Nullable
     public static Float convertToFloat(Tre tre, String fieldName) {
         String value = TreUtility.getTreValue(tre, fieldName);
-        if (value != null) {
+        if (StringUtils.isNotEmpty(value)) {
             return Float.valueOf(value);
         } else {
             return null;
@@ -101,7 +103,7 @@ public final class TreUtility {
     @Nullable
     public static Date convertToDate(Tre tre, String fieldName) {
         String value = TreUtility.getTreValue(tre, fieldName);
-        if (value != null) {
+        if (StringUtils.isNotEmpty(value)) {
             try {
                 return DATE_FORMATTER.parse(value);
             } catch (ParseException e) {

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/CsexraAttributeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/CsexraAttributeTest.java
@@ -93,6 +93,16 @@ public class CsexraAttributeTest {
 
     }
 
+    @Test
+    public void testNiirsEmptyString() throws NitfFormatException {
+        when(tre.getFieldValue(CsexraAttribute.PREDICTED_NIIRS_SHORT_NAME)).thenReturn("");
+
+        Serializable actual = CsexraAttribute.PREDICTED_NIIRS_ATTRIBUTE.getAccessorFunction()
+                .apply(tre);
+
+        assertThat(actual, nullValue());
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     public void testNiirsNotSet() throws NitfFormatException {
@@ -153,6 +163,16 @@ public class CsexraAttributeTest {
                 .apply(tre);
 
         assertThat(actual, is(nullValue()));
+    }
+
+    @Test
+    public void testSnowDepthMinCategoryEmptyString() throws NitfFormatException {
+        when(tre.getFieldValue(CsexraAttribute.SNOW_DEPTH_CAT_SHORT_NAME)).thenReturn("");
+
+        Serializable actual = CsexraAttribute.SNOW_DEPTH_MIN_ATTRIBUTE.getAccessorFunction()
+                .apply(tre);
+
+        assertThat(actual, nullValue());
     }
 
     @SuppressWarnings("unchecked")

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/PiaimcAttributeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/PiaimcAttributeTest.java
@@ -72,6 +72,14 @@ public class PiaimcAttributeTest {
     }
 
     @Test
+    public void testCloudCoverEmptyString() throws NitfFormatException {
+        when(tre.getFieldValue(PiaimcAttribute.CLOUDCVR_SHORT_NAME)).thenReturn("");
+        Serializable actual = PiaimcAttribute.CLOUDCVR_ATTRIBUTE.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, nullValue());
+    }
+
+    @Test
     public void testSrpTrue() throws NitfFormatException {
         when(tre.getFieldValue(PiaimcAttribute.STANDARD_RADIOMETRIC_PRODUCT_SHORT_NAME)).thenReturn("Y");
         Serializable actual = PiaimcAttribute.SRP_ATTRIBUTE.getAccessorFunction()

--- a/catalog/imaging/pom.xml
+++ b/catalog/imaging/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>catalog</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/catalog/nsili/catalog-nsili-bqs/pom.xml
+++ b/catalog/nsili/catalog-nsili-bqs/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice.alliance.nsili</groupId>
         <artifactId>nsili</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>catalog-nsili-bqs</artifactId>

--- a/catalog/nsili/catalog-nsili-common/pom.xml
+++ b/catalog/nsili/catalog-nsili-common/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice.alliance.nsili</groupId>
         <artifactId>nsili</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>catalog-nsili-common</artifactId>

--- a/catalog/nsili/catalog-nsili-endpoint/pom.xml
+++ b/catalog/nsili/catalog-nsili-endpoint/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.codice.alliance.nsili</groupId>
         <artifactId>nsili</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Alliance :: NSILI :: Endpoint</name>

--- a/catalog/nsili/catalog-nsili-orb-api/pom.xml
+++ b/catalog/nsili/catalog-nsili-orb-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice.alliance.nsili</groupId>
         <artifactId>nsili</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>catalog-nsili-orb-api</artifactId>

--- a/catalog/nsili/catalog-nsili-orb-impl/pom.xml
+++ b/catalog/nsili/catalog-nsili-orb-impl/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice.alliance.nsili</groupId>
         <artifactId>nsili</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>catalog-nsili-orb-impl</artifactId>

--- a/catalog/nsili/catalog-nsili-source/pom.xml
+++ b/catalog/nsili/catalog-nsili-source/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice.alliance.nsili</groupId>
         <artifactId>nsili</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>catalog-nsili-source</artifactId>

--- a/catalog/nsili/catalog-nsili-sourcestoquery-ui/pom.xml
+++ b/catalog/nsili/catalog-nsili-sourcestoquery-ui/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>nsili</artifactId>
         <groupId>org.codice.alliance.nsili</groupId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>catalog-nsili-sourcestoquery-ui</artifactId>

--- a/catalog/nsili/catalog-nsili-transformer/pom.xml
+++ b/catalog/nsili/catalog-nsili-transformer/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice.alliance.nsili</groupId>
         <artifactId>nsili</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>catalog-nsili-transformer</artifactId>

--- a/catalog/nsili/nsili-app/pom.xml
+++ b/catalog/nsili/nsili-app/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice.alliance.nsili</groupId>
         <artifactId>nsili</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>nsili-app</artifactId>

--- a/catalog/nsili/pom.xml
+++ b/catalog/nsili/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>catalog</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>nsili</artifactId>

--- a/catalog/plugin/catalog-plugin-defaultsecurityattributevalues/pom.xml
+++ b/catalog/plugin/catalog-plugin-defaultsecurityattributevalues/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice.alliance.catalog.plugin</groupId>
         <artifactId>plugin</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <name>Alliance :: Catalog :: Plugin :: Default Security Attribute Value Plugin</name>
     <artifactId>catalog-plugin-defaultsecurityattributevalues</artifactId>

--- a/catalog/plugin/catalog-plugin-security-audit/pom.xml
+++ b/catalog/plugin/catalog-plugin-security-audit/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>plugin</artifactId>
         <groupId>org.codice.alliance.catalog.plugin</groupId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>bundle</packaging>

--- a/catalog/plugin/pom.xml
+++ b/catalog/plugin/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>catalog</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.codice.alliance.catalog.plugin</groupId>

--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice</groupId>
         <artifactId>alliance</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <groupId>org.codice.alliance</groupId>
     <artifactId>catalog</artifactId>

--- a/catalog/security/banner-marking/pom.xml
+++ b/catalog/security/banner-marking/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.codice.alliance.security</groupId>
         <artifactId>security</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>banner-marking</artifactId>

--- a/catalog/security/pom.xml
+++ b/catalog/security/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>catalog</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.codice.alliance.security</groupId>

--- a/catalog/security/security-app/pom.xml
+++ b/catalog/security/security-app/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.codice.alliance.security</groupId>
         <artifactId>security</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>security-app</artifactId>
     <packaging>pom</packaging>

--- a/catalog/video/pom.xml
+++ b/catalog/video/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>catalog</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>video</artifactId>

--- a/catalog/video/video-admin-plugin/pom.xml
+++ b/catalog/video/video-admin-plugin/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>video</artifactId>
         <groupId>org.codice.alliance.video</groupId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>video-admin-plugin</artifactId>

--- a/catalog/video/video-app/pom.xml
+++ b/catalog/video/video-app/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice.alliance.video</groupId>
         <artifactId>video</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>video-app</artifactId>
     <packaging>pom</packaging>

--- a/catalog/video/video-mpegts-stream/pom.xml
+++ b/catalog/video/video-mpegts-stream/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>video</artifactId>
         <groupId>org.codice.alliance.video</groupId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/netty/UdpStreamProcessor.java
+++ b/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/netty/UdpStreamProcessor.java
@@ -26,6 +26,7 @@ import java.util.Timer;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.Validate;
+import org.codice.alliance.libs.klv.ConvertSubpolygonsToEnvelopes;
 import org.codice.alliance.libs.klv.GeometryOperator;
 import org.codice.alliance.libs.klv.GeometryReducer;
 import org.codice.alliance.libs.klv.NormalizeGeometry;
@@ -152,6 +153,11 @@ public class UdpStreamProcessor implements StreamProcessor {
 
             @Override
             public void visit(NormalizeGeometry function) {
+
+            }
+
+            @Override
+            public void visit(ConvertSubpolygonsToEnvelopes convertSubpolygonsToEnvelopes) {
 
             }
         };

--- a/catalog/video/video-mpegts-stream/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/video/video-mpegts-stream/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -35,6 +35,7 @@
                 <bean class="org.codice.alliance.libs.klv.SimplifyGeometryFunction">
                     <argument value="0.0001"/>
                 </bean>
+                <bean class="org.codice.alliance.libs.klv.ConvertSubpolygonsToEnvelopes"/>
                 <bean class="org.codice.alliance.libs.klv.NormalizeGeometry"/>
             </list>
         </argument>
@@ -134,21 +135,6 @@
                             <bean class="org.codice.alliance.video.stream.mpegts.metacard.TemporalEndMetacardUpdater"/>
                             <bean class="org.codice.alliance.video.stream.mpegts.metacard.CreatedDateMetacardUpdater"/>
                             <bean class="org.codice.alliance.video.stream.mpegts.metacard.ModifiedDateMetacardUpdater"/>
-                            <bean class="org.codice.alliance.video.stream.mpegts.metacard.FrameCenterMetacardUpdater">
-                                <argument>
-                                    <bean class="org.codice.alliance.libs.klv.GeometryOperatorList">
-                                        <argument>
-                                            <list>
-                                                <bean class="org.codice.alliance.libs.klv.SimplifyGeometryFunction">
-                                                    <argument value="0.0001"/>
-                                                </bean>
-                                                <bean class="org.codice.alliance.libs.klv.NormalizeGeometry"/>
-                                                <bean class="org.codice.alliance.libs.klv.GeometryReducer"/>
-                                            </list>
-                                        </argument>
-                                    </bean>
-                                </argument>
-                            </bean>
                             <bean class="org.codice.alliance.video.stream.mpegts.metacard.MediaEncodingMetacardUpdater"/>
                             <bean class="org.codice.alliance.video.stream.mpegts.metacard.MissionIdMetacardUpdater"/>
                             <bean class="org.codice.alliance.video.stream.mpegts.metacard.PlatformIdMetacardUpdater"/>

--- a/catalog/video/video-mpegts-transformer/pom.xml
+++ b/catalog/video/video-mpegts-transformer/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>video</artifactId>
         <groupId>org.codice.alliance.video</groupId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>video-mpegts-transformer</artifactId>
     <packaging>bundle</packaging>

--- a/catalog/video/video-mpegts-transformer/src/main/java/org/codice/alliance/transformer/video/SetDistanceToleranceVisitor.java
+++ b/catalog/video/video-mpegts-transformer/src/main/java/org/codice/alliance/transformer/video/SetDistanceToleranceVisitor.java
@@ -14,6 +14,7 @@
 package org.codice.alliance.transformer.video;
 
 import org.codice.alliance.libs.klv.BaseKlvProcessorVisitor;
+import org.codice.alliance.libs.klv.ConvertSubpolygonsToEnvelopes;
 import org.codice.alliance.libs.klv.FrameCenterKlvProcessor;
 import org.codice.alliance.libs.klv.GeometryOperator;
 import org.codice.alliance.libs.klv.GeometryReducer;
@@ -44,6 +45,11 @@ class SetDistanceToleranceVisitor extends BaseKlvProcessorVisitor {
 
                 @Override
                 public void visit(NormalizeGeometry function) {
+
+                }
+
+                @Override
+                public void visit(ConvertSubpolygonsToEnvelopes convertSubpolygonsToEnvelopes) {
 
                 }
             };

--- a/catalog/video/video-security/pom.xml
+++ b/catalog/video/video-security/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>video</artifactId>
         <groupId>org.codice.alliance.video</groupId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>video-security</artifactId>

--- a/dependency-check-maven-config.xml
+++ b/dependency-check-maven-config.xml
@@ -14,7 +14,7 @@
             CVE-2015-5344 is an issue with Camel version before 2.16.1
             OWASP appears to have confused the internal proxy-camel-servlet
             version with the overall Camel version - marking as false positive.
-        file name: proxy-camel-servlet-2.10.0-SNAPSHOT.jar]]>
+        file name: proxy-camel-servlet-2.11.0-SNAPSHOT.jar]]>
         </notes>
         <cve>CVE-2015-5344</cve>
     </suppress>

--- a/distribution/alliance-branding-plugin/pom.xml
+++ b/distribution/alliance-branding-plugin/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>distribution</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.codice.alliance.distribution</groupId>

--- a/distribution/alliance/pom.xml
+++ b/distribution/alliance/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>distribution</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <groupId>org.codice.alliance.distribution</groupId>
     <artifactId>alliance</artifactId>

--- a/distribution/common/pom.xml
+++ b/distribution/common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>distribution</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.codice.alliance.distribution</groupId>

--- a/distribution/console-branding/pom.xml
+++ b/distribution/console-branding/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>distribution</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/distribution/docs/pom.xml
+++ b/distribution/docs/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>distribution</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>docs</artifactId>
     <name>Alliance :: Docs</name>

--- a/distribution/install-profiles/pom.xml
+++ b/distribution/install-profiles/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>distribution</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <name>Alliance :: Distribution :: Install Profiles</name>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice</groupId>
         <artifactId>alliance</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>distribution</artifactId>

--- a/distribution/sdk/pom.xml
+++ b/distribution/sdk/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>distribution</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>sdk</artifactId>

--- a/distribution/sdk/sample-mpegts-streamgenerator/pom.xml
+++ b/distribution/sdk/sample-mpegts-streamgenerator/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.codice.alliance.distribution</groupId>
         <artifactId>sdk</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/distribution/sdk/sample-nsili-client/pom.xml
+++ b/distribution/sdk/sample-nsili-client/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.codice.alliance.distribution</groupId>
         <artifactId>sdk</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Alliance :: Distribution :: SDK :: Sample NSILI Client</name>

--- a/distribution/sdk/sample-nsili-server/pom.xml
+++ b/distribution/sdk/sample-nsili-server/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.codice.alliance.distribution</groupId>
         <artifactId>sdk</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Alliance :: Distribution :: SDK :: Sample NSILI Server</name>

--- a/distribution/sdk/sdk-app/pom.xml
+++ b/distribution/sdk/sdk-app/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>sdk</artifactId>
         <groupId>org.codice.alliance.distribution</groupId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/distribution/test/itests/pom.xml
+++ b/distribution/test/itests/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice.alliance.test</groupId>
         <artifactId>test</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <groupId>org.codice.alliance.test.itests</groupId>
     <artifactId>itests</artifactId>

--- a/distribution/test/itests/test-itests-alliance/pom.xml
+++ b/distribution/test/itests/test-itests-alliance/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice.alliance.test.itests</groupId>
         <artifactId>itests</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>test-itests-alliance</artifactId>
     <name>Alliance :: Integration :: Test</name>

--- a/distribution/test/itests/test-itests-common/pom.xml
+++ b/distribution/test/itests/test-itests-common/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice.alliance.test.itests</groupId>
         <artifactId>itests</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>test-itests-common</artifactId>
     <name>Alliance :: Test :: Integration :: Common</name>

--- a/distribution/test/itests/test-itests-dependencies-app/pom.xml
+++ b/distribution/test/itests/test-itests-dependencies-app/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>itests</artifactId>
         <groupId>org.codice.alliance.test.itests</groupId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>test-itests-dependencies-app</artifactId>
     <name>Alliance :: Test :: Integration :: Dependencies App</name>

--- a/distribution/test/pom.xml
+++ b/distribution/test/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>distribution</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <groupId>org.codice.alliance.test</groupId>
     <artifactId>test</artifactId>

--- a/libs/klv/pom.xml
+++ b/libs/klv/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>libs</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/libs/klv/src/main/java/org/codice/alliance/libs/klv/FrameCenterKlvProcessor.java
+++ b/libs/klv/src/main/java/org/codice/alliance/libs/klv/FrameCenterKlvProcessor.java
@@ -15,9 +15,15 @@ package org.codice.alliance.libs.klv;
 
 import static org.apache.commons.lang3.Validate.notNull;
 
-import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.codice.alliance.libs.stanag4609.Stanag4609TransportStreamParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
 
 import ddf.catalog.data.Attribute;
 import ddf.catalog.data.Metacard;
@@ -26,14 +32,26 @@ import ddf.catalog.data.impl.AttributeImpl;
 /**
  * Uses {@link Stanag4609TransportStreamParser#FRAME_CENTER_LATITUDE} and
  * {@link Stanag4609TransportStreamParser#FRAME_CENTER_LONGITUDE} to generate a WKT LINESTRING
- * and store it in the metacard attribute {@link AttributeNameConstants#FRAME_CENTER}.
+ * and store it in the metacard attribute {@link AttributeNameConstants#FRAME_CENTER}. Callers must
+ * supply a {@link Configuration} that contains a postive (&gt;0) Integer for
+ * {@link Configuration#SUBSAMPLE_COUNT}.
  */
-public class FrameCenterKlvProcessor extends MultipleFieldKlvProcessor {
+public class FrameCenterKlvProcessor implements KlvProcessor {
+
+    public static final Integer MIN_SUBSAMPLE_COUNT = 1;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FrameCenterKlvProcessor.class);
 
     /**
      * The name of the metacard attribute being set.
      */
     private static final String ATTRIBUTE_NAME = AttributeNameConstants.FRAME_CENTER;
+
+    private static final ImmutableList<String> STANAG_FIELD_NAMES = ImmutableList.of(
+            Stanag4609TransportStreamParser.FRAME_CENTER_LATITUDE,
+            Stanag4609TransportStreamParser.FRAME_CENTER_LONGITUDE);
+
+    private static final int STANAG_FIELD_NAME_SIZE = STANAG_FIELD_NAMES.size();
 
     private final GeometryOperator geometryOperator;
 
@@ -45,8 +63,6 @@ public class FrameCenterKlvProcessor extends MultipleFieldKlvProcessor {
      * @param geometryOperator transform the Geometry object (e.g. simplify) (must be non-null)
      */
     public FrameCenterKlvProcessor(GeometryOperator geometryOperator) {
-        super(Arrays.asList(Stanag4609TransportStreamParser.FRAME_CENTER_LATITUDE,
-                Stanag4609TransportStreamParser.FRAME_CENTER_LONGITUDE));
         notNull(geometryOperator, "geometryOperator must be non-null");
         this.geometryOperator = geometryOperator;
     }
@@ -55,8 +71,7 @@ public class FrameCenterKlvProcessor extends MultipleFieldKlvProcessor {
         return geometryOperator;
     }
 
-    @Override
-    protected void doProcess(Attribute attribute, Metacard metacard) {
+    private void doProcess(Attribute attribute, Metacard metacard) {
 
         String wkt = GeometryUtility.attributeToLineString(attribute, geometryOperator);
 
@@ -67,8 +82,58 @@ public class FrameCenterKlvProcessor extends MultipleFieldKlvProcessor {
         metacard.setAttribute(new AttributeImpl(ATTRIBUTE_NAME, wkt));
     }
 
+    private void callFirstHandler(Metacard metacard, List<LatitudeLongitudeHandler> stanagHandlers,
+            Configuration configuration) {
+
+        Integer subsampleCount = (Integer) configuration.get(Configuration.SUBSAMPLE_COUNT);
+
+        stanagHandlers.stream()
+                .findFirst()
+                .ifPresent(handler -> handler.asSubsampledHandler(subsampleCount)
+                        .asAttribute()
+                        .ifPresent(attribute -> doProcess(attribute, metacard)));
+    }
+
+    /**
+     * All handlers are found if the number of handlers is the same as the number of field names.
+     */
+    private boolean areAllHandlersFound(List<LatitudeLongitudeHandler> stanagHandlers) {
+        return stanagHandlers.size() == STANAG_FIELD_NAME_SIZE;
+    }
+
+    private List<LatitudeLongitudeHandler> findKlvHandlers(Map<String, KlvHandler> handlers) {
+        return handlers.entrySet()
+                .stream()
+                .filter(stringKlvHandlerEntry -> stringKlvHandlerEntry.getValue() instanceof LatitudeLongitudeHandler)
+                .filter(entry -> STANAG_FIELD_NAMES.contains(entry.getKey()))
+                .map(Map.Entry::getValue)
+                .map(LatitudeLongitudeHandler.class::cast)
+                .collect(Collectors.toList());
+    }
+
     @Override
     public void accept(Visitor visitor) {
         visitor.visit(this);
     }
+
+    @Override
+    public final void process(Map<String, KlvHandler> handlers, Metacard metacard,
+            Configuration configuration) {
+
+        if (configuration.get(Configuration.SUBSAMPLE_COUNT) == null || (Integer) configuration.get(
+                Configuration.SUBSAMPLE_COUNT) < MIN_SUBSAMPLE_COUNT) {
+            LOGGER.debug(
+                    "the subsample count configuration is missing or incorrectly configured (the minimum subsample count is {}), skipping location klv processing",
+                    MIN_SUBSAMPLE_COUNT);
+            return;
+        }
+
+        List<LatitudeLongitudeHandler> stanagHandlers = findKlvHandlers(handlers);
+
+        if (areAllHandlersFound(stanagHandlers)) {
+            callFirstHandler(metacard, stanagHandlers, configuration);
+        }
+
+    }
+
 }

--- a/libs/klv/src/test/java/org/codice/alliance/libs/klv/FrameCenterKlvProcessorTest.java
+++ b/libs/klv/src/test/java/org/codice/alliance/libs/klv/FrameCenterKlvProcessorTest.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import org.codice.alliance.libs.stanag4609.Stanag4609TransportStreamParser;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import com.vividsolutions.jts.io.ParseException;
 import com.vividsolutions.jts.io.WKTReader;
@@ -53,8 +54,9 @@ public class FrameCenterKlvProcessorTest {
         frameCenterKlvProcessor = new FrameCenterKlvProcessor();
         attribute = mock(Attribute.class);
 
-        KlvHandler klvHandler = mock(KlvHandler.class);
+        LatitudeLongitudeHandler klvHandler = mock(LatitudeLongitudeHandler.class);
         when(klvHandler.asAttribute()).thenReturn(Optional.of(attribute));
+        when(klvHandler.asSubsampledHandler(Mockito.anyInt())).thenCallRealMethod();
 
         handlerMap = new HashMap<>();
         handlerMap.put(Stanag4609TransportStreamParser.FRAME_CENTER_LATITUDE, klvHandler);
@@ -79,6 +81,7 @@ public class FrameCenterKlvProcessorTest {
         Metacard metacard = new MetacardImpl();
 
         KlvProcessor.Configuration configuration = new KlvProcessor.Configuration();
+        configuration.set(KlvProcessor.Configuration.SUBSAMPLE_COUNT, 100);
 
         frameCenterKlvProcessor.process(handlerMap, metacard, configuration);
 

--- a/libs/mpegts/pom.xml
+++ b/libs/mpegts/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>libs</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/libs/pom-fix-run/pom.xml
+++ b/libs/pom-fix-run/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>libs</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>pom-fix-run</artifactId>
     <packaging>pom</packaging>

--- a/libs/pom.xml
+++ b/libs/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>alliance</artifactId>
         <groupId>org.codice</groupId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/libs/stanag4609/pom.xml
+++ b/libs/stanag4609/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>libs</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.codice</groupId>
     <artifactId>alliance</artifactId>
-    <version>0.2-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Alliance</name>
     <description>Codice Alliance</description>
@@ -37,7 +37,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <ddf.version>2.10.0-SNAPSHOT</ddf.version>
+        <ddf.version>2.11.0-SNAPSHOT</ddf.version>
         <ddf.support.version>2.3.6</ddf.support.version>
         <ddf.scm.connection.url/>
         <snapshots.repository.url/>

--- a/support/pom.xml
+++ b/support/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice</groupId>
         <artifactId>alliance</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>support</artifactId>

--- a/support/support-checkstyle/pom.xml
+++ b/support/support-checkstyle/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>support</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.codice.alliance</groupId>


### PR DESCRIPTION
#### What does this PR do?

* subsample the frame-center data in child metacards
* do not merge frame-center data from the child metacards to the parent
* convert the subpolygons in the parent location geometry to envelopes (ConvertSubpolygonsToEnvelopes.java)

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@bdeining 
@jlcsmith 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@lessarderic
#### How should this be tested?
Test child frame center: ingest an MPEG-TS video that contains frame center data. Examine the resulting metacard and verify that the number of frame center data points is less than or equal to the subsample configuration (default is 50).

Test parent metacard does not have frame center: ingest a streaming video that contains frame center data. Examine the parent metacard and verify that the frame center field is not present.

Test subpolygons: ingest a streaming video that contains location data. Examine the parent metacard and verify that if the location is a multipolygon, then it's subpolygons are rectangular (this can be complicated because of the subpolygons get unioned).

#### Any background context you want to provide?

If the reviews decide that the subpolygon feature is not wanted, then it's a simple blueprint change to disable it.

#### What are the relevant tickets?

[CAL-255](https://codice.atlassian.net/browse/CAL-255)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

