### PR TITLE
CAL-255 (Backport 0.2.x) Improve FMV ingest performance.

### DIFF
--- a/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/netty/UdpStreamProcessor.java
+++ b/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/netty/UdpStreamProcessor.java
@@ -26,6 +26,7 @@ import java.util.Timer;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.Validate;
+import org.codice.alliance.libs.klv.ConvertSubpolygonsToEnvelopes;
 import org.codice.alliance.libs.klv.GeometryOperator;
 import org.codice.alliance.libs.klv.GeometryReducer;
 import org.codice.alliance.libs.klv.NormalizeGeometry;
@@ -152,6 +153,11 @@ public class UdpStreamProcessor implements StreamProcessor {
 
             @Override
             public void visit(NormalizeGeometry function) {
+
+            }
+
+            @Override
+            public void visit(ConvertSubpolygonsToEnvelopes convertSubpolygonsToEnvelopes) {
 
             }
         };

--- a/catalog/video/video-mpegts-stream/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/video/video-mpegts-stream/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -35,6 +35,7 @@
                 <bean class="org.codice.alliance.libs.klv.SimplifyGeometryFunction">
                     <argument value="0.0001"/>
                 </bean>
+                <bean class="org.codice.alliance.libs.klv.ConvertSubpolygonsToEnvelopes"/>
                 <bean class="org.codice.alliance.libs.klv.NormalizeGeometry"/>
             </list>
         </argument>
@@ -134,21 +135,6 @@
                             <bean class="org.codice.alliance.video.stream.mpegts.metacard.TemporalEndMetacardUpdater"/>
                             <bean class="org.codice.alliance.video.stream.mpegts.metacard.CreatedDateMetacardUpdater"/>
                             <bean class="org.codice.alliance.video.stream.mpegts.metacard.ModifiedDateMetacardUpdater"/>
-                            <bean class="org.codice.alliance.video.stream.mpegts.metacard.FrameCenterMetacardUpdater">
-                                <argument>
-                                    <bean class="org.codice.alliance.libs.klv.GeometryOperatorList">
-                                        <argument>
-                                            <list>
-                                                <bean class="org.codice.alliance.libs.klv.SimplifyGeometryFunction">
-                                                    <argument value="0.0001"/>
-                                                </bean>
-                                                <bean class="org.codice.alliance.libs.klv.NormalizeGeometry"/>
-                                                <bean class="org.codice.alliance.libs.klv.GeometryReducer"/>
-                                            </list>
-                                        </argument>
-                                    </bean>
-                                </argument>
-                            </bean>
                             <bean class="org.codice.alliance.video.stream.mpegts.metacard.MediaEncodingMetacardUpdater"/>
                             <bean class="org.codice.alliance.video.stream.mpegts.metacard.MissionIdMetacardUpdater"/>
                             <bean class="org.codice.alliance.video.stream.mpegts.metacard.PlatformIdMetacardUpdater"/>

--- a/catalog/video/video-mpegts-transformer/src/main/java/org/codice/alliance/transformer/video/SetDistanceToleranceVisitor.java
+++ b/catalog/video/video-mpegts-transformer/src/main/java/org/codice/alliance/transformer/video/SetDistanceToleranceVisitor.java
@@ -14,6 +14,7 @@
 package org.codice.alliance.transformer.video;
 
 import org.codice.alliance.libs.klv.BaseKlvProcessorVisitor;
+import org.codice.alliance.libs.klv.ConvertSubpolygonsToEnvelopes;
 import org.codice.alliance.libs.klv.FrameCenterKlvProcessor;
 import org.codice.alliance.libs.klv.GeometryOperator;
 import org.codice.alliance.libs.klv.GeometryReducer;
@@ -44,6 +45,11 @@ class SetDistanceToleranceVisitor extends BaseKlvProcessorVisitor {
 
                 @Override
                 public void visit(NormalizeGeometry function) {
+
+                }
+
+                @Override
+                public void visit(ConvertSubpolygonsToEnvelopes convertSubpolygonsToEnvelopes) {
 
                 }
             };

--- a/libs/klv/pom.xml
+++ b/libs/klv/pom.xml
@@ -163,17 +163,17 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.86</minimum>
+                                            <minimum>0.88</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.65</minimum>
+                                            <minimum>0.68</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.65</minimum>
+                                            <minimum>0.67</minimum>
                                         </limit>
 
                                     </limits>

--- a/libs/klv/src/main/java/org/codice/alliance/libs/klv/FrameCenterKlvProcessor.java
+++ b/libs/klv/src/main/java/org/codice/alliance/libs/klv/FrameCenterKlvProcessor.java
@@ -71,6 +71,31 @@ public class FrameCenterKlvProcessor implements KlvProcessor {
         return geometryOperator;
     }
 
+    @Override
+    public void accept(Visitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public final void process(Map<String, KlvHandler> handlers, Metacard metacard,
+            Configuration configuration) {
+
+        if (configuration.get(Configuration.SUBSAMPLE_COUNT) == null || (Integer) configuration.get(
+                Configuration.SUBSAMPLE_COUNT) < MIN_SUBSAMPLE_COUNT) {
+            LOGGER.debug(
+                    "the subsample count configuration is missing or incorrectly configured (the minimum subsample count is {}), skipping location klv processing",
+                    MIN_SUBSAMPLE_COUNT);
+            return;
+        }
+
+        List<LatitudeLongitudeHandler> stanagHandlers = findKlvHandlers(handlers);
+
+        if (areAllHandlersFound(stanagHandlers)) {
+            callFirstHandler(metacard, stanagHandlers, configuration);
+        }
+
+    }
+
     private void doProcess(Attribute attribute, Metacard metacard) {
 
         String wkt = GeometryUtility.attributeToLineString(attribute, geometryOperator);
@@ -109,31 +134,6 @@ public class FrameCenterKlvProcessor implements KlvProcessor {
                 .map(Map.Entry::getValue)
                 .map(LatitudeLongitudeHandler.class::cast)
                 .collect(Collectors.toList());
-    }
-
-    @Override
-    public void accept(Visitor visitor) {
-        visitor.visit(this);
-    }
-
-    @Override
-    public final void process(Map<String, KlvHandler> handlers, Metacard metacard,
-            Configuration configuration) {
-
-        if (configuration.get(Configuration.SUBSAMPLE_COUNT) == null || (Integer) configuration.get(
-                Configuration.SUBSAMPLE_COUNT) < MIN_SUBSAMPLE_COUNT) {
-            LOGGER.debug(
-                    "the subsample count configuration is missing or incorrectly configured (the minimum subsample count is {}), skipping location klv processing",
-                    MIN_SUBSAMPLE_COUNT);
-            return;
-        }
-
-        List<LatitudeLongitudeHandler> stanagHandlers = findKlvHandlers(handlers);
-
-        if (areAllHandlersFound(stanagHandlers)) {
-            callFirstHandler(metacard, stanagHandlers, configuration);
-        }
-
     }
 
 }

--- a/libs/klv/src/main/java/org/codice/alliance/libs/klv/FrameCenterKlvProcessor.java
+++ b/libs/klv/src/main/java/org/codice/alliance/libs/klv/FrameCenterKlvProcessor.java
@@ -15,9 +15,15 @@ package org.codice.alliance.libs.klv;
 
 import static org.apache.commons.lang3.Validate.notNull;
 
-import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.codice.alliance.libs.stanag4609.Stanag4609TransportStreamParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
 
 import ddf.catalog.data.Attribute;
 import ddf.catalog.data.Metacard;
@@ -26,14 +32,26 @@ import ddf.catalog.data.impl.AttributeImpl;
 /**
  * Uses {@link Stanag4609TransportStreamParser#FRAME_CENTER_LATITUDE} and
  * {@link Stanag4609TransportStreamParser#FRAME_CENTER_LONGITUDE} to generate a WKT LINESTRING
- * and store it in the metacard attribute {@link AttributeNameConstants#FRAME_CENTER}.
+ * and store it in the metacard attribute {@link AttributeNameConstants#FRAME_CENTER}. Callers must
+ * supply a {@link Configuration} that contains a postive (&gt;0) Integer for
+ * {@link Configuration#SUBSAMPLE_COUNT}.
  */
-public class FrameCenterKlvProcessor extends MultipleFieldKlvProcessor {
+public class FrameCenterKlvProcessor implements KlvProcessor {
+
+    public static final Integer MIN_SUBSAMPLE_COUNT = 1;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FrameCenterKlvProcessor.class);
 
     /**
      * The name of the metacard attribute being set.
      */
     private static final String ATTRIBUTE_NAME = AttributeNameConstants.FRAME_CENTER;
+
+    private static final ImmutableList<String> STANAG_FIELD_NAMES = ImmutableList.of(
+            Stanag4609TransportStreamParser.FRAME_CENTER_LATITUDE,
+            Stanag4609TransportStreamParser.FRAME_CENTER_LONGITUDE);
+
+    private static final int STANAG_FIELD_NAME_SIZE = STANAG_FIELD_NAMES.size();
 
     private final GeometryOperator geometryOperator;
 
@@ -45,8 +63,6 @@ public class FrameCenterKlvProcessor extends MultipleFieldKlvProcessor {
      * @param geometryOperator transform the Geometry object (e.g. simplify) (must be non-null)
      */
     public FrameCenterKlvProcessor(GeometryOperator geometryOperator) {
-        super(Arrays.asList(Stanag4609TransportStreamParser.FRAME_CENTER_LATITUDE,
-                Stanag4609TransportStreamParser.FRAME_CENTER_LONGITUDE));
         notNull(geometryOperator, "geometryOperator must be non-null");
         this.geometryOperator = geometryOperator;
     }
@@ -55,8 +71,7 @@ public class FrameCenterKlvProcessor extends MultipleFieldKlvProcessor {
         return geometryOperator;
     }
 
-    @Override
-    protected void doProcess(Attribute attribute, Metacard metacard) {
+    private void doProcess(Attribute attribute, Metacard metacard) {
 
         String wkt = GeometryUtility.attributeToLineString(attribute, geometryOperator);
 
@@ -67,8 +82,58 @@ public class FrameCenterKlvProcessor extends MultipleFieldKlvProcessor {
         metacard.setAttribute(new AttributeImpl(ATTRIBUTE_NAME, wkt));
     }
 
+    private void callFirstHandler(Metacard metacard, List<LatitudeLongitudeHandler> stanagHandlers,
+            Configuration configuration) {
+
+        Integer subsampleCount = (Integer) configuration.get(Configuration.SUBSAMPLE_COUNT);
+
+        stanagHandlers.stream()
+                .findFirst()
+                .ifPresent(handler -> handler.asSubsampledHandler(subsampleCount)
+                        .asAttribute()
+                        .ifPresent(attribute -> doProcess(attribute, metacard)));
+    }
+
+    /**
+     * All handlers are found if the number of handlers is the same as the number of field names.
+     */
+    private boolean areAllHandlersFound(List<LatitudeLongitudeHandler> stanagHandlers) {
+        return stanagHandlers.size() == STANAG_FIELD_NAME_SIZE;
+    }
+
+    private List<LatitudeLongitudeHandler> findKlvHandlers(Map<String, KlvHandler> handlers) {
+        return handlers.entrySet()
+                .stream()
+                .filter(stringKlvHandlerEntry -> stringKlvHandlerEntry.getValue() instanceof LatitudeLongitudeHandler)
+                .filter(entry -> STANAG_FIELD_NAMES.contains(entry.getKey()))
+                .map(Map.Entry::getValue)
+                .map(LatitudeLongitudeHandler.class::cast)
+                .collect(Collectors.toList());
+    }
+
     @Override
     public void accept(Visitor visitor) {
         visitor.visit(this);
     }
+
+    @Override
+    public final void process(Map<String, KlvHandler> handlers, Metacard metacard,
+            Configuration configuration) {
+
+        if (configuration.get(Configuration.SUBSAMPLE_COUNT) == null || (Integer) configuration.get(
+                Configuration.SUBSAMPLE_COUNT) < MIN_SUBSAMPLE_COUNT) {
+            LOGGER.debug(
+                    "the subsample count configuration is missing or incorrectly configured (the minimum subsample count is {}), skipping location klv processing",
+                    MIN_SUBSAMPLE_COUNT);
+            return;
+        }
+
+        List<LatitudeLongitudeHandler> stanagHandlers = findKlvHandlers(handlers);
+
+        if (areAllHandlersFound(stanagHandlers)) {
+            callFirstHandler(metacard, stanagHandlers, configuration);
+        }
+
+    }
+
 }

--- a/libs/klv/src/test/java/org/codice/alliance/libs/klv/ConvertSubpolygonsToEnvelopesTest.java
+++ b/libs/klv/src/test/java/org/codice/alliance/libs/klv/ConvertSubpolygonsToEnvelopesTest.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.libs.klv;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.io.ParseException;
+import com.vividsolutions.jts.io.WKTReader;
+
+public class ConvertSubpolygonsToEnvelopesTest {
+
+    @Test
+    public void testSingleSubpolygon() throws ParseException {
+
+        String wkt = "POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))";
+
+        WKTReader wktReader = new WKTReader();
+
+        Geometry geometry = wktReader.read(wkt);
+
+        ConvertSubpolygonsToEnvelopes convertSubpolygonsToEnvelopes =
+                new ConvertSubpolygonsToEnvelopes();
+
+        Geometry actual = convertSubpolygonsToEnvelopes.apply(geometry);
+
+        assertThat(actual, is(geometry));
+
+    }
+
+    @Test
+    public void testTwoSubpolygons() throws ParseException {
+
+        String wkt =
+                "MULTIPOLYGON (((0 0, 2 10, 10 20, 20 20, 20 0, 0 0)),((0 40, 2 50, 10 60, 20 60, 20 40, 0 40)))";
+
+        WKTReader wktReader = new WKTReader();
+
+        Geometry geometry = wktReader.read(wkt);
+
+        ConvertSubpolygonsToEnvelopes convertSubpolygonsToEnvelopes =
+                new ConvertSubpolygonsToEnvelopes();
+
+        Geometry actual = convertSubpolygonsToEnvelopes.apply(geometry);
+
+        Geometry expected = wktReader.read(
+                "MULTIPOLYGON (((0 0, 0 20, 20 20, 20 0, 0 0)), ((0 40, 0 60, 20 60, 20 40, 0 40)))");
+
+        assertThat(actual, is(expected));
+
+    }
+
+    @Test
+    public void testAccept() {
+
+        GeometryOperator.Visitor visitor = mock(GeometryOperator.Visitor.class);
+
+        ConvertSubpolygonsToEnvelopes convertSubpolygonsToEnvelopes =
+                new ConvertSubpolygonsToEnvelopes();
+
+        convertSubpolygonsToEnvelopes.accept(visitor);
+
+        verify(visitor).visit(convertSubpolygonsToEnvelopes);
+
+    }
+
+}

--- a/libs/klv/src/test/java/org/codice/alliance/libs/klv/FrameCenterKlvProcessorTest.java
+++ b/libs/klv/src/test/java/org/codice/alliance/libs/klv/FrameCenterKlvProcessorTest.java
@@ -15,7 +15,9 @@ package org.codice.alliance.libs.klv;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -61,6 +63,52 @@ public class FrameCenterKlvProcessorTest {
         handlerMap = new HashMap<>();
         handlerMap.put(Stanag4609TransportStreamParser.FRAME_CENTER_LATITUDE, klvHandler);
         handlerMap.put(Stanag4609TransportStreamParser.FRAME_CENTER_LONGITUDE, klvHandler);
+    }
+
+    /**
+     * FrameCenterKlvProcessor requires that the configuration object contain the subsample count.
+     * Make sure it returns without processing. The results of this test are only valid if
+     * {@link #testOneCoordinate()} and {@link #testMultipleCoordinates()} pass.
+     */
+    @Test
+    public void testMissingSubsampleConfiguration() {
+
+        when(attribute.getValues()).thenReturn(Arrays.asList("POINT(0 0)",
+                "POINT(1 1)",
+                "POINT(2 2)"));
+
+        Metacard metacard = mock(Metacard.class);
+
+        KlvProcessor.Configuration configuration = new KlvProcessor.Configuration();
+
+        frameCenterKlvProcessor.process(handlerMap, metacard, configuration);
+
+        verify(metacard, times(0)).setAttribute(any());
+
+    }
+
+    /**
+     * FrameCenterKlvProcessor requires that the configuration object contains a subsample count
+     * >= {@link FrameCenterKlvProcessor#MIN_SUBSAMPLE_COUNT}. Make sure it returns without processing.
+     * The results of this test are only valid if {@link #testOneCoordinate()} and
+     * {@link #testMultipleCoordinates()} pass.
+     */
+    @Test
+    public void testMinSubsampleConfiguration() {
+
+        when(attribute.getValues()).thenReturn(Arrays.asList("POINT(0 0)",
+                "POINT(1 1)",
+                "POINT(2 2)"));
+
+        Metacard metacard = mock(Metacard.class);
+
+        KlvProcessor.Configuration configuration = new KlvProcessor.Configuration();
+        configuration.set(KlvProcessor.Configuration.SUBSAMPLE_COUNT,
+                FrameCenterKlvProcessor.MIN_SUBSAMPLE_COUNT - 1);
+
+        frameCenterKlvProcessor.process(handlerMap, metacard, configuration);
+
+        verify(metacard, times(0)).setAttribute(any());
     }
 
     @Test

--- a/libs/klv/src/test/java/org/codice/alliance/libs/klv/FrameCenterKlvProcessorTest.java
+++ b/libs/klv/src/test/java/org/codice/alliance/libs/klv/FrameCenterKlvProcessorTest.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import org.codice.alliance.libs.stanag4609.Stanag4609TransportStreamParser;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import com.vividsolutions.jts.io.ParseException;
 import com.vividsolutions.jts.io.WKTReader;
@@ -53,8 +54,9 @@ public class FrameCenterKlvProcessorTest {
         frameCenterKlvProcessor = new FrameCenterKlvProcessor();
         attribute = mock(Attribute.class);
 
-        KlvHandler klvHandler = mock(KlvHandler.class);
+        LatitudeLongitudeHandler klvHandler = mock(LatitudeLongitudeHandler.class);
         when(klvHandler.asAttribute()).thenReturn(Optional.of(attribute));
+        when(klvHandler.asSubsampledHandler(Mockito.anyInt())).thenCallRealMethod();
 
         handlerMap = new HashMap<>();
         handlerMap.put(Stanag4609TransportStreamParser.FRAME_CENTER_LATITUDE, klvHandler);
@@ -79,6 +81,7 @@ public class FrameCenterKlvProcessorTest {
         Metacard metacard = new MetacardImpl();
 
         KlvProcessor.Configuration configuration = new KlvProcessor.Configuration();
+        configuration.set(KlvProcessor.Configuration.SUBSAMPLE_COUNT, 100);
 
         frameCenterKlvProcessor.process(handlerMap, metacard, configuration);
 


### PR DESCRIPTION
#### What does this PR do?

* subsample the frame-center data in child metacards
* do not merge frame-center data from the child metacards to the parent
* convert the subpolygons in the parent location geometry to envelopes (ConvertSubpolygonsToEnvelopes.java)

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@bdeining 
@jlcsmith 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire
@lessarderic
#### How should this be tested?
Test child frame center: ingest an MPEG-TS video that contains frame center data. Examine the resulting metacard and verify that the number of frame center data points is less than or equal to the subsample configuration (default is 50).

Test parent metacard does not have frame center: ingest a streaming video that contains frame center data. Examine the parent metacard and verify that the frame center field is not present.

Test subpolygons: ingest a streaming video that contains location data. Examine the parent metacard and verify that if the location is a multipolygon, then it's subpolygons are rectangular (this can be complicated because of the subpolygons get unioned).

#### Any background context you want to provide?

If the reviews decide that the subpolygon feature is not wanted, then it's a simple blueprint change to disable it.

#### What are the relevant tickets?

[CAL-255](https://codice.atlassian.net/browse/CAL-255)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
