### PR TITLE
CAL-257: Fixes documentation activation bug

### DIFF
--- a/distribution/alliance/pom.xml
+++ b/distribution/alliance/pom.xml
@@ -401,7 +401,10 @@ org.codice.alliance.corba_default_port=2809</concat>
         <profile>
             <id>documentation</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>skipDocs</name>
+                    <value>!true</value>
+                </property>
             </activation>
             <build>
                 <plugins>

--- a/distribution/docs/pom.xml
+++ b/distribution/docs/pom.xml
@@ -51,7 +51,10 @@
         <profile>
             <id>documentation</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>skipDocs</name>
+                    <value>!true</value>
+                </property>
             </activation>
             <properties>
                 <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -308,54 +308,6 @@
                                 <goal>prepare-agent</goal>
                             </goals>
                         </execution>
-                        <execution>
-                            <id>default-report</id>
-                            <phase>prepare-package</phase>
-                            <configuration>
-                                <outputDirectory>
-                                    ${project.build.directory}/site/${project.report.output.directory}/jacoco/
-                                </outputDirectory>
-                            </configuration>
-                            <goals>
-                                <goal>report</goal>
-                            </goals>
-                        </execution>
-                        <execution>
-                            <id>default-check</id>
-                            <goals>
-                                <goal>check</goal>
-                            </goals>
-                            <configuration>
-                                <haltOnFailure>true</haltOnFailure>
-                                <rules>
-                                    <rule>
-                                        <element>BUNDLE</element>
-                                        <!--
-                                        When overriding the limits in child pom files make sure
-                                        to override all four limits. Limits that are excluded
-                                        will be set to 0 not 0.75
-                                        -->
-                                        <limits>
-                                            <limit>
-                                                <counter>INSTRUCTION</counter>
-                                                <value>COVEREDRATIO</value>
-                                                <minimum>0.75</minimum>
-                                            </limit>
-                                            <limit>
-                                                <counter>BRANCH</counter>
-                                                <value>COVEREDRATIO</value>
-                                                <minimum>0.75</minimum>
-                                            </limit>
-                                            <limit>
-                                                <counter>COMPLEXITY</counter>
-                                                <value>COVEREDRATIO</value>
-                                                <minimum>0.75</minimum>
-                                            </limit>
-                                        </limits>
-                                    </rule>
-                                </rules>
-                            </configuration>
-                        </execution>
                     </executions>
                 </plugin>
                 <plugin>
@@ -409,29 +361,167 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <!--  We don't want to inherit this *change* to the plugin configuration. -->
-                <!--  Sub modules will still inherit the plugin and the configuration from pluginManagment -->
-                <inherited>false</inherited>
-                <executions>
-                    <execution>
-                        <!-- Match the execution defined in the pluginManagment and override it-->
-                        <!-- Prev check here. -->
-                        <id>checkstyle-check</id>
-                        <phase>none</phase>
-                    </execution>
-                    <execution>
-                        <id>checkstyle-check-xml</id>
-                        <phase>none</phase>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
-
     <profiles>
+        <profile>
+            <id>staticAnalysis</id>
+            <activation>
+                <property>
+                    <name>skipStatic</name>
+                    <value>!true</value>
+                </property>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-checkstyle-plugin</artifactId>
+                            <version>2.17</version>
+                            <dependencies>
+                                <dependency>
+                                    <groupId>ddf.support</groupId>
+                                    <artifactId>support-checkstyle</artifactId>
+                                    <version>${ddf.support.version}</version>
+                                    <optional>true</optional>
+                                </dependency>
+                            </dependencies>
+                            <executions>
+                                <execution>
+                                    <id>checkstyle-check</id>
+                                    <phase>verify</phase>
+                                    <goals>
+                                        <goal>check</goal>
+                                    </goals>
+                                    <configuration>
+                                        <!-- This configures the plugin for mvn install -->
+                                        <configLocation>checkstyle-enforced.xml</configLocation>
+                                        <headerLocation>lpgl-header-check.txt</headerLocation>
+                                        <sourceDirectory>${basedir}</sourceDirectory>
+                                        <includes>src/**/*.java</includes>
+                                        <consoleOutput>true</consoleOutput>
+                                        <failsOnError>true</failsOnError>
+                                        <linkXRef>false</linkXRef>
+                                        <aggregate>true</aggregate>
+                                    </configuration>
+                                </execution>
+                                <execution>
+                                    <id>checkstyle-check-xml</id>
+                                    <phase>verify</phase>
+                                    <goals>
+                                        <goal>check</goal>
+                                    </goals>
+                                    <configuration>
+                                        <!-- This configures the plugin for mvn install -->
+                                        <configLocation>checkstyle-enforced-xml.xml</configLocation>
+                                        <headerLocation>lpgl-header-check-xml.txt</headerLocation>
+                                        <sourceDirectory>${basedir}</sourceDirectory>
+                                        <includes>src/**/*.xml, pom.xml</includes>
+                                        <consoleOutput>true</consoleOutput>
+                                        <failsOnError>true</failsOnError>
+                                        <linkXRef>false</linkXRef>
+                                        <aggregate>true</aggregate>
+                                    </configuration>
+                                </execution>
+                            </executions>
+                            <configuration>
+                                <!-- This configures the plugin for mvn checkstyle:checkstyle  -->
+                                <configLocation>checkstyle-enforced.xml</configLocation>
+                                <headerLocation>lpgl-header-check.txt</headerLocation>
+                                <sourceDirectory>${basedir}</sourceDirectory>
+                                <includes>src/**/*.java</includes>
+                                <consoleOutput>true</consoleOutput>
+                                <failsOnError>true</failsOnError>
+                                <linkXRef>false</linkXRef>
+                                <aggregate>true</aggregate>
+                            </configuration>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.jacoco</groupId>
+                            <artifactId>jacoco-maven-plugin</artifactId>
+                            <executions>
+                                <execution>
+                                    <id>default-prepare-agent</id>
+                                    <goals>
+                                        <goal>prepare-agent</goal>
+                                    </goals>
+                                </execution>
+                                <execution>
+                                    <id>default-report</id>
+                                    <phase>prepare-package</phase>
+                                    <configuration>
+                                        <outputDirectory>
+                                            ${project.build.directory}/site/${project.report.output.directory}/jacoco/
+                                        </outputDirectory>
+                                    </configuration>
+                                    <goals>
+                                        <goal>report</goal>
+                                    </goals>
+                                </execution>
+                                <execution>
+                                    <id>default-check</id>
+                                    <goals>
+                                        <goal>check</goal>
+                                    </goals>
+                                    <configuration>
+                                        <haltOnFailure>true</haltOnFailure>
+                                        <rules>
+                                            <rule>
+                                                <element>BUNDLE</element>
+                                                <!--
+                                                When overriding the limits in child pom files make sure
+                                                to override all three limits. Limits that are excluded
+                                                will be set to 0 not 0.75
+                                                -->
+                                                <limits>
+                                                    <limit>
+                                                        <counter>INSTRUCTION</counter>
+                                                        <value>COVEREDRATIO</value>
+                                                        <minimum>0.75</minimum>
+                                                    </limit>
+                                                    <limit>
+                                                        <counter>BRANCH</counter>
+                                                        <value>COVEREDRATIO</value>
+                                                        <minimum>0.75</minimum>
+                                                    </limit>
+                                                    <limit>
+                                                        <counter>COMPLEXITY</counter>
+                                                        <value>COVEREDRATIO</value>
+                                                        <minimum>0.75</minimum>
+                                                    </limit>
+                                                </limits>
+                                            </rule>
+                                        </rules>
+                                    </configuration>
+                                </execution>
+                            </executions>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-checkstyle-plugin</artifactId>
+                        <!--  We don't want to inherit this *change* to the plugin configuration. -->
+                        <!--  Sub modules will still inherit the plugin and the configuration from pluginManagment -->
+                        <inherited>false</inherited>
+                        <executions>
+                            <execution>
+                                <!-- Match the execution defined in the pluginManagment and override it-->
+                                <!-- Prev check here. -->
+                                <id>checkstyle-check</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>checkstyle-check-xml</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>release</id>
             <activation>


### PR DESCRIPTION
Backport of https://github.com/codice/alliance/pull/257

_distribution/alliance/pom.xml, distribution/docs/pom.xml_
Changes the documentation profile to be activated when the property “skipDocs” is false or not provided. (Reference an example here: http://maven.apache.org/guides/introduction/introduction-to-profiles.html). This was done to prevent issues with profile activation that were happening. 
From the Maven website, emphasis mine:
_[A profile using `<activeByDefault>`] will automatically be active for all builds unless another profile **in the same POM** is activated using one of the previously described methods. All profiles that are active by default are **automatically deactivated when a profile in the POM is activated** on the command line or through its activation config._

@lessarderic @coyotesqrl 