### PR TITLE
CAL-261 Add maven-version-validation-plugin to root pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <ddf.version>2.11.0-SNAPSHOT</ddf.version>
-        <ddf.support.version>2.3.6</ddf.support.version>
+        <ddf.support.version>2.3.7-SNAPSHOT</ddf.support.version>
         <ddf.scm.connection.url/>
         <snapshots.repository.url/>
         <reports.repository.url/>
@@ -543,6 +543,25 @@
                                 <phase>none</phase>
                             </execution>
                         </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>ddf.support</groupId>
+                        <artifactId>version-validation-plugin</artifactId>
+                        <version>${ddf.support.version}</version>
+                        <executions>
+                            <execution>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>check-package-json</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <whitelistedValues>
+                                <param>-beta</param>
+                                <param>#</param>
+                            </whitelistedValues>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
#### What does this PR do?
Enables a ddf-support maven plugin which scans the project at build for any package.json files which incorrectly use version ranges for dependencies.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@ahoffer @emanns95 @AzGoalie @vinamartin 

#### Select at least one member from relevant component team(s) from below (at least one component team member needs to approve the PR).
[Build](https://github.com/orgs/codice/teams/build)

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@pklinef

#### How should this be tested? (List steps with links to updated documentation)
Will need to pull in ddf-support PR as well (https://github.com/codice/ddf-support/pull/38) for the actual plugin, and then run `mvn verify` in Alliance. Successful if verify errors out with a MojoException due to incorrect version range symbols. 

#### Any background context you want to provide?
Version ranges expose the codebase to potential vulnerabilities, unlike sticking to exact, known versions of dependencies. 

#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/DDF-2819)
[](https://codice.atlassian.net/browse/CAL-261)

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
