### PR TITLE
CAL-258 -Port- Fix dependencies in imaging-transformer-nitf.

### DIFF
--- a/catalog/imaging/imaging-transformer-nitf/pom.xml
+++ b/catalog/imaging/imaging-transformer-nitf/pom.xml
@@ -72,6 +72,11 @@
 
         <dependency>
             <groupId>org.codice.imaging.nitf</groupId>
+            <artifactId>codice-imaging-nitf-render</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codice.imaging.nitf</groupId>
             <artifactId>codice-imaging-nitf-fluent-api</artifactId>
             <version>${nitf-imaging.version}</version>
         </dependency>
@@ -85,6 +90,18 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core</artifactId>
             <version>${camel.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.jai-imageio</groupId>
+            <artifactId>jai-imageio-core</artifactId>
+            <version>${jai-imageio-core.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.jai-imageio</groupId>
+            <artifactId>jai-imageio-jpeg2000</artifactId>
+            <version>${jpeg2000.version}</version>
         </dependency>
 
         <!--Spock dependencies-->
@@ -115,7 +132,10 @@
                             catalog-core-api-impl,
                             platform-util,
                             codice-imaging-nitf-core,
+                            codice-imaging-nitf-render,
                             codice-imaging-nitf-fluent-api,
+                            jai-imageio-core,
+                            jai-imageio-jpeg2000,
                             commons-lang3
                         </Embed-Dependency>
                         <Export-Package/>


### PR DESCRIPTION
(cherry picked from commit 52a4b11)

#### What does this PR do?
Port for https://github.com/codice/alliance/pull/267
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@bdeining @emmberk 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@jlcsmith
@kcwire

#### How should this be tested?
Verify itests pass
#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-258](https://codice.atlassian.net/browse/CAL-258)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
