### PR TITLE
(0.2.x) CAL-263: Changed isr.mission-id to be multi-valued

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/org/codice/alliance/catalog/core/api/impl/types/IsrAttributes.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/org/codice/alliance/catalog/core/api/impl/types/IsrAttributes.java
@@ -103,7 +103,7 @@ public class IsrAttributes implements Isr, MetacardType {
                 true /* indexed */,
                 true /* stored */,
                 true /* tokenized */,
-                false /* multivalued */,
+                true /* multivalued */,
                 BasicTypes.STRING_TYPE));
         DESCRIPTORS.add(new AttributeDescriptorImpl(NATO_REPORTING_CODE,
                 true /* indexed */,


### PR DESCRIPTION
#### What does this PR do?
backport of https://github.com/codice/alliance/pull/270

Updates isr.mission-id to be multi-valued
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@bdeining @brendan-hofmann 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@kcwire

#### How should this be tested?
#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-263](https://codice.atlassian.net/browse/CAL-263)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
