### PR TITLE
CAL-264 Fix ImagingTest startup by waiting for endpoint

### DIFF
--- a/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/ImagingTest.java
+++ b/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/ImagingTest.java
@@ -78,7 +78,7 @@ public class ImagingTest extends AbstractAllianceIntegrationTest {
             getServiceManager().startFeature(true, "nitf-render-plugin");
             getCatalogBundle().waitForCatalogProvider();
             getServiceManager().waitForHttpEndpoint(REST_PATH.getUrl()+"query");
-            configureSecurityStsClient();
+            //configureSecurityStsClient();
             getServiceManager().waitForAllBundles();
         } catch (Exception e) {
             LOGGER.error("Failed in @BeforeExam: ", e);

--- a/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/ImagingTest.java
+++ b/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/ImagingTest.java
@@ -77,7 +77,9 @@ public class ImagingTest extends AbstractAllianceIntegrationTest {
             getServiceManager().waitForAllBundles();
             getServiceManager().startFeature(true, "nitf-render-plugin");
             getCatalogBundle().waitForCatalogProvider();
+            getServiceManager().waitForHttpEndpoint(REST_PATH.getUrl()+"query");
             configureSecurityStsClient();
+            getServiceManager().waitForAllBundles();
         } catch (Exception e) {
             LOGGER.error("Failed in @BeforeExam: ", e);
             fail("Failed in @BeforeExam: " + e.getMessage());
@@ -408,6 +410,8 @@ public class ImagingTest extends AbstractAllianceIntegrationTest {
         byte[] fileBytes = IOUtils.toByteArray(inputStream);
 
         String id = given().multiPart("file", fileName, fileBytes, "image/nitf")
+                .auth()
+                .basic("localhost", "localhost")
                 .expect()
                 .statusCode(HttpStatus.SC_CREATED)
                 .when()


### PR DESCRIPTION
#### What does this PR do?
This is just to test if this fix will work on jenkins
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

#### How should this be tested?
itests pass on jenkins
#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-264](https://codice.atlassian.net/browse/CAL-264)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
