### PR TITLE
CAL-266 Add incremental builder extension to speed up PR builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,12 @@
         <commons-configuration.version>1.10</commons-configuration.version>
         <javax-mail.version>1.4.4</javax-mail.version>
         <powermock.version>1.6.6</powermock.version>
+
+        <!-- gitflow-incremental-builder -->
+        <!-- See https://github.com/vackosar/gitflow-incremental-builder for a list of all the options -->
+        <gib.referenceBranch>refs/remotes/origin/master</gib.referenceBranch>
+        <gib.baseBranch>HEAD</gib.baseBranch>
+        <gib.enabled>false</gib.enabled>
     </properties>
 
     <scm>
@@ -185,6 +191,13 @@
         </dependency>
     </dependencies>
     <build>
+        <extensions>
+            <extension>
+                <groupId>com.vackosar.gitflowincrementalbuilder</groupId>
+                <artifactId>gitflow-incremental-builder</artifactId>
+                <version>3.1</version>
+            </extension>
+        </extensions>
         <pluginManagement>
             <plugins>
                 <plugin>


### PR DESCRIPTION
Adds the `gitflow-incremental-builder` build extension to the root `pom.xml` to support local and PR incremental builds.

#### What does this PR do?
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@oconnormi
@LinkMJB

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@shaundmorris

#### How should this be tested?
1. Run `mvn clean install` and make sure a normal build is executed.
1. Make a local change to a source file, run `mvn -Dgib.enaled=true clean install` and make sure only the module that was changed and all its dependent modules are built

#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-266](https://codice.atlassian.net/browse/CAL-266)
#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
