### PR TITLE
CAL-267 Improved handling of empty or null geos in KLV library

### DIFF
--- a/catalog/video/video-mpegts-transformer/src/main/java/org/codice/alliance/transformer/video/MpegTsInputTransformer.java
+++ b/catalog/video/video-mpegts-transformer/src/main/java/org/codice/alliance/transformer/video/MpegTsInputTransformer.java
@@ -179,8 +179,6 @@ public class MpegTsInputTransformer implements InputTransformer {
     public Metacard transform(InputStream inputStream, final String id)
             throws IOException, CatalogTransformerException {
 
-        LOGGER.debug("processing video input for id = {}", id);
-
         try (TemporaryFileBackedOutputStream fileBackedOutputStream = new TemporaryFileBackedOutputStream()) {
 
             populateFileBackedOutputStream(inputStream, fileBackedOutputStream);

--- a/libs/klv/pom.xml
+++ b/libs/klv/pom.xml
@@ -170,14 +170,13 @@
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.68</minimum>
+                                            <minimum>0.69</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
                                             <minimum>0.67</minimum>
                                         </limit>
-
                                     </limits>
                                 </rule>
                             </rules>

--- a/libs/klv/src/main/java/org/codice/alliance/libs/klv/GeometryReducer.java
+++ b/libs/klv/src/main/java/org/codice/alliance/libs/klv/GeometryReducer.java
@@ -24,6 +24,10 @@ public class GeometryReducer implements GeometryOperator {
 
     @Override
     public Geometry apply(Geometry geometry) {
+        if(geometry == null || geometry.isEmpty()) {
+            return geometry;
+        }
+
         return geometryPrecisionReducer.reduce(geometry);
     }
 

--- a/libs/klv/src/main/java/org/codice/alliance/libs/klv/GeometryUtility.java
+++ b/libs/klv/src/main/java/org/codice/alliance/libs/klv/GeometryUtility.java
@@ -79,6 +79,8 @@ public class GeometryUtility {
                 .map(preUnionGeometryOperator)
                 .reduce(Geometry::union)
                 .map(postUnionGeometryOperator)
+                .map(geo -> !geo.isValid() ? geo.convexHull() : geo)
+                .filter(Geometry::isValid)
                 .map(wktWriter::write);
     }
 

--- a/libs/klv/src/main/java/org/codice/alliance/libs/klv/SimplifyGeometryFunction.java
+++ b/libs/klv/src/main/java/org/codice/alliance/libs/klv/SimplifyGeometryFunction.java
@@ -45,11 +45,14 @@ public class SimplifyGeometryFunction implements GeometryOperator {
 
     @Override
     public Geometry apply(Geometry geometry) {
-        if (geometry == null) {
-            return null;
+        if (geometry == null || geometry.isEmpty()) {
+            return geometry;
         }
 
-        LOGGER.debug("simplifying geometry: {}", geometry);
+        LOGGER.trace("simplifying geometry: {}\n {} coordinates, isValid? {}",
+                geometry,
+                geometry.getCoordinates().length,
+                geometry.isValid());
 
         Geometry simplifiedGeometry;
         if (distanceTolerance.isPresent()) {
@@ -59,11 +62,12 @@ public class SimplifyGeometryFunction implements GeometryOperator {
             simplifiedGeometry = new TopologyPreservingSimplifier(geometry).getResultGeometry();
         }
 
-        LOGGER.debug("old coord count={} new coord count={}",
-                geometry.getCoordinates().length,
-                simplifiedGeometry.getCoordinates().length);
+        LOGGER.trace("simplified geometry: {}\n {} coordinates, isValid? {}",
+                simplifiedGeometry,
+                simplifiedGeometry.getCoordinates().length,
+                simplifiedGeometry.isValid());
 
-        return simplifiedGeometry;
+        return simplifiedGeometry.isValid() ? simplifiedGeometry : geometry;
     }
 
     @Override

--- a/libs/klv/src/test/java/org/codice/alliance/libs/klv/GeometryReducerTest.java
+++ b/libs/klv/src/test/java/org/codice/alliance/libs/klv/GeometryReducerTest.java
@@ -26,20 +26,19 @@ import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.io.ParseException;
 import com.vividsolutions.jts.io.WKTReader;
 
-public class ConvertSubpolygonsToEnvelopesTest {
+public class GeometryReducerTest {
 
     private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory();
-
 
     @Test
     public void testNullSubpolygon() throws ParseException {
 
         Geometry geometry = null;
 
-        ConvertSubpolygonsToEnvelopes convertSubpolygonsToEnvelopes =
-                new ConvertSubpolygonsToEnvelopes();
+        GeometryReducer reducer =
+                new GeometryReducer();
 
-        Geometry actual = convertSubpolygonsToEnvelopes.apply(geometry);
+        Geometry actual = reducer.apply(geometry);
 
         assertThat(actual, nullValue());
     }
@@ -49,10 +48,10 @@ public class ConvertSubpolygonsToEnvelopesTest {
 
         Geometry geometry = GEOMETRY_FACTORY.createMultiPolygon(null);
 
-        ConvertSubpolygonsToEnvelopes convertSubpolygonsToEnvelopes =
-                new ConvertSubpolygonsToEnvelopes();
+        GeometryReducer reducer =
+                new GeometryReducer();
 
-        Geometry actual = convertSubpolygonsToEnvelopes.apply(geometry);
+        Geometry actual = reducer.apply(geometry);
 
         assertThat(actual.isEmpty(), is(true));
     }
@@ -66,10 +65,10 @@ public class ConvertSubpolygonsToEnvelopesTest {
 
         Geometry geometry = wktReader.read(wkt);
 
-        ConvertSubpolygonsToEnvelopes convertSubpolygonsToEnvelopes =
-                new ConvertSubpolygonsToEnvelopes();
+        GeometryReducer reducer =
+                new GeometryReducer();
 
-        Geometry actual = convertSubpolygonsToEnvelopes.apply(geometry);
+        Geometry actual = reducer.apply(geometry);
 
         assertThat(actual, is(geometry));
 
@@ -85,13 +84,12 @@ public class ConvertSubpolygonsToEnvelopesTest {
 
         Geometry geometry = wktReader.read(wkt);
 
-        ConvertSubpolygonsToEnvelopes convertSubpolygonsToEnvelopes =
-                new ConvertSubpolygonsToEnvelopes();
+        GeometryReducer reducer =
+                new GeometryReducer();
 
-        Geometry actual = convertSubpolygonsToEnvelopes.apply(geometry);
+        Geometry actual = reducer.apply(geometry);
 
-        Geometry expected = wktReader.read(
-                "MULTIPOLYGON (((0 0, 0 20, 20 20, 20 0, 0 0)), ((0 40, 0 60, 20 60, 20 40, 0 40)))");
+        Geometry expected = wktReader.read(wkt);
 
         assertThat(actual, is(expected));
 
@@ -102,12 +100,12 @@ public class ConvertSubpolygonsToEnvelopesTest {
 
         GeometryOperator.Visitor visitor = mock(GeometryOperator.Visitor.class);
 
-        ConvertSubpolygonsToEnvelopes convertSubpolygonsToEnvelopes =
-                new ConvertSubpolygonsToEnvelopes();
+        GeometryReducer reducer =
+                new GeometryReducer();
 
-        convertSubpolygonsToEnvelopes.accept(visitor);
+        reducer.accept(visitor);
 
-        verify(visitor).visit(convertSubpolygonsToEnvelopes);
+        verify(visitor).visit(reducer);
 
     }
 

--- a/libs/klv/src/test/java/org/codice/alliance/libs/klv/GeometryUtilityTest.java
+++ b/libs/klv/src/test/java/org/codice/alliance/libs/klv/GeometryUtilityTest.java
@@ -151,6 +151,28 @@ public class GeometryUtilityTest {
     }
 
     @Test
+    public void testUnionWithInvalidGeo() throws ParseException {
+        String polygonWithHole =
+                "POLYGON ((-2.009211 51.199649, -1.99911 51.231578, -1.915058 51.240884, "
+                        + "-1.9201379049078626 51.228738313629776, -1.895395 51.226235, "
+                        + "-1.9781007533907866 51.196335611502384, -2.009211 51.199649), "
+                        + "(-1.9880383632176948 51.194513502505224, -1.9848251778950785 "
+                        + "51.19299587819516, -1.9838038434104859 51.1939685777043, "
+                        + "-1.9880383632176948 51.194513502505224))";
+        Attribute attribute = new AttributeImpl(FIELD, Arrays.asList(polygonWithHole));
+
+        Optional<String> optionalWkt = GeometryUtility.createUnionOfGeometryAttribute(wktReader,
+                wktWriter,
+                attribute);
+
+        Geometry actual = wktReader.read(optionalWkt.get())
+                .norm();
+
+        assertThat(actual.isValid(), is(true));
+
+    }
+
+    @Test
     public void testAttributeToLineString() {
 
         Attribute attribute = new AttributeImpl(FIELD,

--- a/libs/klv/src/test/java/org/codice/alliance/libs/klv/SimplifyGeometryFunctionTest.java
+++ b/libs/klv/src/test/java/org/codice/alliance/libs/klv/SimplifyGeometryFunctionTest.java
@@ -24,9 +24,13 @@ import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.io.ParseException;
 import com.vividsolutions.jts.io.WKTReader;
+
+
 
 public class SimplifyGeometryFunctionTest {
 
@@ -36,6 +40,8 @@ public class SimplifyGeometryFunctionTest {
     private SimplifyGeometryFunction simplifyGeometryFunction;
 
     private WKTReader wktReader;
+
+    private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory();
 
     @Before
     public void setup() {
@@ -66,6 +72,23 @@ public class SimplifyGeometryFunctionTest {
     public void testApplyNullArg() {
         Geometry result = simplifyGeometryFunction.apply(null);
         assertThat(result, nullValue());
+    }
+
+    @Test
+    public void testEmptryLineString() {
+        final Geometry emptyGeo = GEOMETRY_FACTORY.createLineString((Coordinate[]) null);
+
+        Geometry result = simplifyGeometryFunction.apply(emptyGeo);
+
+        assertThat(result, is(emptyGeo));
+    }
+
+    @Test
+    public void testEmptyPolygon() {
+        final Geometry emptyGeo = GEOMETRY_FACTORY.createMultiPolygon(null);
+        Geometry result = simplifyGeometryFunction.apply(emptyGeo);
+
+        assertThat(result, is(emptyGeo));
     }
 
     @Test


### PR DESCRIPTION
#### What does this PR do?
- Added checks for empty geos
- Added checks for null geos
- Added geo validity checking
- In geometry union method, added fallback to convex hull to handle validity issues

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@glenhein @bdeining 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@millerw8 

#### How should this be tested?
1) Turn up TRACE level logging on org.codice.alliance
2) Start one or more video streams.  Use ffmpeg or similar utility to stream video.
3) Verify that no NPEs occur during streaming

#### Any background context you want to provide?
During video streaming, depending on the video metadata, empty or null geometries may be encountered during the geometry subsampling and simplification process.  Also, there have been instances of invalid geometries occurring as the result of the geometry calculations which can cause failures during solr indexing.

This PR handles those cases gracefully.

#### What are the relevant tickets?

[CAL-267](https://codice.atlassian.net/browse/CAL-267)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
