### PR TITLE
CAL-268 Reset the catalog contents after every itest

### DIFF
--- a/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/AllianceAppsTest.java
+++ b/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/AllianceAppsTest.java
@@ -27,6 +27,7 @@ import org.codice.ddf.admin.application.service.ApplicationServiceException;
 import org.codice.ddf.admin.application.service.ApplicationStatus;
 import org.codice.ddf.itests.common.annotations.BeforeExam;
 import org.codice.ddf.security.common.Security;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
@@ -42,8 +43,7 @@ import ddf.security.Subject;
 @ExamReactorStrategy(PerClass.class)
 public class AllianceAppsTest extends AbstractAllianceIntegrationTest {
 
-    private static final String[] APPS =
-            {"security-app", "nsili-app", "imaging-app", "video-app"};
+    private static final String[] APPS = {"security-app", "nsili-app", "imaging-app", "video-app"};
 
     @BeforeExam
     public void beforeAllianceTest() throws Exception {
@@ -60,10 +60,15 @@ public class AllianceAppsTest extends AbstractAllianceIntegrationTest {
         }
     }
 
+    @After
+    public void tearDown() {
+        clearCatalog();
+    }
+
     @Test
     public void installAllianceApps() throws Exception {
-        ApplicationService applicationService = getServiceManager().getService(
-                ApplicationService.class);
+        ApplicationService applicationService =
+                getServiceManager().getService(ApplicationService.class);
         Subject systemSubject = Security.runAsAdmin(() -> Security.getInstance()
                 .getSystemSubject());
 
@@ -72,7 +77,8 @@ public class AllianceAppsTest extends AbstractAllianceIntegrationTest {
                 Application app = applicationService.getApplication(appName);
                 assertNotNull(String.format("Application [%s] must not be null", appName), app);
                 ApplicationStatus status = applicationService.getApplicationStatus(app);
-                assertThat(String.format("%s should be INACTIVE", appName), status.getState(),
+                assertThat(String.format("%s should be INACTIVE", appName),
+                        status.getState(),
                         is(INACTIVE));
 
                 try {
@@ -82,7 +88,8 @@ public class AllianceAppsTest extends AbstractAllianceIntegrationTest {
                     fail(String.format("Failed to start the %s: %s", appName, e.getMessage()));
                 }
                 status = applicationService.getApplicationStatus(app);
-                assertThat(String.format("%s should be ACTIVE after start, but was [%s]", appName,
+                assertThat(String.format("%s should be ACTIVE after start, but was [%s]",
+                        appName,
                         status.getState()), status.getState(), is(ACTIVE));
             }
 

--- a/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/BannerMarkingsTest.java
+++ b/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/BannerMarkingsTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Dictionary;
@@ -31,6 +32,7 @@ import org.codice.alliance.security.banner.marking.BannerCommonMarkingExtractor;
 import org.codice.alliance.security.banner.marking.Dod520001MarkingExtractor;
 import org.codice.alliance.test.itests.common.AbstractAllianceIntegrationTest;
 import org.codice.ddf.itests.common.annotations.BeforeExam;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
@@ -69,6 +71,11 @@ public class BannerMarkingsTest extends AbstractAllianceIntegrationTest {
             LOGGER.error("Failed in @BeforeExam: ", e);
             fail("Failed in @BeforeExam: " + e.getMessage());
         }
+    }
+
+    @After
+    public void tearDown() {
+        clearCatalog();
     }
 
     @Test
@@ -152,8 +159,8 @@ public class BannerMarkingsTest extends AbstractAllianceIntegrationTest {
         // The invalid marking has the HCS-X SCI marking without NOFORN
         Metacard metacard = getMetacard("invalid.txt");
 
-        Attribute attribute = metacard.getAttribute(
-                BannerCommonMarkingExtractor.SECURITY_CLASSIFICATION);
+        Attribute attribute =
+                metacard.getAttribute(BannerCommonMarkingExtractor.SECURITY_CLASSIFICATION);
         assertNull(attribute);
     }
 
@@ -172,8 +179,8 @@ public class BannerMarkingsTest extends AbstractAllianceIntegrationTest {
         }
 
         InputTransformer xformer = inputTransformer.get();
-        return xformer.transform(
-                getAllianceItestResourceAsStream(String.format("/markings/%s", fileName)));
+        return xformer.transform(getAllianceItestResourceAsStream(String.format("/markings/%s",
+                fileName)));
     }
 
     private Attribute getAttribute(Metacard metacard, String attrName) {
@@ -185,11 +192,13 @@ public class BannerMarkingsTest extends AbstractAllianceIntegrationTest {
 
     private void configureSecurityStsClient() throws IOException, InterruptedException {
         Configuration stsClientConfig = configAdmin.getConfiguration(
-                "ddf.security.sts.client.configuration.cfg", null);
+                "ddf.security.sts.client.configuration.cfg",
+                null);
         Dictionary<String, Object> properties = new Hashtable<>();
 
-        properties.put("address", DynamicUrl.SECURE_ROOT + HTTPS_PORT.getPort()
-                + "/services/SecurityTokenService?wsdl");
+        properties.put("address",
+                DynamicUrl.SECURE_ROOT + HTTPS_PORT.getPort()
+                        + "/services/SecurityTokenService?wsdl");
         stsClientConfig.update(properties);
     }
 }

--- a/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/ImagingTest.java
+++ b/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/ImagingTest.java
@@ -27,7 +27,6 @@ import static com.jayway.restassured.RestAssured.when;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.LinkedList;
@@ -71,8 +70,6 @@ public class ImagingTest extends AbstractAllianceIntegrationTest {
     private static final String TEST_IMAGE_NITF = "i_3001a.ntf";
 
     private static final String TEST_MTI_NITF = "gmti-test.ntf";
-
-    private final List<String> metacardIds = new ArrayList<>();
 
     @BeforeExam
     public void beforeAllianceTest() throws Exception {
@@ -350,8 +347,7 @@ public class ImagingTest extends AbstractAllianceIntegrationTest {
 
     @After
     public void tearDown() {
-        metacardIds.forEach(this::deleteMetacard);
-        metacardIds.clear();
+        clearCatalog();
     }
 
     private MetacardXmlValidator ingestAndValidateCommonNitfJpeg2000Attributes(
@@ -383,8 +379,6 @@ public class ImagingTest extends AbstractAllianceIntegrationTest {
                 .when()
                 .post(REST_PATH.getUrl())
                 .getHeader("id");
-        metacardIds.add(id);
-
         return id;
     }
 

--- a/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/NsiliEndpointTest.java
+++ b/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/NsiliEndpointTest.java
@@ -99,7 +99,6 @@ public class NsiliEndpointTest extends AbstractAllianceIntegrationTest {
             configureRestForGuest();
             getSecurityPolicy().waitForGuestAuthReady(REST_PATH.getUrl() + "?_wadl");
 
-            ingestedProductId = ingestRecord("alliance.png", "image/png");
             startHttpListener();
         } catch (Exception e) {
             LOGGER.error("Failed in @BeforeExam: ", e);
@@ -118,12 +117,14 @@ public class NsiliEndpointTest extends AbstractAllianceIntegrationTest {
 
     @Before
     public void startSampleNsiliClientFeature() throws Exception {
+        ingestedProductId = ingestRecord("alliance.png", "image/png");
         getServiceManager().startFeature(true, SAMPLE_NSILI_CLIENT_FEATURE_NAME);
     }
 
     @After
     public void stopSampleNsiliClientFeature() throws Exception {
         getServiceManager().stopFeature(true, SAMPLE_NSILI_CLIENT_FEATURE_NAME);
+        clearCatalog();
     }
 
     @Test
@@ -159,11 +160,14 @@ public class NsiliEndpointTest extends AbstractAllianceIntegrationTest {
 
         // ProductMgr
         DAG parametersDag = sampleNsiliClient.getParameters(result);
-        assertThat(getAttributeFromDag(parametersDag, NsiliConstants.IDENTIFIER), is(ingestedProductId));
+        assertThat(getAttributeFromDag(parametersDag, NsiliConstants.IDENTIFIER),
+                is(ingestedProductId));
         assertThat(getAttributeFromDag(parametersDag, NsiliConstants.STATUS), is("NEW"));
-        assertThat(sampleNsiliClient.getRelatedFileTypes(result), is(new String[]{NsiliConstants.THUMBNAIL_TYPE}));
+        assertThat(sampleNsiliClient.getRelatedFileTypes(result),
+                is(new String[] {NsiliConstants.THUMBNAIL_TYPE}));
         final String expectedThumbnailFilename = ingestedProductId + "-THUMBNAIL.jpg";
-        assertThat(sampleNsiliClient.getRelatedFiles(result), is(new String[]{expectedThumbnailFilename}));
+        assertThat(sampleNsiliClient.getRelatedFiles(result),
+                is(new String[] {expectedThumbnailFilename}));
         verifyStubServerPutRequest(expectedThumbnailFilename, "image/jpeg");
 
         // OrderMgr
@@ -191,11 +195,10 @@ public class NsiliEndpointTest extends AbstractAllianceIntegrationTest {
     }
 
     private void verifyStubServerPutRequest(String expectedFilename, String expectedType) {
-        verifyHttp(server).once(
-                method(Method.PUT),
+        verifyHttp(server).once(method(Method.PUT),
                 url(RESTITO_STUB_SERVER.getUrl() + "/" + expectedFilename),
-                custom(call -> call.getContentType().equals(expectedType))
-        );
+                custom(call -> call.getContentType()
+                        .equals(expectedType)));
     }
 
     private String ingestRecord(String fileName, String fileType)

--- a/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/NsiliSourceTest.java
+++ b/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/NsiliSourceTest.java
@@ -33,6 +33,7 @@ import org.codice.alliance.test.itests.common.AbstractAllianceIntegrationTest;
 import org.codice.alliance.test.itests.common.mock.MockNsiliRunnable;
 import org.codice.ddf.itests.common.annotations.AfterExam;
 import org.codice.ddf.itests.common.annotations.BeforeExam;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Option;
@@ -224,10 +225,16 @@ public class NsiliSourceTest extends AbstractAllianceIntegrationTest {
         mockServerThread = null;
     }
 
+    @After
+    public void tearDown() {
+        clearCatalog();
+    }
+
     private void startMockResources() throws Exception {
         MockNsiliRunnable mockServer =
-                new MockNsiliRunnable(Integer.parseInt(HTTP_WEB_PORT.getPort()), Integer.parseInt(
-                        FTP_WEB_PORT.getPort()), Integer.parseInt(CORBA_PORT.getPort()));
+                new MockNsiliRunnable(Integer.parseInt(HTTP_WEB_PORT.getPort()),
+                        Integer.parseInt(FTP_WEB_PORT.getPort()),
+                        Integer.parseInt(CORBA_PORT.getPort()));
 
         mockServerThread = new Thread(mockServer, "mockServer");
         mockServerThread.start();

--- a/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/SecurityAuditPluginTest.java
+++ b/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/SecurityAuditPluginTest.java
@@ -31,6 +31,7 @@ import org.apache.commons.io.IOUtils;
 import org.codice.alliance.test.itests.common.AbstractAllianceIntegrationTest;
 import org.codice.ddf.itests.common.WaitCondition;
 import org.codice.ddf.itests.common.annotations.BeforeExam;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
@@ -64,6 +65,11 @@ public class SecurityAuditPluginTest extends AbstractAllianceIntegrationTest {
 
         configureRestForGuest();
         getSecurityPolicy().waitForGuestAuthReady(REST_PATH.getUrl() + "?_wadl");
+    }
+
+    @After
+    public void tearDown() {
+        clearCatalog();
     }
 
     @Test

--- a/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/VideoTest.java
+++ b/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/VideoTest.java
@@ -37,6 +37,7 @@ import org.codice.alliance.distribution.sdk.video.stream.mpegts.MpegTsUdpClient;
 import org.codice.alliance.test.itests.common.AbstractAllianceIntegrationTest;
 import org.codice.alliance.video.stream.mpegts.UdpStreamMonitor;
 import org.codice.ddf.itests.common.annotations.BeforeExam;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -84,6 +85,11 @@ public class VideoTest extends AbstractAllianceIntegrationTest {
 
         configureRestForGuest();
         getSecurityPolicy().waitForGuestAuthReady(REST_PATH.getUrl() + "?_wadl");
+    }
+
+    @After
+    public void tearDown() {
+        clearCatalog();
     }
 
     @Test


### PR DESCRIPTION
#### What does this PR do?
All itests reset catalog contents in an @after with the karaf command "catalog:removeall -f -p". Previous cleanup logic has been removed from relevant itests. Additonally, data used by itests are now ingested in @before.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@ahoffer @emanns95 @mweser @brendan-hofmann 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@shaundmorris

#### What are the relevant tickets?
[CAL-268](https://codice.atlassian.net/browse/CAL-268)

#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [X] Update / Add Integration Tests
