### PR TITLE
CAL-274 added template for documenting endpoints in auto-docs

### DIFF
--- a/distribution/docs/pom.xml
+++ b/distribution/docs/pom.xml
@@ -12,7 +12,9 @@
  *
  **/
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.codice.alliance</groupId>
@@ -34,20 +36,11 @@
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctorj</artifactId>
             <version>${asciidoctorj.version}</version>
-        </dependency> 
-        <dependency>
-            <groupId>ddf</groupId>
-            <artifactId>docs</artifactId>
-            <version>${ddf.version}</version>
-            <classifier>adoc-files</classifier>
-            <type>zip</type>
         </dependency>
         <dependency>
             <groupId>ddf.ui.search</groupId>
             <artifactId>standard</artifactId>
-            <classifier>adoc-files</classifier>
             <version>${ddf.version}</version>
-            <type>zip</type>
         </dependency>
     </dependencies>
     <build>
@@ -78,7 +71,7 @@
                 <executions>
                     <execution>
                         <id>unpack</id>
-                        <phase>generate-sources</phase>
+                        <phase>validate</phase>
                         <goals>
                             <goal>unpack</goal>
                         </goals>
@@ -92,7 +85,7 @@
                                     <type>zip</type>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/adoc/_ddf</outputDirectory>
-                                    <includes>**</includes>     
+                                    <includes>**</includes>
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>ddf.ui.search</groupId>
@@ -101,6 +94,16 @@
                                     <version>${ddf.version}</version>
                                     <type>zip</type>
                                     <outputDirectory>${project.build.directory}/adoc/ui-help</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>ddf</groupId>
+                                    <version>${ddf.version}</version>
+                                    <artifactId>docs</artifactId>
+                                    <classifier>jdoc-files</classifier>
+                                    <type>zip</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}/jdoc/_ddf</outputDirectory>
+                                    <includes>**</includes>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>
@@ -113,7 +116,7 @@
                 <executions>
                     <execution>
                         <id>copy-adocs</id>
-                        <phase>process-sources</phase>
+                        <phase>initialize</phase>
                         <goals>
                             <goal>copy-resources</goal>
                         </goals>
@@ -125,6 +128,15 @@
                                     <filtering>true</filtering>
                                     <includes>
                                         <include>**/*.adoc</include>
+                                    </includes>
+                                </resource>
+                                <resource>
+                                    <directory>src/main/jdocs</directory>
+                                    <filtering>true</filtering>
+                                    <includes>
+                                        <include>**/*.adoc</include>
+                                        <include>jbake.properties</include>
+                                        <include>**/*.ftl</include>
                                     </includes>
                                 </resource>
                                 <resource>
@@ -141,12 +153,63 @@
                                         <include>**/*.adoc</include>
                                     </includes>
                                 </resource>
+                                <resource>
+                                    <directory>${project.build.directory}/jdoc</directory>
+                                    <filtering>true</filtering>
+                                    <includes>
+                                        <include>**/*.adoc</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-jdocs</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/doc-contents/content</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.build.directory}/jdoc</directory>
+                                    <filtering>true</filtering>
+                                    <includes>
+                                        <include>**/*.adoc</include>
+                                    </includes>
+                                    <excludes>
+                                        <exclude>jdocumentation.adoc</exclude>
+                                    </excludes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-templates</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/doc-contents/templates</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.build.directory}/jdoc/_ddf/docs-${ddf.version}/templates</directory>
+                                    <filtering>true</filtering>
+                                    <includes>
+                                        <include>**/*.ftl</include>
+                                    </includes>
+                                    <excludes>
+                                        <exclude>jdocumentation.adoc</exclude>
+                                    </excludes>
+                                </resource>
                             </resources>
                         </configuration>
                     </execution>
                     <execution>
                         <id>copy-images</id>
-                        <phase>process-sources</phase>
+                        <phase>initialize</phase>
                         <goals>
                             <goal>copy-resources</goal>
                         </goals>
@@ -178,6 +241,39 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>br.com.ingenieux</groupId>
+                <artifactId>jbake-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <inputDirectory>${project.build.directory}/doc-contents</inputDirectory>
+                    <outputDirectory>${project.build.directory}/doc-contents/jdoc-contents</outputDirectory>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.freemarker</groupId>
+                        <artifactId>freemarker</artifactId>
+                        <version>2.3.23</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctor-maven-plugin</artifactId>
+                        <version>${asciidoctor.maven.plugin.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.pegdown</groupId>
+                        <artifactId>pegdown</artifactId>
+                        <version>1.4.2</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.asciidoctor</groupId>
@@ -239,8 +335,8 @@
                             <backend>pdf</backend>
                             <outputDirectory>${project.build.directory}/docs/pdf</outputDirectory>
                             <attributes>
-                                <pagenums />
-                                <toc />
+                                <pagenums/>
+                                <toc/>
                                 <idprefix>_</idprefix>
                                 <idseparator>_</idseparator>
                             </attributes>
@@ -291,6 +387,17 @@
                             <outputDirectory>${project.build.directory}/export-docs</outputDirectory>
                         </configuration>
                         <id>include-docs</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <configuration>
+                            <descriptor>${project.basedir}/src/assembly/jdocs.xml</descriptor>
+                            <outputDirectory>${project.build.directory}/jdoc-files</outputDirectory>
+                        </configuration>
+                        <id>include-jdocs</id>
                         <phase>package</phase>
                         <goals>
                             <goal>single</goal>

--- a/distribution/docs/src/assembly/docs-export.xml
+++ b/distribution/docs/src/assembly/docs-export.xml
@@ -28,7 +28,7 @@
             <directoryMode>0755</directoryMode>
             <directory>${project.build.directory}/docs/html</directory>
             <includes>
-                <include>*.html</include>
+                <include>documentation*.html</include>
             </includes>
             <outputDirectory>html</outputDirectory>
         </fileSet>
@@ -37,7 +37,7 @@
             <directoryMode>0755</directoryMode>
             <directory>${project.build.directory}/docs/pdf</directory>
             <includes>
-                <include>*.pdf</include>
+                <include>documentation.pdf</include>
             </includes>
             <outputDirectory>pdf</outputDirectory>
         </fileSet>

--- a/distribution/docs/src/assembly/jdocs.xml
+++ b/distribution/docs/src/assembly/jdocs.xml
@@ -18,28 +18,22 @@
         xsi:schemaLocation="
       http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2
       http://maven.apache.org/xsd/assembly-1.1.2.xsd">
-    <id>docs-export</id>
+    <id>jdoc-files</id>
     <formats>
-        <format>zip</format>
+          <format>zip</format>
     </formats>
     <fileSets>
         <fileSet>
-            <fileMode>0644</fileMode>
-            <directoryMode>0755</directoryMode>
-            <directory>${project.build.directory}/docs/html</directory>
-            <includes>
-                <include>*.html</include>
+             <fileMode>0644</fileMode>
+             <directoryMode>0755</directoryMode>
+             <directory>src/main/jdocs/content</directory>
+             <includes>
+                   <include>**</include>
             </includes>
-            <outputDirectory>html</outputDirectory>
+            <excludes>
+                <exclude>jdocumentation.adoc</exclude>
+            </excludes>
+            <outputDirectory></outputDirectory>
         </fileSet>
-        <fileSet>
-            <fileMode>0644</fileMode>
-            <directoryMode>0755</directoryMode>
-            <directory>${project.build.directory}/docs/pdf</directory>
-            <includes>
-                <include>*.pdf</include>
-            </includes>
-            <outputDirectory>pdf</outputDirectory>
-        </fileSet>
-    </fileSets>
+     </fileSets>
 </assembly>

--- a/distribution/docs/src/main/jdocs/content/jdocumentation.adoc
+++ b/distribution/docs/src/main/jdocs/content/jdocumentation.adoc
@@ -1,0 +1,2 @@
+:type: documentation
+:status: published

--- a/distribution/docs/src/main/jdocs/jbake.properties
+++ b/distribution/docs/src/main/jdocs/jbake.properties
@@ -1,0 +1,12 @@
+site.host=http://codice.org/alliance
+render.tags=false
+render.sitemap=false
+render.index=false
+render.archive=false
+render.feed=false
+output.extension=.adoc
+template.documentation.file=documentation.ftl
+template.endpoint.file=endpoints.ftl
+template.endpointService.file=endpoints.ftl
+template.endpointIntro.file=endpoints.ftl
+template.developingComponent.file=developing-components.ftl

--- a/distribution/docs/src/main/resources/_contents/jconfig.adoc
+++ b/distribution/docs/src/main/resources/_contents/jconfig.adoc
@@ -1,0 +1,26 @@
+Version: ${project.version}. Copyright (c) Codice Foundation
+:imagesdir: target/doc-contents/images
+:toc: left
+:example-caption!:
+:source-highlighter: coderay
+:sectlinks:
+:sectanchors:
+:data-uri:
+:sectnums:
+:title-logo: alliance-logo.png
+:branding: Alliance
+:hardening-step: Required Step for Security Hardening
+:adoc-include: ${project.build.directory}/doc-contents/content/_ddf/docs-${ddf.version}/content
+:adoc-include-cal: ${project.build.directory}/doc-contents/content
+:download-url: https://github.com/codice/alliance/releases
+:last-update-label: Copyright (c) Codice Foundation. +
+This work is licensed under a Creative Commons Attribution 4.0 International License (http://creativecommons.org/licenses/by/4.0). +
+This page last updated:
+
+ifdef::backend-pdf[]
+[colophon]
+== License
+Copyright (c) Codice Foundation. +
+This work is licensed under a http://creativecommons.org/licenses/by/4.0[Creative Commons Attribution 4.0 International License].
+endif::[]
+


### PR DESCRIPTION
#### What does this PR do?

Sets up jbake as part of documentation process to render docs from templates.

#### Who is reviewing it?

@mcalcote @vinamartin @Lambeaux @jrnorth 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@coyotesqrl
@jlcsmith
@pklinef
@shaundmorris

#### How should this be tested?

- fresh build with a clean repo
- no test failures or unresolved directive errors in rendered documentation
- all marked content included correctly

#### Any background context you want to provide?

As part of the larger automation process, the incomplete documentation will be rendered as a file called `jdocumentation.html` / `pdf`. Once all sections are migrated, this non-deployed file will replace the current documentation.html files being generated.

#### What are the relevant tickets?

[DDF-2802](https://codice.atlassian.net/browse/DDF-2802)
[CAL-274](https://codice.atlassian.net/browse/CAL-274)

#### Screenshots (if appropriate)

[jdocumentation.zip](https://github.com/codice/alliance/files/863233/jdocumentation.zip)

#### Checklist:
- [x] Documentation Updated
	- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
