### PR TITLE
CAL-283- Catches exception that could cause thumbnail gen to fail

### DIFF
--- a/catalog/imaging/imaging-plugin-nitf/pom.xml
+++ b/catalog/imaging/imaging-plugin-nitf/pom.xml
@@ -84,6 +84,14 @@
             <version>${jpeg2000.version}</version>
         </dependency>
 
+        <dependency>
+            <!-- Upgrade mockito to version 2.1.0 for this module to get final mock capability -->
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.1.0</version>
+            <scope>test</scope>
+        </dependency>
+
         <!--Spock dependencies-->
         <dependency>
             <groupId>ddf.lib</groupId>

--- a/catalog/imaging/imaging-plugin-nitf/src/main/java/org/codice/alliance/plugin/nitf/NitfPreStoragePlugin.java
+++ b/catalog/imaging/imaging-plugin-nitf/src/main/java/org/codice/alliance/plugin/nitf/NitfPreStoragePlugin.java
@@ -212,7 +212,7 @@ public class NitfPreStoragePlugin implements PreCreateStoragePlugin, PreUpdateSt
                 }
 
             }
-        } catch (IOException | ParseException | NitfFormatException | UnsupportedOperationException e) {
+        } catch (IOException | ParseException | NitfFormatException | RuntimeException e) {
             LOGGER.debug(e.getMessage(), e);
         }
     }
@@ -258,7 +258,7 @@ public class NitfPreStoragePlugin implements PreCreateStoragePlugin, PreUpdateSt
 
             if (inputStream != null) {
                 try {
-                    NitfRenderer renderer = new NitfRenderer();
+                    NitfRenderer renderer = getNitfRenderer();
 
                     new NitfParserInputFlow().inputStream(inputStream)
                             .allData()
@@ -470,5 +470,9 @@ public class NitfPreStoragePlugin implements PreCreateStoragePlugin, PreUpdateSt
 
     public void setStoreOriginalImage(boolean storeOriginalImage) {
         this.storeOriginalImage = storeOriginalImage;
+    }
+
+    NitfRenderer getNitfRenderer() {
+        return new NitfRenderer();
     }
 }

--- a/catalog/imaging/imaging-plugin-nitf/src/test/java/org/codice/alliance/plugin/nitf/PreStoragePluginTest.java
+++ b/catalog/imaging/imaging-plugin-nitf/src/test/java/org/codice/alliance/plugin/nitf/PreStoragePluginTest.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Codice Foundation
- * <p/>
+ * <p>
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * <p/>
+ * <p>
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
@@ -18,6 +18,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -30,6 +31,8 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.codice.imaging.nitf.core.image.ImageSegment;
+import org.codice.imaging.nitf.render.NitfRenderer;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -65,7 +68,7 @@ public class PreStoragePluginTest {
     public void setUp()
             throws UnsupportedQueryException, SourceUnavailableException, FederationException,
             IOException {
-        nitfPreStoragePlugin = new NitfPreStoragePlugin();
+        this.nitfPreStoragePlugin = new NitfPreStoragePlugin();
 
         this.createStorageRequest = mock(CreateStorageRequest.class);
         this.updateStorageRequest = mock(UpdateStorageRequest.class);
@@ -81,7 +84,23 @@ public class PreStoragePluginTest {
         when(contentItem.getId()).thenReturn("101ABC");
         when(contentItem.getInputStream()).thenAnswer(invocationOnMock -> getInputStream(GEO_NITF));
         when(contentItem.getMimeTypeRawData()).thenReturn(NitfPreStoragePlugin.NITF_MIME_TYPE.toString());
-        when(contentItem.getSize()).thenReturn(5L*1024L*1024L);
+        when(contentItem.getSize()).thenReturn(5L * 1024L * 1024L);
+    }
+
+    @Test
+    public void testRunTimeException() throws IOException, PluginExecutionException {
+        NitfRenderer nitfRenderer = mock(NitfRenderer.class);
+
+        NitfPreStoragePlugin nitfPreStoragePlugin = new NitfPreStoragePlugin() {
+            @Override
+            NitfRenderer getNitfRenderer() {
+                return nitfRenderer;
+            }
+        };
+
+        when(nitfRenderer.render(any(ImageSegment.class))).thenThrow(RuntimeException.class);
+        CreateStorageRequest result = nitfPreStoragePlugin.process(createStorageRequest);
+        assertThat(result.getContentItems(), is(createStorageRequest.getContentItems()));
     }
 
     @Test(expected = PluginExecutionException.class)

--- a/catalog/imaging/imaging-plugin-nitf/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/catalog/imaging/imaging-plugin-nitf/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
#### What does this PR do?

Catches an `IllegalArgumentException` being thrown by jai-imageio-jpeg2000 when there is an image with 0 bands. This allows nitfs to be ingested without a successful thumbnail being generated. 

This PR uses an incubating feature in Mockito version 2 for mocking finals, more details here: https://github.com/mockito/mockito/wiki/What%27s-new-in-Mockito-2#unmockable

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@clockard @brendan-hofmann @garrettfreibott @brianfelix @emanns95 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@lessarderic
@figliold 
@jlcsmith 

[CAL-283](https://codice.atlassian.net/browse/CAL-283)

#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
