### PR TITLE
CAL-284 Update imaging-app to use imaging-nitf 0.8

### DIFF
--- a/catalog/imaging/imaging-app/src/main/resources/features.xml
+++ b/catalog/imaging/imaging-app/src/main/resources/features.xml
@@ -25,6 +25,7 @@
     <feature name="imaging-app" install="auto" version="${project.version}"
              description="The Imaging Application provides support for ingesting and searching for NITF products.::Imaging">
         <feature prerequisite="true">catalog-app</feature>
+        <feature prerequisite="true">platform-usng4j</feature>
         <bundle dependency="true">mvn:org.codice.alliance.catalog.core/catalog-core-api/${project.version}</bundle>
         <bundle>mvn:org.codice.alliance.imaging/imaging-nitf-api/${project.version}</bundle>
         <bundle>mvn:org.codice.alliance.imaging/imaging-nitf-impl/${project.version}</bundle>

--- a/catalog/imaging/imaging-nitf-api/pom.xml
+++ b/catalog/imaging/imaging-nitf-api/pom.xml
@@ -35,12 +35,7 @@
         </dependency>
         <dependency>
             <groupId>org.codice.imaging.nitf</groupId>
-            <artifactId>codice-imaging-nitf-core</artifactId>
-            <version>${nitf-imaging.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codice.imaging.nitf</groupId>
-            <artifactId>codice-imaging-nitf-render</artifactId>
+            <artifactId>codice-imaging-nitf-core-api</artifactId>
             <version>${nitf-imaging.version}</version>
         </dependency>
     </dependencies>
@@ -55,14 +50,22 @@
                     <instructions>
                         <Embed-Dependency>
                             codice-imaging-nitf-fluent-api,
-                            codice-imaging-nitf-core,
-                            codice-imaging-nitf-render
+                            codice-imaging-nitf-core-api
                         </Embed-Dependency>
                         <Export-Package>
-                            org.codice.imaging.nitf.fluent.*,
-                            org.codice.imaging.nitf.core.*,
-                            org.codice.imaging.nitf.render.*,
-                            org.codice.alliance.imaging.nitf.api.*
+                            org.codice.alliance.imaging.nitf.api,
+                            org.codice.imaging.nitf.core,
+                            org.codice.imaging.nitf.core.common,
+                            org.codice.imaging.nitf.core.dataextension,
+                            org.codice.imaging.nitf.core.graphic,
+                            org.codice.imaging.nitf.core.header,
+                            org.codice.imaging.nitf.core.image,
+                            org.codice.imaging.nitf.core.label,
+                            org.codice.imaging.nitf.core.security,
+                            org.codice.imaging.nitf.core.symbol,
+                            org.codice.imaging.nitf.core.text,
+                            org.codice.imaging.nitf.core.tre,
+                            org.codice.imaging.nitf.fluent
                         </Export-Package>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                     </instructions>

--- a/catalog/imaging/imaging-nitf-impl/pom.xml
+++ b/catalog/imaging/imaging-nitf-impl/pom.xml
@@ -35,12 +35,12 @@
         </dependency>
         <dependency>
             <groupId>org.codice.imaging.nitf</groupId>
-            <artifactId>codice-imaging-nitf-core</artifactId>
+            <artifactId>codice-imaging-nitf-fluent</artifactId>
             <version>${nitf-imaging.version}</version>
         </dependency>
         <dependency>
             <groupId>org.codice.imaging.nitf</groupId>
-            <artifactId>codice-imaging-nitf-render</artifactId>
+            <artifactId>codice-imaging-nitf-core</artifactId>
             <version>${nitf-imaging.version}</version>
         </dependency>
         <dependency>
@@ -53,6 +53,27 @@
             <artifactId>slf4j-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>2.8.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.usng4j</groupId>
+            <artifactId>usng4j-api</artifactId>
+            <version>${usng4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.usng4j</groupId>
+            <artifactId>usng4j-impl</artifactId>
+            <version>${usng4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -63,7 +84,17 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
+                        <Embed-Dependency>
+                            codice-imaging-nitf-core,
+                            codice-imaging-nitf-fluent,
+                            commons-lang3,
+                            usng4j-impl
+                        </Embed-Dependency>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Export-Package>
+                            org.codice.imaging.nitf.fluent.impl,
+                            org.codice.imaging.nitf.core.impl
+                        </Export-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/catalog/imaging/imaging-nitf-impl/src/main/java/org/codice/alliance/imaging/nitf/impl/NitfParserServiceImpl.java
+++ b/catalog/imaging/imaging-nitf-impl/src/main/java/org/codice/alliance/imaging/nitf/impl/NitfParserServiceImpl.java
@@ -20,8 +20,8 @@ import java.util.Optional;
 
 import org.codice.alliance.imaging.nitf.api.NitfParserService;
 import org.codice.imaging.nitf.core.common.NitfFormatException;
-import org.codice.imaging.nitf.fluent.NitfParserInputFlow;
 import org.codice.imaging.nitf.fluent.NitfSegmentsFlow;
+import org.codice.imaging.nitf.fluent.impl.NitfParserInputFlowImpl;
 
 public class NitfParserServiceImpl implements NitfParserService {
 
@@ -37,11 +37,11 @@ public class NitfParserServiceImpl implements NitfParserService {
         }
 
         if (allData != null && allData) {
-            return new NitfParserInputFlow().inputStream(inputStream)
+            return new NitfParserInputFlowImpl().inputStream(inputStream)
                     .allData();
         }
 
-        return new NitfParserInputFlow().inputStream(inputStream)
+        return new NitfParserInputFlowImpl().inputStream(inputStream)
                 .headerOnly();
     }
 
@@ -57,11 +57,11 @@ public class NitfParserServiceImpl implements NitfParserService {
         }
 
         if (allData != null && allData) {
-            return new NitfParserInputFlow().file(nitfFile)
+            return new NitfParserInputFlowImpl().file(nitfFile)
                     .allData();
         }
 
-        return new NitfParserInputFlow().file(nitfFile)
+        return new NitfParserInputFlowImpl().file(nitfFile)
                 .headerOnly();
     }
 

--- a/catalog/imaging/imaging-plugin-nitf/pom.xml
+++ b/catalog/imaging/imaging-plugin-nitf/pom.xml
@@ -47,17 +47,31 @@
 
         <dependency>
             <groupId>org.codice.imaging.nitf</groupId>
+            <artifactId>codice-imaging-nitf-core-api</artifactId>
+            <version>${nitf-imaging.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codice.imaging.nitf</groupId>
             <artifactId>codice-imaging-nitf-core</artifactId>
+            <version>${nitf-imaging.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.codice.imaging.nitf</groupId>
             <artifactId>codice-imaging-nitf-render</artifactId>
+            <version>${nitf-imaging.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.codice.imaging.nitf</groupId>
             <artifactId>codice-imaging-nitf-fluent-api</artifactId>
+            <version>${nitf-imaging.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codice.imaging.nitf</groupId>
+            <artifactId>codice-imaging-nitf-fluent</artifactId>
             <version>${nitf-imaging.version}</version>
         </dependency>
 
@@ -122,6 +136,7 @@
                             catalog-core-api-impl;groupId=ddf.catalog.core;version${ddf.version},
                             platform-util,
                             jai-imageio-core,
+                            codice-imaging-nitf-render,
                             jai-imageio-jpeg2000,
                             commons-lang3
                         </Embed-Dependency>

--- a/catalog/imaging/imaging-plugin-nitf/src/main/java/org/codice/alliance/plugin/nitf/NitfPreStoragePlugin.java
+++ b/catalog/imaging/imaging-plugin-nitf/src/main/java/org/codice/alliance/plugin/nitf/NitfPreStoragePlugin.java
@@ -39,7 +39,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.codice.imaging.nitf.core.common.NitfFormatException;
 import org.codice.imaging.nitf.core.image.ImageSegment;
-import org.codice.imaging.nitf.fluent.NitfParserInputFlow;
+import org.codice.imaging.nitf.fluent.impl.NitfParserInputFlowImpl;
 import org.codice.imaging.nitf.render.NitfRenderer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -260,7 +260,7 @@ public class NitfPreStoragePlugin implements PreCreateStoragePlugin, PreUpdateSt
                 try {
                     NitfRenderer renderer = getNitfRenderer();
 
-                    new NitfParserInputFlow().inputStream(inputStream)
+                    new NitfParserInputFlowImpl().inputStream(inputStream)
                             .allData()
                             .forEachImageSegment(segment -> {
                                 if (bufferedImage.get() == null) {

--- a/catalog/imaging/imaging-transformer-chipping/pom.xml
+++ b/catalog/imaging/imaging-transformer-chipping/pom.xml
@@ -90,11 +90,20 @@
         </dependency>
         <dependency>
             <groupId>org.codice.imaging.nitf</groupId>
+            <artifactId>codice-imaging-nitf-core-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.imaging.nitf</groupId>
             <artifactId>codice-imaging-nitf-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.codice.imaging.nitf</groupId>
             <artifactId>codice-imaging-nitf-fluent-api</artifactId>
+            <version>${nitf-imaging.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.imaging.nitf</groupId>
+            <artifactId>codice-imaging-nitf-fluent</artifactId>
             <version>${nitf-imaging.version}</version>
         </dependency>
         <dependency>
@@ -138,6 +147,11 @@
             <artifactId>jai-imageio-core</artifactId>
             <version>${jai-imageio-core.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.codice.usng4j</groupId>
+            <artifactId>usng4j-impl</artifactId>
+            <version>${usng4j.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -163,7 +177,7 @@
                             commons-lang3,
                             codice-imaging-nitf-core,
                             codice-imaging-nitf-render,
-                            codice-imaging-nitf-fluent-api,
+                            usng4j-impl,
                             la4j,
                             jai-imageio-jpeg2000,
                             jai-imageio-core

--- a/catalog/imaging/imaging-transformer-chipping/src/main/java/org/codice/alliance/imaging/chip/transformer/CatalogOutputAdapter.java
+++ b/catalog/imaging/imaging-transformer-chipping/src/main/java/org/codice/alliance/imaging/chip/transformer/CatalogOutputAdapter.java
@@ -41,29 +41,32 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.codice.alliance.imaging.chip.service.impl.CoordinateConverter;
 import org.codice.ddf.platform.util.TemporaryFileBackedOutputStream;
-import org.codice.imaging.nitf.core.common.DateTime;
 import org.codice.imaging.nitf.core.common.FileType;
 import org.codice.imaging.nitf.core.common.NitfFormatException;
 import org.codice.imaging.nitf.core.common.TaggedRecordExtensionHandler;
+import org.codice.imaging.nitf.core.common.impl.DateTimeImpl;
 import org.codice.imaging.nitf.core.header.NitfHeader;
-import org.codice.imaging.nitf.core.header.NitfHeaderFactory;
+import org.codice.imaging.nitf.core.header.impl.NitfHeaderFactory;
 import org.codice.imaging.nitf.core.image.ImageBand;
 import org.codice.imaging.nitf.core.image.ImageCoordinatePair;
 import org.codice.imaging.nitf.core.image.ImageCoordinates;
 import org.codice.imaging.nitf.core.image.ImageCoordinatesRepresentation;
 import org.codice.imaging.nitf.core.image.ImageRepresentation;
 import org.codice.imaging.nitf.core.image.ImageSegment;
-import org.codice.imaging.nitf.core.image.ImageSegmentFactory;
 import org.codice.imaging.nitf.core.image.PixelJustification;
 import org.codice.imaging.nitf.core.image.PixelValueType;
+import org.codice.imaging.nitf.core.image.impl.ImageBandImpl;
+import org.codice.imaging.nitf.core.image.impl.ImageCoordinatePairImpl;
+import org.codice.imaging.nitf.core.image.impl.ImageCoordinatesImpl;
+import org.codice.imaging.nitf.core.image.impl.ImageSegmentFactory;
 import org.codice.imaging.nitf.core.tre.Tre;
 import org.codice.imaging.nitf.core.tre.TreCollection;
-import org.codice.imaging.nitf.core.tre.TreEntry;
-import org.codice.imaging.nitf.core.tre.TreFactory;
 import org.codice.imaging.nitf.core.tre.TreSource;
-import org.codice.imaging.nitf.fluent.NitfCreationFlow;
-import org.codice.imaging.nitf.fluent.NitfParserInputFlow;
+import org.codice.imaging.nitf.core.tre.impl.TreEntryImpl;
+import org.codice.imaging.nitf.core.tre.impl.TreFactory;
 import org.codice.imaging.nitf.fluent.NitfSegmentsFlow;
+import org.codice.imaging.nitf.fluent.impl.NitfCreationFlowImpl;
+import org.codice.imaging.nitf.fluent.impl.NitfParserInputFlowImpl;
 import org.la4j.Vector;
 import org.la4j.vector.dense.BasicVector;
 import org.slf4j.Logger;
@@ -239,7 +242,7 @@ public class CatalogOutputAdapter {
 
             try (InputStream is = tfbos.asByteSource()
                     .openBufferedStream()) {
-                nitfSegmentsFlow = new NitfParserInputFlow().inputStream(is)
+                nitfSegmentsFlow = new NitfParserInputFlowImpl().inputStream(is)
                         .allData();
             }
         }
@@ -312,7 +315,7 @@ public class CatalogOutputAdapter {
             chipHeader.setFileTitle(originalHeader.getFileTitle());
             chipHeader.setOriginatingStationId(originalHeader.getOriginatingStationId());
             chipHeader.setFileBackgroundColour(originalHeader.getFileBackgroundColour());
-            chipHeader.setFileDateTime(DateTime.getNitfDateTimeForNow());
+            chipHeader.setFileDateTime(DateTimeImpl.getNitfDateTimeForNow());
             chipHeader.setFileSecurityMetadata(originalHeader.getFileSecurityMetadata());
             chipHeader.setOriginatorsName(originalHeader.getOriginatorsName());
             chipHeader.setOriginatorsPhoneNumber(originalHeader.getOriginatorsPhoneNumber());
@@ -519,7 +522,7 @@ public class CatalogOutputAdapter {
     }
 
     private ImageBand createImageBand(String imageRepresentation) {
-        ImageBand imageBand = new ImageBand();
+        ImageBandImpl imageBand = new ImageBandImpl();
         imageBand.setImageRepresentation(imageRepresentation);
         imageBand.setImageSubcategory("");
         imageBand.setNumLUTEntries(0);
@@ -572,31 +575,31 @@ public class CatalogOutputAdapter {
 
         List<Vector> chipCornerCoords = coordinateConverter.toLonLat(chipCornerPixels);
 
-        ImageCoordinatePair icp0 = new ImageCoordinatePair();
+        ImageCoordinatePairImpl icp0 = new ImageCoordinatePairImpl();
         icp0.setFromDMS(formatToDMS(chipCornerCoords.get(0)
                         .get(1),
                 chipCornerCoords.get(0)
                         .get(0)));
 
-        ImageCoordinatePair icp1 = new ImageCoordinatePair();
+        ImageCoordinatePairImpl icp1 = new ImageCoordinatePairImpl();
         icp1.setFromDMS(formatToDMS(chipCornerCoords.get(1)
                         .get(1),
                 chipCornerCoords.get(1)
                         .get(0)));
 
-        ImageCoordinatePair icp2 = new ImageCoordinatePair();
+        ImageCoordinatePairImpl icp2 = new ImageCoordinatePairImpl();
         icp2.setFromDMS(formatToDMS(chipCornerCoords.get(2)
                         .get(1),
                 chipCornerCoords.get(2)
                         .get(0)));
 
-        ImageCoordinatePair icp3 = new ImageCoordinatePair();
+        ImageCoordinatePairImpl icp3 = new ImageCoordinatePairImpl();
         icp3.setFromDMS(formatToDMS(chipCornerCoords.get(3)
                         .get(1),
                 chipCornerCoords.get(3)
                         .get(0)));
 
-        chipImageSegment.setImageCoordinates(new ImageCoordinates(new ImageCoordinatePair[] {icp0,
+        chipImageSegment.setImageCoordinates(new ImageCoordinatesImpl(new ImageCoordinatePair[] {icp0,
                 icp1, icp2, icp3}));
         chipImageSegment.setImageCoordinatesRepresentation(ImageCoordinatesRepresentation.GEOGRAPHIC);
 
@@ -682,7 +685,7 @@ public class CatalogOutputAdapter {
         byte[] data;
         File tmpFile = File.createTempFile("nitfchip-", ".ntf");
         try {
-            new NitfCreationFlow().fileHeader(() -> header)
+            new NitfCreationFlowImpl().fileHeader(() -> header)
                     .imageSegment(() -> imageSegment)
                     .write(tmpFile.getAbsolutePath());
 
@@ -705,11 +708,11 @@ public class CatalogOutputAdapter {
 
         Tre ichipb = TreFactory.getDefault("ICHIPB", TreSource.ImageExtendedSubheaderData);
 
-        ichipb.add(new TreEntry("XFRM_FLAG", "00", UINT));
-        ichipb.add(new TreEntry("SCALE_FACTOR", "0001.00000", REAL));
-        ichipb.add(new TreEntry("ANAMRPH_CORR", "00", UINT));
+        ichipb.add(new TreEntryImpl("XFRM_FLAG", "00", UINT));
+        ichipb.add(new TreEntryImpl("SCALE_FACTOR", "0001.00000", REAL));
+        ichipb.add(new TreEntryImpl("ANAMRPH_CORR", "00", UINT));
 
-        ichipb.add(new TreEntry("SCANBLK_NUM", "01", UINT));
+        ichipb.add(new TreEntryImpl("SCANBLK_NUM", "01", UINT));
 
         float halfPixel = 0.5f;
 
@@ -719,14 +722,14 @@ public class CatalogOutputAdapter {
         float chipX1 = (float) chip.getWidth() - halfPixel;
         float chipY1 = (float) chip.getHeight() - halfPixel;
 
-        ichipb.add(new TreEntry("OP_ROW_11", formatCoord(chipY0), REAL));
-        ichipb.add(new TreEntry("OP_COL_11", formatCoord(chipX0), REAL));
-        ichipb.add(new TreEntry("OP_ROW_12", formatCoord(chipY0), REAL));
-        ichipb.add(new TreEntry("OP_COL_12", formatCoord(chipX1), REAL));
-        ichipb.add(new TreEntry("OP_ROW_21", formatCoord(chipY1), REAL));
-        ichipb.add(new TreEntry("OP_COL_21", formatCoord(chipX0), REAL));
-        ichipb.add(new TreEntry("OP_ROW_22", formatCoord(chipY1), REAL));
-        ichipb.add(new TreEntry("OP_COL_22", formatCoord(chipX1), REAL));
+        ichipb.add(new TreEntryImpl("OP_ROW_11", formatCoord(chipY0), REAL));
+        ichipb.add(new TreEntryImpl("OP_COL_11", formatCoord(chipX0), REAL));
+        ichipb.add(new TreEntryImpl("OP_ROW_12", formatCoord(chipY0), REAL));
+        ichipb.add(new TreEntryImpl("OP_COL_12", formatCoord(chipX1), REAL));
+        ichipb.add(new TreEntryImpl("OP_ROW_21", formatCoord(chipY1), REAL));
+        ichipb.add(new TreEntryImpl("OP_COL_21", formatCoord(chipX0), REAL));
+        ichipb.add(new TreEntryImpl("OP_ROW_22", formatCoord(chipY1), REAL));
+        ichipb.add(new TreEntryImpl("OP_COL_22", formatCoord(chipX1), REAL));
 
         float origX0 = sourceX + halfPixel;
         float origY0 = sourceY + halfPixel;
@@ -734,17 +737,17 @@ public class CatalogOutputAdapter {
         float origX1 = sourceX + selectWidth - halfPixel;
         float origY1 = sourceY + selectHeight - halfPixel;
 
-        ichipb.add(new TreEntry("FI_ROW_11", formatCoord(origY0), REAL));
-        ichipb.add(new TreEntry("FI_COL_11", formatCoord(origX0), REAL));
-        ichipb.add(new TreEntry("FI_ROW_12", formatCoord(origY0), REAL));
-        ichipb.add(new TreEntry("FI_COL_12", formatCoord(origX1), REAL));
-        ichipb.add(new TreEntry("FI_ROW_21", formatCoord(origY1), REAL));
-        ichipb.add(new TreEntry("FI_COL_21", formatCoord(origX0), REAL));
-        ichipb.add(new TreEntry("FI_ROW_22", formatCoord(origY1), REAL));
-        ichipb.add(new TreEntry("FI_COL_22", formatCoord(origX1), REAL));
+        ichipb.add(new TreEntryImpl("FI_ROW_11", formatCoord(origY0), REAL));
+        ichipb.add(new TreEntryImpl("FI_COL_11", formatCoord(origX0), REAL));
+        ichipb.add(new TreEntryImpl("FI_ROW_12", formatCoord(origY0), REAL));
+        ichipb.add(new TreEntryImpl("FI_COL_12", formatCoord(origX1), REAL));
+        ichipb.add(new TreEntryImpl("FI_ROW_21", formatCoord(origY1), REAL));
+        ichipb.add(new TreEntryImpl("FI_COL_21", formatCoord(origX0), REAL));
+        ichipb.add(new TreEntryImpl("FI_ROW_22", formatCoord(origY1), REAL));
+        ichipb.add(new TreEntryImpl("FI_COL_22", formatCoord(origX1), REAL));
 
-        ichipb.add(new TreEntry("FI_ROW", "00000000", UINT));
-        ichipb.add(new TreEntry("FI_COL", "00000000", UINT));
+        ichipb.add(new TreEntryImpl("FI_ROW", "00000000", UINT));
+        ichipb.add(new TreEntryImpl("FI_COL", "00000000", UINT));
 
         return ichipb;
     }

--- a/catalog/imaging/imaging-transformer-chipping/src/test/java/org/codice/alliance/imaging/chip/transformer/CatalogOutputAdapterTest.java
+++ b/catalog/imaging/imaging-transformer-chipping/src/test/java/org/codice/alliance/imaging/chip/transformer/CatalogOutputAdapterTest.java
@@ -42,10 +42,10 @@ import javax.imageio.ImageIO;
 
 import org.codice.ddf.platform.util.TemporaryFileBackedOutputStream;
 import org.codice.imaging.nitf.core.DataSource;
-import org.codice.imaging.nitf.core.RGBColour;
 import org.codice.imaging.nitf.core.common.DateTime;
 import org.codice.imaging.nitf.core.common.FileType;
 import org.codice.imaging.nitf.core.common.NitfFormatException;
+import org.codice.imaging.nitf.core.common.impl.DateTimeImpl;
 import org.codice.imaging.nitf.core.header.NitfHeader;
 import org.codice.imaging.nitf.core.image.ImageCategory;
 import org.codice.imaging.nitf.core.image.ImageCoordinatePair;
@@ -53,15 +53,19 @@ import org.codice.imaging.nitf.core.image.ImageCoordinates;
 import org.codice.imaging.nitf.core.image.ImageRepresentation;
 import org.codice.imaging.nitf.core.image.ImageSegment;
 import org.codice.imaging.nitf.core.image.PixelValueType;
-import org.codice.imaging.nitf.core.image.TargetId;
+import org.codice.imaging.nitf.core.image.impl.ImageCoordinatePairImpl;
+import org.codice.imaging.nitf.core.image.impl.ImageCoordinatesImpl;
+import org.codice.imaging.nitf.core.image.impl.TargetIdImpl;
+import org.codice.imaging.nitf.core.impl.RGBColourImpl;
 import org.codice.imaging.nitf.core.security.FileSecurityMetadata;
 import org.codice.imaging.nitf.core.security.SecurityClassification;
 import org.codice.imaging.nitf.core.security.SecurityMetadata;
 import org.codice.imaging.nitf.core.tre.Tre;
-import org.codice.imaging.nitf.core.tre.TreCollection;
 import org.codice.imaging.nitf.core.tre.TreEntry;
-import org.codice.imaging.nitf.fluent.NitfParserInputFlow;
+import org.codice.imaging.nitf.core.tre.impl.TreCollectionImpl;
 import org.codice.imaging.nitf.fluent.NitfSegmentsFlow;
+import org.codice.imaging.nitf.fluent.impl.NitfParserInputFlowImpl;
+import org.codice.imaging.nitf.fluent.impl.NitfSegmentsFlowImpl;
 import org.hamcrest.Description;
 import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
@@ -189,7 +193,7 @@ public class CatalogOutputAdapterTest {
                 0);
 
         NitfSegmentsFlow chipNitfSegmentFlow =
-                new NitfParserInputFlow().inputStream(binaryContent.getInputStream())
+                new NitfParserInputFlowImpl().inputStream(binaryContent.getInputStream())
                         .allData();
 
         chipNitfSegmentFlow.forEachImageSegment(imageSegment1 -> {
@@ -227,7 +231,7 @@ public class CatalogOutputAdapterTest {
                 0);
 
         NitfSegmentsFlow chipNitfSegmentFlow =
-                new NitfParserInputFlow().inputStream(binaryContent.getInputStream())
+                new NitfParserInputFlowImpl().inputStream(binaryContent.getInputStream())
                         .allData();
 
         chipNitfSegmentFlow.forEachImageSegment(imageSegment1 -> {
@@ -265,7 +269,7 @@ public class CatalogOutputAdapterTest {
                 0);
 
         NitfSegmentsFlow chipNitfSegmentFlow =
-                new NitfParserInputFlow().inputStream(binaryContent.getInputStream())
+                new NitfParserInputFlowImpl().inputStream(binaryContent.getInputStream())
                         .allData();
 
         chipNitfSegmentFlow.forEachImageSegment(imageSegment1 -> {
@@ -307,7 +311,7 @@ public class CatalogOutputAdapterTest {
 
         FileSecurityMetadata fileSecurityMetadata = createFileSecurityMetadata();
 
-        DateTime dateTime = DateTime.getNitfDateTimeForNow();
+        DateTime dateTime = DateTimeImpl.getNitfDateTimeForNow();
 
         NitfHeader nitfHeader = getNitfHeader(fileSecurityMetadata, dateTime);
 
@@ -323,8 +327,8 @@ public class CatalogOutputAdapterTest {
 
         DataSource dataSource = getDataSource(nitfHeader, Collections.singletonList(imageSegment));
 
-        Constructor<NitfSegmentsFlow> constructor;
-        constructor = NitfSegmentsFlow.class.getDeclaredConstructor(DataSource.class,
+        Constructor<NitfSegmentsFlowImpl> constructor;
+        constructor = NitfSegmentsFlowImpl.class.getDeclaredConstructor(DataSource.class,
                 Runnable.class);
         constructor.setAccessible(true);
         NitfSegmentsFlow nitfSegmentsFlow = constructor.newInstance(dataSource, (Runnable) () -> {
@@ -336,7 +340,7 @@ public class CatalogOutputAdapterTest {
                 chipY);
 
         NitfSegmentsFlow chipNitfSegmentFlow =
-                new NitfParserInputFlow().inputStream(binaryContent.getInputStream())
+                new NitfParserInputFlowImpl().inputStream(binaryContent.getInputStream())
                         .allData();
 
         assertThat(chipNitfSegmentFlow, notNullValue());
@@ -434,7 +438,7 @@ public class CatalogOutputAdapterTest {
             assertThat(imageSegment1.getImageMagnification(), is("1.0 "));
             try {
                 assertThat(imageSegment1.getImageTargetId()
-                        .textValue(), is(new TargetId("                 ").textValue()));
+                        .textValue(), is(new TargetIdImpl("                 ").textValue()));
             } catch (NitfFormatException e) {
                 fail(e.getMessage());
             }
@@ -470,7 +474,7 @@ public class CatalogOutputAdapterTest {
 
         FileSecurityMetadata fileSecurityMetadata = createFileSecurityMetadata();
 
-        DateTime dateTime = DateTime.getNitfDateTimeForNow();
+        DateTime dateTime = DateTimeImpl.getNitfDateTimeForNow();
 
         DataSource dataSource = mock(DataSource.class);
         NitfHeader nitfHeader = getNitfHeader(fileSecurityMetadata, dateTime);
@@ -488,8 +492,8 @@ public class CatalogOutputAdapterTest {
         when(dataSource.getNitfHeader()).thenReturn(nitfHeader);
         when(dataSource.getImageSegments()).thenReturn(Collections.singletonList(imageSegment));
 
-        Constructor<NitfSegmentsFlow> constructor;
-        constructor = NitfSegmentsFlow.class.getDeclaredConstructor(DataSource.class,
+        Constructor<NitfSegmentsFlowImpl> constructor;
+        constructor = NitfSegmentsFlowImpl.class.getDeclaredConstructor(DataSource.class,
                 Runnable.class);
         constructor.setAccessible(true);
         NitfSegmentsFlow nitfSegmentsFlow = constructor.newInstance(dataSource, (Runnable) () -> {
@@ -501,7 +505,7 @@ public class CatalogOutputAdapterTest {
                 chipY);
 
         NitfSegmentsFlow chipNitfSegmentFlow =
-                new NitfParserInputFlow().inputStream(binaryContent.getInputStream())
+                new NitfParserInputFlowImpl().inputStream(binaryContent.getInputStream())
                         .allData();
 
         assertThat(chipNitfSegmentFlow, notNullValue());
@@ -599,7 +603,7 @@ public class CatalogOutputAdapterTest {
             assertThat(imageSegment1.getImageMagnification(), is("1.0 "));
             try {
                 assertThat(imageSegment1.getImageTargetId()
-                        .textValue(), is(new TargetId("                 ").textValue()));
+                        .textValue(), is(new TargetIdImpl("                 ").textValue()));
             } catch (NitfFormatException e) {
                 fail(e.getMessage());
             }
@@ -770,7 +774,7 @@ public class CatalogOutputAdapterTest {
     }
 
     private ImageCoordinates getImageCoordinates() throws NitfFormatException {
-        return new ImageCoordinates(new ImageCoordinatePair[] {icp("200000N0200000E"),
+        return new ImageCoordinatesImpl(new ImageCoordinatePair[] {icp("200000N0200000E"),
                 icp("200000N0400000E"), icp("000000N0400000E"), icp("000000N0200000E")});
     }
 
@@ -787,12 +791,12 @@ public class CatalogOutputAdapterTest {
         when(imageSegment.getIdentifier()).thenReturn("0123456789");
         when(imageSegment.getImageIdentifier2()).thenReturn("abc");
         when(imageSegment.getImageMagnification()).thenReturn("1.0 ");
-        when(imageSegment.getImageTargetId()).thenReturn(new TargetId("                 "));
+        when(imageSegment.getImageTargetId()).thenReturn(new TargetIdImpl("                 "));
         when(imageSegment.getImageSource()).thenReturn("");
         when(imageSegment.getImageDateTime()).thenReturn(dateTime);
         when(imageSegment.getImageRepresentation()).thenReturn(ImageRepresentation.UNKNOWN);
         when(imageSegment.getSecurityMetadata()).thenReturn(imageSecurityMetadata);
-        when(imageSegment.getTREsRawStructure()).thenReturn(new TreCollection());
+        when(imageSegment.getTREsRawStructure()).thenReturn(new TreCollectionImpl());
         return imageSegment;
     }
 
@@ -835,14 +839,14 @@ public class CatalogOutputAdapterTest {
         when(nitfHeader.getFileTitle()).thenReturn("FileTitle");
         when(nitfHeader.getStandardType()).thenReturn("BF01");
         when(nitfHeader.getOriginatingStationId()).thenReturn("U21SOO90");
-        when(nitfHeader.getFileBackgroundColour()).thenReturn(new RGBColour((byte) 0,
+        when(nitfHeader.getFileBackgroundColour()).thenReturn(new RGBColourImpl((byte) 0,
                 (byte) 0,
                 (byte) 0));
         when(nitfHeader.getFileDateTime()).thenReturn(dateTime);
         when(nitfHeader.getFileSecurityMetadata()).thenReturn(fileSecurityMetadata);
         when(nitfHeader.getOriginatorsName()).thenReturn("W.TEMPEL");
         when(nitfHeader.getOriginatorsPhoneNumber()).thenReturn("44 1480 84 5611");
-        when(nitfHeader.getTREsRawStructure()).thenReturn(new TreCollection());
+        when(nitfHeader.getTREsRawStructure()).thenReturn(new TreCollectionImpl());
         return nitfHeader;
     }
 
@@ -905,7 +909,7 @@ public class CatalogOutputAdapterTest {
     }
 
     private ImageCoordinatePair icp(String value) throws NitfFormatException {
-        ImageCoordinatePair icp = new ImageCoordinatePair();
+        ImageCoordinatePairImpl icp = new ImageCoordinatePairImpl();
         icp.setFromDMS(value);
         return icp;
     }
@@ -913,7 +917,7 @@ public class CatalogOutputAdapterTest {
     private NitfSegmentsFlow createGenericNitfSegmentFlow(int originalWidth, int originalHeight)
             throws NitfFormatException, NoSuchMethodException, InstantiationException,
             IllegalAccessException, InvocationTargetException {
-        DateTime dateTime = DateTime.getNitfDateTimeForNow();
+        DateTime dateTime = DateTimeImpl.getNitfDateTimeForNow();
 
         FileSecurityMetadata fileSecurityMetadata = createFileSecurityMetadata();
 
@@ -931,8 +935,8 @@ public class CatalogOutputAdapterTest {
 
         DataSource dataSource = getDataSource(nitfHeader, Collections.singletonList(imageSegment));
 
-        Constructor<NitfSegmentsFlow> constructor;
-        constructor = NitfSegmentsFlow.class.getDeclaredConstructor(DataSource.class,
+        Constructor<NitfSegmentsFlowImpl> constructor;
+        constructor = NitfSegmentsFlowImpl.class.getDeclaredConstructor(DataSource.class,
                 Runnable.class);
         constructor.setAccessible(true);
         return constructor.newInstance(dataSource, (Runnable) () -> {

--- a/catalog/imaging/imaging-transformer-nitf/pom.xml
+++ b/catalog/imaging/imaging-transformer-nitf/pom.xml
@@ -67,18 +67,33 @@
 
         <dependency>
             <groupId>org.codice.imaging.nitf</groupId>
+            <artifactId>codice-imaging-nitf-core-api</artifactId>
+            <version>${nitf-imaging.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codice.imaging.nitf</groupId>
             <artifactId>codice-imaging-nitf-core</artifactId>
+            <version>${nitf-imaging.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.codice.imaging.nitf</groupId>
             <artifactId>codice-imaging-nitf-render</artifactId>
+            <version>${nitf-imaging.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.codice.imaging.nitf</groupId>
             <artifactId>codice-imaging-nitf-fluent-api</artifactId>
             <version>${nitf-imaging.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codice.imaging.nitf</groupId>
+            <artifactId>codice-imaging-nitf-fluent</artifactId>
+            <version>${nitf-imaging.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -117,6 +132,12 @@
             <artifactId>commons-lang3</artifactId>
             <version>${commons-lang3.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.codice.usng4j</groupId>
+            <artifactId>usng4j-impl</artifactId>
+            <version>${usng4j.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -133,6 +154,7 @@
                             platform-util,
                             jai-imageio-core,
                             jai-imageio-jpeg2000,
+                            usng4j-impl,
                             commons-lang3
                         </Embed-Dependency>
                         <Export-Package/>

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/NitfImageTransformer.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/NitfImageTransformer.java
@@ -132,14 +132,18 @@ public class NitfImageTransformer extends SegmentHandler {
         ImageCoordinatesRepresentation imageCoordinatesRepresentation =
                 imageSegmentHeader.getImageCoordinatesRepresentation();
 
-        if (imageCoordinatesRepresentation == ImageCoordinatesRepresentation.GEOGRAPHIC
-                || imageCoordinatesRepresentation
-                == ImageCoordinatesRepresentation.DECIMALDEGREES) {
+        switch (imageCoordinatesRepresentation) {
+        case MGRS:
+        case UTMNORTH:
+        case UTMSOUTH:
+        case GEOGRAPHIC:
+        case DECIMALDEGREES:
             polygons.add(getPolygonForSegment(imageSegmentHeader, GEOMETRY_FACTORY));
-
-        } else if (imageCoordinatesRepresentation != ImageCoordinatesRepresentation.NONE) {
+            break;
+        default:
             LOGGER.debug("Unsupported representation: {}. The NITF will be ingested, but image"
                     + " coordinates will not be available.", imageCoordinatesRepresentation);
+            break;
         }
     }
 

--- a/catalog/imaging/imaging-transformer-nitf/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -66,6 +66,9 @@
             <setHeader headerName="nitfSegmentsFlow">
                 <method ref="nitfParserService" method="endNitfSegmentsFlow(${header.nitfSegmentsFlow})"/>
             </setHeader>
+            <setHeader headerName="allData">
+                <constant>true</constant>
+            </setHeader>
         </route>
 
         <route id="transform-nitf">

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/RoutingSlipTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/RoutingSlipTest.java
@@ -20,8 +20,8 @@ import java.io.File;
 import java.io.FileNotFoundException;
 
 import org.codice.imaging.nitf.core.common.NitfFormatException;
-import org.codice.imaging.nitf.fluent.NitfParserInputFlow;
 import org.codice.imaging.nitf.fluent.NitfSegmentsFlow;
+import org.codice.imaging.nitf.fluent.impl.NitfParserInputFlowImpl;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -58,7 +58,7 @@ public class RoutingSlipTest {
 
     @Test
     public void testChannelImageNoTres() throws FileNotFoundException, NitfFormatException {
-        NitfSegmentsFlow parserInputFlow = new NitfParserInputFlow().file(new File(
+        NitfSegmentsFlow parserInputFlow = new NitfParserInputFlowImpl().file(new File(
                 IMAGE_NO_TRE_NTF_FILENAME))
                 .headerOnly();
 
@@ -68,7 +68,7 @@ public class RoutingSlipTest {
 
     @Test
     public void testChannelImageTre() throws FileNotFoundException, NitfFormatException {
-        NitfSegmentsFlow parserInputFlow = new NitfParserInputFlow().file(new File(
+        NitfSegmentsFlow parserInputFlow = new NitfParserInputFlowImpl().file(new File(
                 IMAGE_TRE_NTF_FILENAME))
                 .headerOnly();
 
@@ -78,7 +78,7 @@ public class RoutingSlipTest {
 
     @Test
     public void testChannelNoImageTre() throws FileNotFoundException, NitfFormatException {
-        NitfSegmentsFlow parserInputFlow = new NitfParserInputFlow().file(new File(
+        NitfSegmentsFlow parserInputFlow = new NitfParserInputFlowImpl().file(new File(
                 NO_IMAGE_TRE_NTF_FILENAME))
                 .headerOnly();
 
@@ -88,7 +88,7 @@ public class RoutingSlipTest {
 
     @Test
     public void testChannelNoImageNoTre() throws FileNotFoundException, NitfFormatException {
-        NitfSegmentsFlow parserInputFlow = new NitfParserInputFlow().file(new File(
+        NitfSegmentsFlow parserInputFlow = new NitfParserInputFlowImpl().file(new File(
                 NO_IMAGE_NO_TRE_NTF_FILENAME))
                 .headerOnly();
 

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/TreTestUtility.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/TreTestUtility.java
@@ -20,10 +20,10 @@ import static org.mockito.Mockito.when;
 import java.io.File;
 import java.util.function.Consumer;
 
-import org.codice.imaging.nitf.core.RGBColour;
 import org.codice.imaging.nitf.core.common.DateTime;
 import org.codice.imaging.nitf.core.common.FileType;
 import org.codice.imaging.nitf.core.common.NitfFormatException;
+import org.codice.imaging.nitf.core.common.impl.DateTimeImpl;
 import org.codice.imaging.nitf.core.header.NitfHeader;
 import org.codice.imaging.nitf.core.image.ImageBand;
 import org.codice.imaging.nitf.core.image.ImageCategory;
@@ -34,16 +34,18 @@ import org.codice.imaging.nitf.core.image.ImageRepresentation;
 import org.codice.imaging.nitf.core.image.ImageSegment;
 import org.codice.imaging.nitf.core.image.PixelJustification;
 import org.codice.imaging.nitf.core.image.PixelValueType;
-import org.codice.imaging.nitf.core.image.TargetId;
+import org.codice.imaging.nitf.core.image.impl.TargetIdImpl;
+import org.codice.imaging.nitf.core.impl.RGBColourImpl;
 import org.codice.imaging.nitf.core.security.FileSecurityMetadata;
 import org.codice.imaging.nitf.core.security.SecurityClassification;
 import org.codice.imaging.nitf.core.security.SecurityMetadata;
 import org.codice.imaging.nitf.core.tre.Tre;
 import org.codice.imaging.nitf.core.tre.TreCollection;
-import org.codice.imaging.nitf.core.tre.TreEntry;
 import org.codice.imaging.nitf.core.tre.TreGroup;
 import org.codice.imaging.nitf.core.tre.TreSource;
-import org.codice.imaging.nitf.fluent.NitfCreationFlow;
+import org.codice.imaging.nitf.core.tre.impl.TreCollectionImpl;
+import org.codice.imaging.nitf.core.tre.impl.TreEntryImpl;
+import org.codice.imaging.nitf.fluent.impl.NitfCreationFlowImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,18 +61,18 @@ public class TreTestUtility {
     }
 
     public static void createNitfNoImageNoTres(String filename) {
-        new NitfCreationFlow().fileHeader(() -> createFileHeader())
+        new NitfCreationFlowImpl().fileHeader(() -> createFileHeader())
                 .write(filename);
     }
 
     public static void createNitfImageNoTres(String filename) {
-        new NitfCreationFlow().fileHeader(() -> createFileHeader())
+        new NitfCreationFlowImpl().fileHeader(() -> createFileHeader())
                 .imageSegment(() -> createImageSegment())
                 .write(filename);
     }
 
     public static void createNitfNoImageTres(String filename) {
-        new NitfCreationFlow().fileHeader(() -> {
+        new NitfCreationFlowImpl().fileHeader(() -> {
             try {
                 return createFileHeaderWithMtirpb();
             } catch (NitfFormatException e) {
@@ -83,7 +85,7 @@ public class TreTestUtility {
     }
 
     public static void createNitfImageTres(String filename) {
-        new NitfCreationFlow().fileHeader(() -> {
+        new NitfCreationFlowImpl().fileHeader(() -> {
             try {
                 return createFileHeaderWithMtirpb();
             } catch (NitfFormatException e) {
@@ -118,11 +120,11 @@ public class TreTestUtility {
 
         for (int i = 0; i < fieldNames.length; i++) {
             accumulator.append(values[i]);
-            when(tre.getEntry(fieldNames[i])).thenReturn(new TreEntry(fieldNames[i], values[i], "string"));
+            when(tre.getEntry(fieldNames[i])).thenReturn(new TreEntryImpl(fieldNames[i], values[i], "string"));
         }
 
         TreGroup targetsGroup = createTreGroup(accumulator);
-        TreEntry targetsEntry = new TreEntry("TARGETS");
+        TreEntryImpl targetsEntry = new TreEntryImpl("TARGETS");
         targetsEntry.addGroup(targetsGroup);
         when(tre.getEntry("TARGETS")).thenReturn(targetsEntry);
         when(tre.getSource()).thenReturn(TreSource.UserDefinedHeaderData);
@@ -149,11 +151,11 @@ public class TreTestUtility {
     }
 
     public static NitfHeader createFileHeader() {
-        return createFileHeader(DateTime.getNitfDateTimeForNow());
+        return createFileHeader(DateTimeImpl.getNitfDateTimeForNow());
     }
 
     public static NitfHeader createFileHeader(DateTime fileDateTime) {
-        TreCollection treCollection = new TreCollection();
+        TreCollection treCollection = new TreCollectionImpl();
         FileSecurityMetadata securityMetadata = createSecurityMetadata();
         NitfHeader nitfHeader = mock(NitfHeader.class);
         when(nitfHeader.getFileTitle()).thenReturn("TEST NITF");
@@ -162,7 +164,7 @@ public class TreTestUtility {
         when(nitfHeader.getFileDateTime()).thenReturn(fileDateTime);
         when(nitfHeader.getOriginatingStationId()).thenReturn("LOCALHOST");
         when(nitfHeader.getStandardType()).thenReturn("BF01");
-        when(nitfHeader.getFileBackgroundColour()).thenReturn(new RGBColour((byte) 0,
+        when(nitfHeader.getFileBackgroundColour()).thenReturn(new RGBColourImpl((byte) 0,
                 (byte) 0,
                 (byte) 0));
         when(nitfHeader.getOriginatorsName()).thenReturn("");
@@ -197,21 +199,21 @@ public class TreTestUtility {
     }
 
     public static ImageSegment createImageSegment() {
-        return createImageSegment(DateTime.getNitfDateTimeForNow());
+        return createImageSegment(DateTimeImpl.getNitfDateTimeForNow());
     }
 
     public static ImageSegment createImageSegment(DateTime imageDateTime) {
         SecurityMetadata securityMetadata = createSecurityMetadata();
         ImageBand imageBand = createImageBand();
         ImageSegment imageSegment = mock(ImageSegment.class);
-        TreCollection treCollection = new TreCollection();
+        TreCollection treCollection = new TreCollectionImpl();
 
         when(imageSegment.getFileType()).thenReturn(FileType.NITF_TWO_ONE);
         when(imageSegment.getNumBands()).thenReturn(3);
         when(imageSegment.getActualBitsPerPixelPerBand()).thenReturn(8);
         when(imageSegment.getIdentifier()).thenReturn("12345");
         when(imageSegment.getImageDateTime()).thenReturn(imageDateTime);
-        when(imageSegment.getImageTargetId()).thenReturn(new TargetId());
+        when(imageSegment.getImageTargetId()).thenReturn(new TargetIdImpl());
         when(imageSegment.getImageIdentifier2()).thenReturn("");
         when(imageSegment.getSecurityMetadata()).thenReturn(securityMetadata);
         when(imageSegment.getImageSource()).thenReturn("");
@@ -241,9 +243,9 @@ public class TreTestUtility {
     }
 
     public static ImageBand createImageBand() {
-        ImageBand imageBand = new ImageBand();
-        imageBand.setImageRepresentation("RGB");
-        imageBand.setImageSubcategory("XXX");
+        ImageBand imageBand = mock(ImageBand.class);
+        when(imageBand.getImageRepresentation()).thenReturn("RGB");
+        when(imageBand.getSubCategory()).thenReturn("XXX");
         return imageBand;
     }
 }

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/gmti/NitfGmtiTransformerTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/gmti/NitfGmtiTransformerTest.java
@@ -41,8 +41,8 @@ import org.codice.alliance.transformer.nitf.common.NitfAttribute;
 import org.codice.alliance.transformer.nitf.common.NitfHeaderTransformer;
 import org.codice.imaging.nitf.core.common.NitfFormatException;
 import org.codice.imaging.nitf.core.tre.Tre;
-import org.codice.imaging.nitf.fluent.NitfParserInputFlow;
 import org.codice.imaging.nitf.fluent.NitfSegmentsFlow;
+import org.codice.imaging.nitf.fluent.impl.NitfParserInputFlowImpl;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -93,7 +93,7 @@ public class NitfGmtiTransformerTest {
 
     @Test
     public void testTre() throws IOException, CatalogTransformerException, NitfFormatException {
-        NitfSegmentsFlow nitfSegmentsFlow = new NitfParserInputFlow().inputStream(getInputStream(
+        NitfSegmentsFlow nitfSegmentsFlow = new NitfParserInputFlowImpl().inputStream(getInputStream(
                 GMTI_TEST_NITF))
                 .allData();
 

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageInputTransformerTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageInputTransformerTest.java
@@ -60,19 +60,20 @@ import org.codice.alliance.transformer.nitf.common.PiatgbAttribute;
 import org.codice.imaging.nitf.core.common.DateTime;
 import org.codice.imaging.nitf.core.common.FileType;
 import org.codice.imaging.nitf.core.common.NitfFormatException;
+import org.codice.imaging.nitf.core.common.impl.DateTimeImpl;
 import org.codice.imaging.nitf.core.header.NitfHeader;
-import org.codice.imaging.nitf.core.header.NitfHeaderFactory;
-import org.codice.imaging.nitf.core.image.ImageBand;
+import org.codice.imaging.nitf.core.header.impl.NitfHeaderFactory;
 import org.codice.imaging.nitf.core.image.ImageSegment;
-import org.codice.imaging.nitf.core.image.ImageSegmentFactory;
+import org.codice.imaging.nitf.core.image.impl.ImageSegmentFactory;
 import org.codice.imaging.nitf.core.tre.Tre;
-import org.codice.imaging.nitf.core.tre.TreEntry;
-import org.codice.imaging.nitf.core.tre.TreFactory;
 import org.codice.imaging.nitf.core.tre.TreGroup;
 import org.codice.imaging.nitf.core.tre.TreSource;
+import org.codice.imaging.nitf.core.tre.impl.TreEntryImpl;
+import org.codice.imaging.nitf.core.tre.impl.TreFactory;
 import org.codice.imaging.nitf.fluent.NitfCreationFlow;
-import org.codice.imaging.nitf.fluent.NitfParserInputFlow;
 import org.codice.imaging.nitf.fluent.NitfSegmentsFlow;
+import org.codice.imaging.nitf.fluent.impl.NitfCreationFlowImpl;
+import org.codice.imaging.nitf.fluent.impl.NitfParserInputFlowImpl;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -118,7 +119,7 @@ public class ImageInputTransformerTest {
 
     @Test
     public void testNitfParsing() throws Exception {
-        NitfSegmentsFlow nitfSegmentsFlow = new NitfParserInputFlow().inputStream(getInputStream(
+        NitfSegmentsFlow nitfSegmentsFlow = new NitfParserInputFlowImpl().inputStream(getInputStream(
                 GEO_NITF))
                 .allData();
 
@@ -206,29 +207,29 @@ public class ImageInputTransformerTest {
         String location = "4559N23345W";
 
         Tre aimidb = TreFactory.getDefault("AIMIDB", TreSource.ImageExtendedSubheaderData);
-        aimidb.add(new TreEntry("ACQUISITION_DATE", acquisitionDate, "string"));
-        aimidb.add(new TreEntry("MISSION_NO", missionNumber, "string"));
-        aimidb.add(new TreEntry("MISSION_IDENTIFICATION", "NOT AVAIL.", "string"));
-        aimidb.add(new TreEntry("FLIGHT_NO", "01", "string"));
-        aimidb.add(new TreEntry("OP_NUM", "001", "UINT"));
-        aimidb.add(new TreEntry("CURRENT_SEGMENT", "AA", "string"));
-        aimidb.add(new TreEntry("REPRO_NUM", "01", "UINT"));
-        aimidb.add(new TreEntry("REPLAY", "000", "string"));
-        aimidb.add(new TreEntry("RESERVED_1", " ", "string"));
-        aimidb.add(new TreEntry("START_TILE_COLUMN", "001", "UINT"));
-        aimidb.add(new TreEntry("START_TILE_ROW", "00001", "UINT"));
-        aimidb.add(new TreEntry("END_SEGMENT", "AA", "string"));
-        aimidb.add(new TreEntry("END_TILE_COLUMN", "001", "UINT"));
-        aimidb.add(new TreEntry("END_TILE_ROW", "00001", "UINT"));
-        aimidb.add(new TreEntry("COUNTRY", country, "string"));
-        aimidb.add(new TreEntry("RESERVED_2", "    ", "string"));
-        aimidb.add(new TreEntry("LOCATION", location, "string"));
-        aimidb.add(new TreEntry("RESERVED_3", "             ", "string"));
+        aimidb.add(new TreEntryImpl("ACQUISITION_DATE", acquisitionDate, "string"));
+        aimidb.add(new TreEntryImpl("MISSION_NO", missionNumber, "string"));
+        aimidb.add(new TreEntryImpl("MISSION_IDENTIFICATION", "NOT AVAIL.", "string"));
+        aimidb.add(new TreEntryImpl("FLIGHT_NO", "01", "string"));
+        aimidb.add(new TreEntryImpl("OP_NUM", "001", "UINT"));
+        aimidb.add(new TreEntryImpl("CURRENT_SEGMENT", "AA", "string"));
+        aimidb.add(new TreEntryImpl("REPRO_NUM", "01", "UINT"));
+        aimidb.add(new TreEntryImpl("REPLAY", "000", "string"));
+        aimidb.add(new TreEntryImpl("RESERVED_1", " ", "string"));
+        aimidb.add(new TreEntryImpl("START_TILE_COLUMN", "001", "UINT"));
+        aimidb.add(new TreEntryImpl("START_TILE_ROW", "00001", "UINT"));
+        aimidb.add(new TreEntryImpl("END_SEGMENT", "AA", "string"));
+        aimidb.add(new TreEntryImpl("END_TILE_COLUMN", "001", "UINT"));
+        aimidb.add(new TreEntryImpl("END_TILE_ROW", "00001", "UINT"));
+        aimidb.add(new TreEntryImpl("COUNTRY", country, "string"));
+        aimidb.add(new TreEntryImpl("RESERVED_2", "    ", "string"));
+        aimidb.add(new TreEntryImpl("LOCATION", location, "string"));
+        aimidb.add(new TreEntryImpl("RESERVED_3", "             ", "string"));
         ImageSegment imageSegment = TreTestUtility.createImageSegment();
         imageSegment.getTREsRawStructure()
                 .add(aimidb);
 
-        new NitfCreationFlow().fileHeader(() -> TreTestUtility.createFileHeader())
+        new NitfCreationFlowImpl().fileHeader(() -> TreTestUtility.createFileHeader())
                 .imageSegment(() -> imageSegment)
                 .write(file.getAbsolutePath());
 
@@ -249,7 +250,7 @@ public class ImageInputTransformerTest {
 
             try (InputStream inputStream = new FileInputStream(nitfFile)) {
                 Metacard metacard = metacardFactory.createMetacard("aimidbTest");
-                NitfSegmentsFlow nitfSegmentsFlow = new NitfParserInputFlow().inputStream(inputStream)
+                NitfSegmentsFlow nitfSegmentsFlow = new NitfParserInputFlowImpl().inputStream(inputStream)
                         .headerOnly();
                 headerTransformer.transform(nitfSegmentsFlow, metacard);
                 transformer.transform(nitfSegmentsFlow, metacard);
@@ -270,68 +271,68 @@ public class ImageInputTransformerTest {
                 + "                -END-";
 
         Tre piaprd = TreFactory.getDefault("PIAPRD", TreSource.ImageExtendedSubheaderData);
-        piaprd.add(new TreEntry("ACCESSID", accessId, "string"));
-        piaprd.add(new TreEntry("FMCONTROL", "PXX                        -END-", "string"));
-        piaprd.add(new TreEntry("SUBDET", "P", "string"));
-        piaprd.add(new TreEntry("PRODCODE", "YY", "string"));
-        piaprd.add(new TreEntry("PRODUCERSE", "UNKNOW", "string"));
-        piaprd.add(new TreEntry("PRODIDNO", "X211           -END-", "string"));
-        piaprd.add(new TreEntry("PRODSNME", "JUNK FILE.", "string"));
-        piaprd.add(new TreEntry("PRODUCERCD", "27", "string"));
-        piaprd.add(new TreEntry("PRODCRTIME", "26081023ZOCT95", "string"));
-        piaprd.add(new TreEntry("MAPID", "132                                -END-", "string"));
-        piaprd.add(new TreEntry("SECTITLEREP", "01", "UINT"));
-        TreEntry secTitleEntry = new TreEntry("SECTITLE", null, "string");
+        piaprd.add(new TreEntryImpl("ACCESSID", accessId, "string"));
+        piaprd.add(new TreEntryImpl("FMCONTROL", "PXX                        -END-", "string"));
+        piaprd.add(new TreEntryImpl("SUBDET", "P", "string"));
+        piaprd.add(new TreEntryImpl("PRODCODE", "YY", "string"));
+        piaprd.add(new TreEntryImpl("PRODUCERSE", "UNKNOW", "string"));
+        piaprd.add(new TreEntryImpl("PRODIDNO", "X211           -END-", "string"));
+        piaprd.add(new TreEntryImpl("PRODSNME", "JUNK FILE.", "string"));
+        piaprd.add(new TreEntryImpl("PRODUCERCD", "27", "string"));
+        piaprd.add(new TreEntryImpl("PRODCRTIME", "26081023ZOCT95", "string"));
+        piaprd.add(new TreEntryImpl("MAPID", "132                                -END-", "string"));
+        piaprd.add(new TreEntryImpl("SECTITLEREP", "01", "UINT"));
+        TreEntryImpl secTitleEntry = new TreEntryImpl("SECTITLE", null, "string");
         TreGroup secTitleGroup = TreFactory.getDefault("SECTITLE",
                 TreSource.ImageExtendedSubheaderData);
         secTitleGroup.getEntries()
                 .add(0,
-                        new TreEntry("SECTITLE",
+                        new TreEntryImpl("SECTITLE",
                                 "                                   -END-",
                                 "string"));
         secTitleGroup.getEntries()
-                .add(1, new TreEntry("PPNUM", "32/47", "string"));
+                .add(1, new TreEntryImpl("PPNUM", "32/47", "string"));
         secTitleGroup.getEntries()
-                .add(2, new TreEntry("TPP", "001", "UINT"));
+                .add(2, new TreEntryImpl("TPP", "001", "UINT"));
         secTitleEntry.initGroups();
         secTitleEntry.addGroup(secTitleGroup);
         piaprd.add(secTitleEntry);
-        piaprd.add(new TreEntry("REQORGREP", "01", "UINT"));
-        TreEntry reqorgEntry = new TreEntry("REQORG", null, "string");
+        piaprd.add(new TreEntryImpl("REQORGREP", "01", "UINT"));
+        TreEntryImpl reqorgEntry = new TreEntryImpl("REQORG", null, "string");
         TreGroup reqorgGroup = TreFactory.getDefault("REQORG",
                 TreSource.ImageExtendedSubheaderData);
         reqorgGroup.getEntries()
                 .add(0,
-                        new TreEntry("REQORG",
+                        new TreEntryImpl("REQORG",
                                 "FIRST                                                      -END-",
                                 "string"));
         reqorgEntry.initGroups();
         reqorgEntry.addGroup(reqorgGroup);
         piaprd.add(reqorgEntry);
-        piaprd.add(new TreEntry("KEYWORDREP", "01", "UINT"));
-        TreEntry keywordEntry = new TreEntry("KEYWORD", null, "string");
+        piaprd.add(new TreEntryImpl("KEYWORDREP", "01", "UINT"));
+        TreEntryImpl keywordEntry = new TreEntryImpl("KEYWORD", null, "string");
         TreGroup keywordGroup = TreFactory.getDefault("KEYWORD",
                 TreSource.ImageExtendedSubheaderData);
         keywordGroup.getEntries()
-                .add(0, new TreEntry("KEYWORD", keyword, "string"));
+                .add(0, new TreEntryImpl("KEYWORD", keyword, "string"));
         keywordEntry.initGroups();
         keywordEntry.addGroup(keywordGroup);
         piaprd.add(keywordEntry);
-        piaprd.add(new TreEntry("ASSRPTREP", "01", "UNIT"));
-        TreEntry assrptEntry = new TreEntry("ASSRPT", null, "string");
+        piaprd.add(new TreEntryImpl("ASSRPTREP", "01", "UNIT"));
+        TreEntryImpl assrptEntry = new TreEntryImpl("ASSRPT", null, "string");
         TreGroup asserptGroup = TreFactory.getDefault("ASSRPT",
                 TreSource.ImageExtendedSubheaderData);
         asserptGroup.getEntries()
-                .add(0, new TreEntry("ASSRPT", "FIRST          -END-", "string"));
+                .add(0, new TreEntryImpl("ASSRPT", "FIRST          -END-", "string"));
         assrptEntry.initGroups();
         assrptEntry.addGroup(asserptGroup);
         piaprd.add(assrptEntry);
-        piaprd.add(new TreEntry("ATEXTREP", "01", "UINT"));
-        TreEntry atextEntry = new TreEntry("ATEXT", null, "string");
+        piaprd.add(new TreEntryImpl("ATEXTREP", "01", "UINT"));
+        TreEntryImpl atextEntry = new TreEntryImpl("ATEXT", null, "string");
         TreGroup atextGroup = TreFactory.getDefault("ATEXT", TreSource.ImageExtendedSubheaderData);
         atextGroup.getEntries()
                 .add(0,
-                        new TreEntry("ATEXT",
+                        new TreEntryImpl("ATEXT",
                                 "FIRST                                                             "
                                         + "                                                        "
                                         + "                                                        "
@@ -345,7 +346,7 @@ public class ImageInputTransformerTest {
         ImageSegment imageSegment = TreTestUtility.createImageSegment();
         imageSegment.getTREsRawStructure()
                 .add(piaprd);
-        new NitfCreationFlow().fileHeader(() -> TreTestUtility.createFileHeader())
+        new NitfCreationFlowImpl().fileHeader(() -> TreTestUtility.createFileHeader())
                 .imageSegment(() -> imageSegment)
                 .write(file.getAbsolutePath());
 
@@ -364,7 +365,7 @@ public class ImageInputTransformerTest {
 
             try (InputStream inputStream = new FileInputStream(nitfFile)) {
                 Metacard metacard = metacardFactory.createMetacard("piaprdTest");
-                NitfSegmentsFlow nitfSegmentsFlow = new NitfParserInputFlow().inputStream(inputStream)
+                NitfSegmentsFlow nitfSegmentsFlow = new NitfParserInputFlowImpl().inputStream(inputStream)
                         .headerOnly();
                 headerTransformer.transform(nitfSegmentsFlow, metacard);
                 transformer.transform(nitfSegmentsFlow, metacard);
@@ -378,27 +379,27 @@ public class ImageInputTransformerTest {
     private static void createNitfWithCsdida(File file) {
         NitfHeader header = NitfHeaderFactory.getDefault(FileType.NITF_TWO_ONE);
         Tre csdida = TreFactory.getDefault("CSDIDA", TreSource.ExtendedHeaderData);
-        csdida.add(new TreEntry("DAY", "01", "UINT"));
-        csdida.add(new TreEntry("MONTH", str(3), "UINT"));
-        csdida.add(new TreEntry("YEAR", "1234", "UINT"));
-        csdida.add(new TreEntry("PLATFORM_CODE", "XY", "string"));
-        csdida.add(new TreEntry("VEHICLE_ID", "01", "string"));
-        csdida.add(new TreEntry("PASS", "01", "string"));
-        csdida.add(new TreEntry("OPERATION", "001", "UINT"));
-        csdida.add(new TreEntry("SENSOR_ID", str(2), "string"));
-        csdida.add(new TreEntry("PRODUCT_ID", str(2), "string"));
-        csdida.add(new TreEntry("RESERVED_0", str(4), "string"));
-        csdida.add(new TreEntry("TIME", "20000202010101", "UINT"));
-        csdida.add(new TreEntry("PROCESS_TIME", "20000202010101", "UINT"));
-        csdida.add(new TreEntry("RESERVED_1", str(2), "string"));
-        csdida.add(new TreEntry("RESERVED_2", str(2), "string"));
-        csdida.add(new TreEntry("RESERVED_3", str(1), "string"));
-        csdida.add(new TreEntry("RESERVED_4", str(1), "string"));
-        csdida.add(new TreEntry("SOFTWARE_VERSION_NUMBER", str(10), "string"));
+        csdida.add(new TreEntryImpl("DAY", "01", "UINT"));
+        csdida.add(new TreEntryImpl("MONTH", str(3), "UINT"));
+        csdida.add(new TreEntryImpl("YEAR", "1234", "UINT"));
+        csdida.add(new TreEntryImpl("PLATFORM_CODE", "XY", "string"));
+        csdida.add(new TreEntryImpl("VEHICLE_ID", "01", "string"));
+        csdida.add(new TreEntryImpl("PASS", "01", "string"));
+        csdida.add(new TreEntryImpl("OPERATION", "001", "UINT"));
+        csdida.add(new TreEntryImpl("SENSOR_ID", str(2), "string"));
+        csdida.add(new TreEntryImpl("PRODUCT_ID", str(2), "string"));
+        csdida.add(new TreEntryImpl("RESERVED_0", str(4), "string"));
+        csdida.add(new TreEntryImpl("TIME", "20000202010101", "UINT"));
+        csdida.add(new TreEntryImpl("PROCESS_TIME", "20000202010101", "UINT"));
+        csdida.add(new TreEntryImpl("RESERVED_1", str(2), "string"));
+        csdida.add(new TreEntryImpl("RESERVED_2", str(2), "string"));
+        csdida.add(new TreEntryImpl("RESERVED_3", str(1), "string"));
+        csdida.add(new TreEntryImpl("RESERVED_4", str(1), "string"));
+        csdida.add(new TreEntryImpl("SOFTWARE_VERSION_NUMBER", str(10), "string"));
 
         header.getTREsRawStructure()
                 .add(csdida);
-        new NitfCreationFlow().fileHeader(() -> header)
+        new NitfCreationFlowImpl().fileHeader(() -> header)
                 .write(file.getAbsolutePath());
     }
 
@@ -410,7 +411,7 @@ public class ImageInputTransformerTest {
 
             try (InputStream inputStream = new FileInputStream(nitfFile)) {
                 Metacard metacard = metacardFactory.createMetacard("csexraTest");
-                NitfSegmentsFlow nitfSegmentsFlow = new NitfParserInputFlow().inputStream(inputStream)
+                NitfSegmentsFlow nitfSegmentsFlow = new NitfParserInputFlowImpl().inputStream(inputStream)
                         .headerOnly();
                 headerTransformer.transform(nitfSegmentsFlow, metacard);
                 assertThat(metacard.getAttribute(Isr.PLATFORM_ID)
@@ -426,38 +427,38 @@ public class ImageInputTransformerTest {
     private static void createNitfWithCsexra(File file) {
         NitfHeader header = NitfHeaderFactory.getDefault(FileType.NITF_TWO_ONE);
         Tre csexra = TreFactory.getDefault("CSEXRA", TreSource.ImageExtendedSubheaderData);
-        csexra.add(new TreEntry("SNOW_DEPTH_CAT", "1", "string"));
-        csexra.add(new TreEntry("SENSOR", str(6), "string"));
-        csexra.add(new TreEntry("TIME_FIRST_LINE_IMAGE", "12345.000000", "string"));
-        csexra.add(new TreEntry("TIME_IMAGE_DURATION", "12345.000000", "string"));
-        csexra.add(new TreEntry("MAX_GSD", "123.5", "string"));
-        csexra.add(new TreEntry("ALONG_SCAN_GSD", "123.5", "string"));
-        csexra.add(new TreEntry("CROSS_SCAN_GSD", "123.5", "string"));
-        csexra.add(new TreEntry("GEO_MEAN_GSD", "123.5", "string"));
-        csexra.add(new TreEntry("A_S_VERT_GSD", "123.5", "string"));
-        csexra.add(new TreEntry("C_S_VERT_GSD", "123.5", "string"));
-        csexra.add(new TreEntry("GEO_MEAN_VERT_GSD", "123.5", "string"));
-        csexra.add(new TreEntry("GSD_BETA_ANGLE", "123.5", "string"));
-        csexra.add(new TreEntry("DYNAMIC_RANGE", "02047", "string"));
-        csexra.add(new TreEntry("NUM_LINES", "0000101", "string"));
-        csexra.add(new TreEntry("NUM_SAMPLES", "00101", "string"));
-        csexra.add(new TreEntry("ANGLE_TO_NORTH", "000.000", "string"));
-        csexra.add(new TreEntry("OBLIQUITY_ANGLE", "00.000", "string"));
-        csexra.add(new TreEntry("AZ_OF_OBLIQUITY", "000.000", "string"));
-        csexra.add(new TreEntry("GRD_COVER", "1", "string"));
-        csexra.add(new TreEntry("SNOW_DEPTH_CAT", "1", "string"));
-        csexra.add(new TreEntry("SUN_AZIMUTH", "000.000", "string"));
-        csexra.add(new TreEntry("SUN_ELEVATION", "-90.000", "string"));
-        csexra.add(new TreEntry("PREDICTED_NIIRS", "1.0", "string"));
-        csexra.add(new TreEntry("CIRCL_ERR", "000", "string"));
-        csexra.add(new TreEntry("LINEAR_ERR", "000", "string"));
+        csexra.add(new TreEntryImpl("SNOW_DEPTH_CAT", "1", "string"));
+        csexra.add(new TreEntryImpl("SENSOR", str(6), "string"));
+        csexra.add(new TreEntryImpl("TIME_FIRST_LINE_IMAGE", "12345.000000", "string"));
+        csexra.add(new TreEntryImpl("TIME_IMAGE_DURATION", "12345.000000", "string"));
+        csexra.add(new TreEntryImpl("MAX_GSD", "123.5", "string"));
+        csexra.add(new TreEntryImpl("ALONG_SCAN_GSD", "123.5", "string"));
+        csexra.add(new TreEntryImpl("CROSS_SCAN_GSD", "123.5", "string"));
+        csexra.add(new TreEntryImpl("GEO_MEAN_GSD", "123.5", "string"));
+        csexra.add(new TreEntryImpl("A_S_VERT_GSD", "123.5", "string"));
+        csexra.add(new TreEntryImpl("C_S_VERT_GSD", "123.5", "string"));
+        csexra.add(new TreEntryImpl("GEO_MEAN_VERT_GSD", "123.5", "string"));
+        csexra.add(new TreEntryImpl("GSD_BETA_ANGLE", "123.5", "string"));
+        csexra.add(new TreEntryImpl("DYNAMIC_RANGE", "02047", "string"));
+        csexra.add(new TreEntryImpl("NUM_LINES", "0000101", "string"));
+        csexra.add(new TreEntryImpl("NUM_SAMPLES", "00101", "string"));
+        csexra.add(new TreEntryImpl("ANGLE_TO_NORTH", "000.000", "string"));
+        csexra.add(new TreEntryImpl("OBLIQUITY_ANGLE", "00.000", "string"));
+        csexra.add(new TreEntryImpl("AZ_OF_OBLIQUITY", "000.000", "string"));
+        csexra.add(new TreEntryImpl("GRD_COVER", "1", "string"));
+        csexra.add(new TreEntryImpl("SNOW_DEPTH_CAT", "1", "string"));
+        csexra.add(new TreEntryImpl("SUN_AZIMUTH", "000.000", "string"));
+        csexra.add(new TreEntryImpl("SUN_ELEVATION", "-90.000", "string"));
+        csexra.add(new TreEntryImpl("PREDICTED_NIIRS", "1.0", "string"));
+        csexra.add(new TreEntryImpl("CIRCL_ERR", "000", "string"));
+        csexra.add(new TreEntryImpl("LINEAR_ERR", "000", "string"));
 
         ImageSegment imageSegment = ImageSegmentFactory.getDefault(FileType.NITF_TWO_ONE);
-        imageSegment.addImageBand(new ImageBand());
+        imageSegment.addImageBand(TreTestUtility.createImageBand());
 
         imageSegment.getTREsRawStructure()
                 .add(csexra);
-        new NitfCreationFlow().fileHeader(() -> header)
+        new NitfCreationFlowImpl().fileHeader(() -> header)
                 .imageSegment(() -> imageSegment)
                 .write(file.getAbsolutePath());
 
@@ -466,33 +467,33 @@ public class ImageInputTransformerTest {
     private static void createNitfWithPiaimc(File file) {
         NitfHeader header = NitfHeaderFactory.getDefault(FileType.NITF_TWO_ONE);
         Tre piaimc = TreFactory.getDefault("PIAIMC", TreSource.ImageExtendedSubheaderData);
-        piaimc.add(new TreEntry("CLOUDCVR", "070", "string"));
-        piaimc.add(new TreEntry("SRP", "Y", "string"));
-        piaimc.add(new TreEntry("SENSMODE", str(12), "string"));
-        piaimc.add(new TreEntry("SENSNAME", str(18), "string"));
-        piaimc.add(new TreEntry("SOURCE", str(255), "string"));
-        piaimc.add(new TreEntry("COMGEN", "09", "string"));
-        piaimc.add(new TreEntry("SUBQUAL", str(1), "string"));
-        piaimc.add(new TreEntry("PIAMSNNUM", str(7), "string"));
-        piaimc.add(new TreEntry("CAMSPECS", str(32), "string"));
-        piaimc.add(new TreEntry("PROJID", str(2), "string"));
-        piaimc.add(new TreEntry("GENERATION", "8", "string"));
-        piaimc.add(new TreEntry("ESD", "Y", "string"));
-        piaimc.add(new TreEntry("OTHERCOND", str(2), "string"));
-        piaimc.add(new TreEntry("MEANGSD", "00000.0", "string"));
-        piaimc.add(new TreEntry("IDATUM", str(3), "string"));
-        piaimc.add(new TreEntry("IELLIP", str(3), "string"));
-        piaimc.add(new TreEntry("PREPROC", str(2), "string"));
-        piaimc.add(new TreEntry("IPROJ", str(2), "string"));
-        piaimc.add(new TreEntry("SATTRACK_PATH", "0000", "string"));
-        piaimc.add(new TreEntry("SATTRACK_ROW", "0000", "string"));
+        piaimc.add(new TreEntryImpl("CLOUDCVR", "070", "string"));
+        piaimc.add(new TreEntryImpl("SRP", "Y", "string"));
+        piaimc.add(new TreEntryImpl("SENSMODE", str(12), "string"));
+        piaimc.add(new TreEntryImpl("SENSNAME", str(18), "string"));
+        piaimc.add(new TreEntryImpl("SOURCE", str(255), "string"));
+        piaimc.add(new TreEntryImpl("COMGEN", "09", "string"));
+        piaimc.add(new TreEntryImpl("SUBQUAL", str(1), "string"));
+        piaimc.add(new TreEntryImpl("PIAMSNNUM", str(7), "string"));
+        piaimc.add(new TreEntryImpl("CAMSPECS", str(32), "string"));
+        piaimc.add(new TreEntryImpl("PROJID", str(2), "string"));
+        piaimc.add(new TreEntryImpl("GENERATION", "8", "string"));
+        piaimc.add(new TreEntryImpl("ESD", "Y", "string"));
+        piaimc.add(new TreEntryImpl("OTHERCOND", str(2), "string"));
+        piaimc.add(new TreEntryImpl("MEANGSD", "00000.0", "string"));
+        piaimc.add(new TreEntryImpl("IDATUM", str(3), "string"));
+        piaimc.add(new TreEntryImpl("IELLIP", str(3), "string"));
+        piaimc.add(new TreEntryImpl("PREPROC", str(2), "string"));
+        piaimc.add(new TreEntryImpl("IPROJ", str(2), "string"));
+        piaimc.add(new TreEntryImpl("SATTRACK_PATH", "0000", "string"));
+        piaimc.add(new TreEntryImpl("SATTRACK_ROW", "0000", "string"));
 
         ImageSegment imageSegment = ImageSegmentFactory.getDefault(FileType.NITF_TWO_ONE);
-        imageSegment.addImageBand(new ImageBand());
+        imageSegment.addImageBand(TreTestUtility.createImageBand());
 
         imageSegment.getTREsRawStructure()
                 .add(piaimc);
-        new NitfCreationFlow().fileHeader(() -> header)
+        new NitfCreationFlowImpl().fileHeader(() -> header)
                 .imageSegment(() -> imageSegment)
                 .write(file.getAbsolutePath());
     }
@@ -505,7 +506,7 @@ public class ImageInputTransformerTest {
 
             try (InputStream inputStream = new FileInputStream(nitfFile)) {
                 Metacard metacard = metacardFactory.createMetacard("csexraTest");
-                NitfSegmentsFlow nitfSegmentsFlow = new NitfParserInputFlow().inputStream(inputStream)
+                NitfSegmentsFlow nitfSegmentsFlow = new NitfParserInputFlowImpl().inputStream(inputStream)
                         .headerOnly();
                 transformer.transform(nitfSegmentsFlow, metacard);
                 assertThat(metacard.getAttribute(Isr.CLOUD_COVER)
@@ -521,23 +522,23 @@ public class ImageInputTransformerTest {
     private static void createNitfWithPiatgb(File file) {
         NitfHeader header = NitfHeaderFactory.getDefault(FileType.NITF_TWO_ONE);
         Tre piatgb = TreFactory.getDefault("PIATGB", TreSource.ImageExtendedSubheaderData);
-        piatgb.add(new TreEntry("TGTUTM", "55HFA9359093610", "string"));
-        piatgb.add(new TreEntry("PIATGAID", "ABCDEFGHIJUVWXY", "string"));
-        piatgb.add(new TreEntry("PIACTRY", "AS", "string"));
-        piatgb.add(new TreEntry("PIACAT", "702XX", "string"));
-        piatgb.add(new TreEntry("TGTGEO", "351655S1490742E", "string"));
-        piatgb.add(new TreEntry("DATUM", "WGE", "string"));
-        piatgb.add(new TreEntry("TGTNAME", "Canberra Hill                         ", "string"));
-        piatgb.add(new TreEntry("PERCOVER", "57", "UINT"));
-        piatgb.add(new TreEntry("TGTLAT", "-35.30812 ", "float"));
-        piatgb.add(new TreEntry("TGTLON", "+149.12447 ", "float"));
+        piatgb.add(new TreEntryImpl("TGTUTM", "55HFA9359093610", "string"));
+        piatgb.add(new TreEntryImpl("PIATGAID", "ABCDEFGHIJUVWXY", "string"));
+        piatgb.add(new TreEntryImpl("PIACTRY", "AS", "string"));
+        piatgb.add(new TreEntryImpl("PIACAT", "702XX", "string"));
+        piatgb.add(new TreEntryImpl("TGTGEO", "351655S1490742E", "string"));
+        piatgb.add(new TreEntryImpl("DATUM", "WGE", "string"));
+        piatgb.add(new TreEntryImpl("TGTNAME", "Canberra Hill                         ", "string"));
+        piatgb.add(new TreEntryImpl("PERCOVER", "57", "UINT"));
+        piatgb.add(new TreEntryImpl("TGTLAT", "-35.30812 ", "float"));
+        piatgb.add(new TreEntryImpl("TGTLON", "+149.12447 ", "float"));
 
         ImageSegment imageSegment = ImageSegmentFactory.getDefault(FileType.NITF_TWO_ONE);
-        imageSegment.addImageBand(new ImageBand());
+        imageSegment.addImageBand(TreTestUtility.createImageBand());
 
         imageSegment.getTREsRawStructure()
                 .add(piatgb);
-        new NitfCreationFlow().fileHeader(() -> header)
+        new NitfCreationFlowImpl().fileHeader(() -> header)
                 .imageSegment(() -> imageSegment)
                 .write(file.getAbsolutePath());
     }
@@ -550,7 +551,7 @@ public class ImageInputTransformerTest {
 
             try (InputStream inputStream = new FileInputStream(nitfFile)) {
                 Metacard metacard = metacardFactory.createMetacard("piatgbTest");
-                NitfSegmentsFlow nitfSegmentsFlow = new NitfParserInputFlow().inputStream(inputStream)
+                NitfSegmentsFlow nitfSegmentsFlow = new NitfParserInputFlowImpl().inputStream(inputStream)
                         .headerOnly();
                 transformer.transform(nitfSegmentsFlow, metacard);
                 assertThat(metacard.getAttribute(PiatgbAttribute.TARGET_NAME_ATTRIBUTE.getLongName())
@@ -592,7 +593,7 @@ public class ImageInputTransformerTest {
 
             try (InputStream inputStream = new FileInputStream(nitfFile)) {
                 Metacard metacard = metacardFactory.createMetacard("csexraTest");
-                NitfSegmentsFlow nitfSegmentsFlow = new NitfParserInputFlow().inputStream(inputStream)
+                NitfSegmentsFlow nitfSegmentsFlow = new NitfParserInputFlowImpl().inputStream(inputStream)
                         .headerOnly();
                 transformer.transform(nitfSegmentsFlow, metacard);
                 consumer.accept(metacard);
@@ -606,7 +607,7 @@ public class ImageInputTransformerTest {
     private static void createNitfWithDifferentImageDateTimes(File file, DateTime fileDateTime,
             DateTime... imageDateTimes) {
         NitfCreationFlow nitfCreationFlow =
-                new NitfCreationFlow().fileHeader(() -> TreTestUtility.createFileHeader(fileDateTime));
+                new NitfCreationFlowImpl().fileHeader(() -> TreTestUtility.createFileHeader(fileDateTime));
         Arrays.stream(imageDateTimes)
                 .forEach(imageDateTime -> nitfCreationFlow.imageSegment(() -> createImageSegment(
                         imageDateTime)));
@@ -630,7 +631,7 @@ public class ImageInputTransformerTest {
 
             try (InputStream inputStream = new FileInputStream(nitfFile)) {
                 Metacard metacard = metacardFactory.createMetacard("differentImageDateTimesTest");
-                NitfSegmentsFlow nitfSegmentsFlow = new NitfParserInputFlow().inputStream(inputStream)
+                NitfSegmentsFlow nitfSegmentsFlow = new NitfParserInputFlowImpl().inputStream(inputStream)
                         .headerOnly();
 
                 nitfSegmentsFlow = headerTransformer.transform(nitfSegmentsFlow, metacard);
@@ -784,7 +785,7 @@ public class ImageInputTransformerTest {
 
     private static DateTime createNitfDateTime(int year, int month, int dayOfMonth, int hour,
             int minute, int second) {
-        DateTime dateTime = new DateTime();
+        DateTimeImpl dateTime = new DateTimeImpl();
         dateTime.set(ZonedDateTime.of(year,
                 month,
                 dayOfMonth,

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/TestTextAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/TestTextAttribute.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 import java.util.stream.Stream;
 
 import org.codice.imaging.nitf.core.common.DateTime;
+import org.codice.imaging.nitf.core.common.impl.DateTimeImpl;
 import org.codice.imaging.nitf.core.security.SecurityMetadata;
 import org.codice.imaging.nitf.core.text.TextFormat;
 import org.codice.imaging.nitf.core.text.TextSegment;
@@ -48,7 +49,7 @@ public class TestTextAttribute {
     @Before
     public void setUp() {
         this.textSegment = mock(TextSegment.class);
-        this.currentDateTime = DateTime.getNitfDateTimeForNow();
+        this.currentDateTime = DateTimeImpl.getNitfDateTimeForNow();
         when(textSegment.getIdentifier()).thenReturn(TEXT_IDENTIFIER);
         when(textSegment.getSecurityMetadata()).thenReturn(mock(SecurityMetadata.class));
         when(textSegment.getTextDateTime()).thenReturn(currentDateTime);

--- a/catalog/imaging/pom.xml
+++ b/catalog/imaging/pom.xml
@@ -28,15 +28,20 @@
     <name>Alliance :: Imaging</name>
 
     <properties>
-        <nitf-imaging.version>0.7</nitf-imaging.version>
         <camel.version>2.16.1</camel.version>
         <jai-imageio-core.version>1.3.1</jai-imageio-core.version>
         <jpeg2000.version>1.3.1_CODICE_2</jpeg2000.version>
+        <usng4j.version>0.1</usng4j.version>
         <thumbnailator.version>0.4.8</thumbnailator.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.codice.imaging.nitf</groupId>
+                <artifactId>codice-imaging-nitf-core-api</artifactId>
+                <version>${nitf-imaging.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.codice.imaging.nitf</groupId>
                 <artifactId>codice-imaging-nitf-core</artifactId>

--- a/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/ImagingTest.java
+++ b/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/ImagingTest.java
@@ -42,8 +42,8 @@ import org.codice.alliance.transformer.nitf.image.ImageAttribute;
 import org.codice.ddf.itests.common.annotations.BeforeExam;
 import org.codice.ddf.platform.util.TemporaryFileBackedOutputStream;
 import org.codice.imaging.nitf.core.image.ImageSegment;
-import org.codice.imaging.nitf.fluent.NitfParserInputFlow;
 import org.codice.imaging.nitf.fluent.NitfSegmentsFlow;
+import org.codice.imaging.nitf.fluent.impl.NitfParserInputFlowImpl;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -179,7 +179,7 @@ public class ImagingTest extends AbstractAllianceIntegrationTest {
             IOUtils.copyLarge(chippedImageStream, tfbos);
 
             NitfSegmentsFlow nitfSegmentsFlow =
-                    new NitfParserInputFlow().inputStream(tfbos.asByteSource()
+                    new NitfParserInputFlowImpl().inputStream(tfbos.asByteSource()
                             .openBufferedStream())
                             .allData();
 

--- a/distribution/test/itests/test-itests-dependencies-app/pom.xml
+++ b/distribution/test/itests/test-itests-dependencies-app/pom.xml
@@ -87,12 +87,22 @@
 
         <dependency>
             <groupId>org.codice.imaging.nitf</groupId>
+            <artifactId>codice-imaging-nitf-core-api</artifactId>
+            <version>${nitf-imaging.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.imaging.nitf</groupId>
             <artifactId>codice-imaging-nitf-core</artifactId>
             <version>${nitf-imaging.version}</version>
         </dependency>
         <dependency>
             <groupId>org.codice.imaging.nitf</groupId>
             <artifactId>codice-imaging-nitf-fluent-api</artifactId>
+            <version>${nitf-imaging.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.imaging.nitf</groupId>
+            <artifactId>codice-imaging-nitf-fluent</artifactId>
             <version>${nitf-imaging.version}</version>
         </dependency>
         <dependency>

--- a/distribution/test/itests/test-itests-dependencies-app/src/main/filtered-resources/features.xml
+++ b/distribution/test/itests/test-itests-dependencies-app/src/main/filtered-resources/features.xml
@@ -24,11 +24,11 @@
         <bundle>mvn:commons-io/commons-io/2.5</bundle>
         <bundle>wrap:mvn:org.awaitility/awaitility/${awaitility.version}</bundle>
         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.hamcrest/${hamcrest-all.version}</bundle>
-
+        <bundle>wrap:mvn:org.codice.imaging.nitf/codice-imaging-nitf-core-api/${nitf-imaging.version}</bundle>
         <bundle>wrap:mvn:org.codice.imaging.nitf/codice-imaging-nitf-core/${nitf-imaging.version}</bundle>
         <bundle>wrap:mvn:org.codice.imaging.nitf/codice-imaging-nitf-fluent-api/${nitf-imaging.version}</bundle>
+        <bundle>wrap:mvn:org.codice.imaging.nitf/codice-imaging-nitf-fluent/${nitf-imaging.version}</bundle>
         <bundle>wrap:mvn:org.codice.imaging.nitf/codice-imaging-nitf-render/${nitf-imaging.version}</bundle>
-
     </feature>
 
     <feature name="ddf-dependencies">

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
         <jts.version>1.12</jts.version>
         <commons-lang3.version>3.4</commons-lang3.version>
         <commons-beanutils.version>1.9.2</commons-beanutils.version>
+        <slf4j.version>1.7.14</slf4j.version>
         <awaitility.version>3.0.0</awaitility.version>
         <slf4j.version>1.7.12</slf4j.version>
         <maven.javadoc.plugin.version>2.7</maven.javadoc.plugin.version>
@@ -116,7 +117,7 @@
         <gib.referenceBranch>refs/remotes/origin/master</gib.referenceBranch>
         <gib.baseBranch>HEAD</gib.baseBranch>
         <gib.enabled>false</gib.enabled>
-        <nitf-imaging.version>0.7</nitf-imaging.version>
+        <nitf-imaging.version>0.8.1</nitf-imaging.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
#### What does this PR do?
The imaging-nitf fluent-api bundle was recently split into 'fluent' and 'fluent-api'.  The imaging-nitf core bundle was recently split into 'core-api' and 'core'. The bulk of these changes remove unneeded embedded dependencies from pom files and to make code changes to reflect the imaging-nitf API changes.

Imaging-nitf core also added the ability to deal with coordinates in UTM and MGRS formats. This PR also modifies a line of code that was filtering out locations that weren't in DMS or decimal degrees format.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@glenhein 
@roelens8 
@vinamartin 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@jaymcnallie
@kcwire
@jlcsmith 

#### How should this be tested?
1) build and start Alliance
   -- verify that the imaging-app starts up
2) ingest some NITFs that have locations recorded with various coordinate systems (UTMNORTH, UTMSOUTH, MGRS, etc.)
   -- verify that the product appears on the globe at the correct location, regardless of coordinate system.

#### Any background context you want to provide?
See Description 

#### What are the relevant tickets?
[CAL-284] (https://codice.atlassian.net/browse/CAL-284)

#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [x] Update / Add Unit Tests
- [x] Update / Add Integration Tests
