### PR TITLE
CAL-286 Fix errors with the ImagingTest itest.

### DIFF
--- a/catalog/imaging/imaging-plugin-nitf/pom.xml
+++ b/catalog/imaging/imaging-plugin-nitf/pom.xml
@@ -118,7 +118,8 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Embed-Dependency>
                             thumbnailator,
-                            catalog-core-api-impl,
+                            catalog-core-api-impl;groupId=org.codice.alliance.catalog.core;version=${project.version},
+                            catalog-core-api-impl;groupId=ddf.catalog.core;version${ddf.version},
                             platform-util,
                             jai-imageio-core,
                             jai-imageio-jpeg2000,


### PR DESCRIPTION
#### What does this PR do?
Fixes a problem with dependencies that caused the ImagingTest to not pass.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@bdeining
@glenhein

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@millerw8

#### How should this be tested?
Run a full `mvn clean install`

#### Any background context you want to provide?
The ImagingTest was still intermittently failing after https://github.com/codice/alliance/pull/295 was merged. 

#### What are the relevant tickets?
[CAL-286](https://codice.atlassian.net/browse/CAL-286)

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
