### PR TITLE
CAL-288 Fixing gitsetup to truly not run plugins from the parent pom

### DIFF
--- a/gitsetup/pom.xml
+++ b/gitsetup/pom.xml
@@ -134,40 +134,22 @@
                 <executions>
                     <execution>
                         <id>unpack-findbugs</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
+                        <phase>none</phase>
                     </execution>
                 </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-		<version>2.17</version>
+                <version>2.17</version>
                 <executions>
                     <execution>
                         <id>checkstyle-check</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
+                        <phase>none</phase>
                     </execution>
                     <execution>
                         <id>checkstyle-check-xml</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
+                        <phase>none</phase>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
#### What does this PR do?
Fix to the gitsetup module. A maven build (normal or quick) is not actually skipping execution of these plugins on the gitsetup module, as intended.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@Lambeaux @figliold 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl 
@lessarderic 
#### How should this be tested?
Run both a `mvn clean install` and `quickbuild` from the root. The build can be stopped after the Gitsetup module is built (it's only the second one). Verify in the maven output that `maven-dependency-plugin`, `findbugs-maven-plugin`, and `maven-checkstyle` plugins are not executed under the Gitsetup module.
#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-288](https://codice.atlassian.net/browse/CAL-288)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
