### PR TITLE
CAL-298 Refactor code to use new DDF Security class' non-static runAsAdmin method

### DIFF
--- a/catalog/plugin/catalog-plugin-defaultsecurityattributevalues/src/main/java/org/codice/alliance/catalog/plugin/defaultsecurity/DefaultSecurityAttributeValuesPlugin.java
+++ b/catalog/plugin/catalog-plugin-defaultsecurityattributevalues/src/main/java/org/codice/alliance/catalog/plugin/defaultsecurity/DefaultSecurityAttributeValuesPlugin.java
@@ -219,7 +219,8 @@ public class DefaultSecurityAttributeValuesPlugin implements PreIngestPlugin {
      */
     private Map<String, Attribute> getHighwaterSecurityMarkings() {
         Map<String, Attribute> securityMarkings = new HashMap<>();
-        Subject system = org.codice.ddf.security.common.Security.runAsAdmin(subjectSupplier::get);
+        Subject system = org.codice.ddf.security.common.Security.getInstance()
+                .runAsAdmin(subjectSupplier::get);
         SecurityAssertion assertion = system.getPrincipals()
                 .oneByType(SecurityAssertion.class);
         List<AttributeStatement> attributeStatements = assertion.getAttributeStatements();

--- a/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/netty/UdpStreamProcessor.java
+++ b/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/netty/UdpStreamProcessor.java
@@ -232,11 +232,12 @@ public class UdpStreamProcessor implements StreamProcessor {
         LOGGER.trace("Shutting down stream processor.");
         packetBuffer.cancelTimer();
 
-        Security.runAsAdmin(() -> {
+        Security security = Security.getInstance();
+
+        security.runAsAdmin(() -> {
 
             if (streamCreationSubject == null) {
-                streamCreationSubject = Security.getInstance()
-                        .getSystemSubject();
+                streamCreationSubject = security.getSystemSubject();
             }
 
             streamCreationSubject.execute(() -> {
@@ -372,12 +373,12 @@ public class UdpStreamProcessor implements StreamProcessor {
      * processor is ready to run.
      */
     public void init() {
+        Security security = Security.getInstance();
 
-        Security.runAsAdmin(() -> {
+        security.runAsAdmin(() -> {
 
             if (streamCreationSubject == null) {
-                streamCreationSubject = Security.getInstance()
-                        .getSystemSubject();
+                streamCreationSubject = security.getSystemSubject();
             }
 
             streamCreationSubject.execute(() -> {


### PR DESCRIPTION
#### What does this PR do?
Changes code to use non-static version of `Security.runAsAdmin()` method.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@glenhein 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@clockard 
@stustison

#### How should this be tested?
Full build, install and make sure default security attribute values plug-in and UDP stream processor are still working as expected.

#### Any background context you want to provide?
This change depends on https://github.com/codice/ddf/pull/1966

#### What are the relevant tickets?
[CAL-298](https://codice.atlassian.net/browse/CAL-298)

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
