### PR TITLE
CAL-303 Upgrade to Pax Exam 4.11.0

### DIFF
--- a/distribution/test/itests/pom.xml
+++ b/distribution/test/itests/pom.xml
@@ -27,7 +27,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <pax.exam.version>4.9.2</pax.exam.version>
+        <pax.exam.version>4.11.0</pax.exam.version>
     </properties>
 
     <modules>

--- a/distribution/test/itests/test-itests-alliance/pom.xml
+++ b/distribution/test/itests/test-itests-alliance/pom.xml
@@ -25,6 +25,8 @@
     <name>Alliance :: Integration :: Test</name>
 
     <properties>
+        <!-- Copied from ops4j/org.ops4j.pax.exam2/4.11.0/pom/pom.xml
+         Do not change these unless upgrading pax exam-->
         <pax.tinybundles.version>2.1.1</pax.tinybundles.version>
         <pax.url.version>2.4.5</pax.url.version>
     </properties>
@@ -60,7 +62,7 @@
         <dependency>
             <groupId>org.ops4j.pax.url</groupId>
             <artifactId>pax-url-aether</artifactId>
-            <version>2.2.0</version>
+            <version>${pax.url.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.inject</groupId>
@@ -70,7 +72,7 @@
         <dependency>
             <groupId>org.ops4j.pax.tinybundles</groupId>
             <artifactId>tinybundles</artifactId>
-            <version>2.1.0</version>
+            <version>${pax.tinybundles.version}</version>
         </dependency>
         <!--end pax-exam dependencies-->
 


### PR DESCRIPTION
#### What does this PR do?
Release Notes:
https://ops4j1.jira.com/wiki/display/PAXEXAM4/2017/05/16/Pax+Exam+4.11.0+released
Referenced: 
https://github.com/ops4j/org.ops4j.pax.exam2/blob/exam-reactor-4.11.0/pom/pom.xml

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@emmberk @stustison @kcwire 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@clockard 
@lessarderic 

#### How should this be tested?
Run the integration tests and make sure everything passes

#### What are the relevant tickets?
[CAL-303](https://codice.atlassian.net/browse/CAL-303)

