### PR TITLE
CAL-306 Corrected NITF metacard format and version

### DIFF
--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/NitfHeaderAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/NitfHeaderAttribute.java
@@ -28,6 +28,7 @@ import org.codice.alliance.catalog.core.api.types.Isr;
 import org.codice.alliance.catalog.core.api.types.Security;
 import org.codice.alliance.transformer.nitf.ExtNitfUtility;
 import org.codice.imaging.nitf.core.common.DateTime;
+import org.codice.imaging.nitf.core.common.FileType;
 import org.codice.imaging.nitf.core.header.NitfHeader;
 
 import ddf.catalog.data.AttributeDescriptor;
@@ -114,6 +115,17 @@ public class NitfHeaderAttribute extends NitfAttributeImpl<NitfHeader> {
 
     public static final String FILE_BACKGROUND_COLOR = PREFIX + "file-background-color";
 
+    public static final String NITF = "NITF";
+
+    public static final String NSIF = "NSIF";
+
+    public static final String TWO_ONE = "2.1";
+
+    public static final String TWO_ZERO = "2.0";
+
+    public static final String ONE_ZERO = "1.0";
+
+
     private static final List<NitfAttribute<NitfHeader>> ATTRIBUTES  = new LinkedList<>();
 
     /*
@@ -124,17 +136,15 @@ public class NitfHeaderAttribute extends NitfAttributeImpl<NitfHeader> {
     public static final NitfHeaderAttribute FILE_PROFILE_NAME_ATTRIBUTE =
             new NitfHeaderAttribute(Media.FORMAT,
                     "FHDR",
-                    header -> header.getFileType()
-                            .name(),
+                    header -> convertFormat(header.getFileType()),
                     new MediaAttributes().getAttributeDescriptor(Media.FORMAT),
                     FILE_PROFILE_NAME);
 
     public static final NitfHeaderAttribute FILE_VERSION_ATTRIBUTE =
             new NitfHeaderAttribute(Media.FORMAT_VERSION,
                     "FVER",
-                    header -> header.getFileType()
-                            .name(),
-                    new MediaAttributes().getAttributeDescriptor(Media.FORMAT),
+                    header -> convertFormatVersion(header.getFileType()),
+                    new MediaAttributes().getAttributeDescriptor(Media.FORMAT_VERSION),
                     FILE_VERSION);
 
     public static final NitfHeaderAttribute ORIGINATING_STATION_ID_ATTRIBUTE =
@@ -357,6 +367,28 @@ public class NitfHeaderAttribute extends NitfAttributeImpl<NitfHeader> {
             AttributeDescriptor attributeDescriptor, String extNitfName) {
         super(longName, shortName, accessorFunction, attributeDescriptor, extNitfName);
         ATTRIBUTES.add(this);
+    }
+
+    private static String convertFormat(final FileType format) {
+        if (format == FileType.NITF_TWO_ONE || format == FileType.NITF_TWO_ZERO) {
+            return NITF;
+        } else if (format == FileType.NSIF_ONE_ZERO) {
+            return NSIF;
+        }
+
+        return NITF;
+    }
+
+    private static String convertFormatVersion(final FileType format) {
+        if (format == FileType.NITF_TWO_ONE) {
+            return TWO_ONE;
+        } else if (format == FileType.NITF_TWO_ZERO) {
+            return TWO_ZERO;
+        } else if (format == FileType.NSIF_ONE_ZERO) {
+            return ONE_ZERO;
+        }
+
+        return "";
     }
 
     private static Date convertNitfDate(DateTime nitfDateTime) {

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/NitfHeaderAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/NitfHeaderAttribute.java
@@ -376,7 +376,7 @@ public class NitfHeaderAttribute extends NitfAttributeImpl<NitfHeader> {
             return NSIF;
         }
 
-        return NITF;
+        return "";
     }
 
     private static String convertFormatVersion(final FileType format) {

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageInputTransformerTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageInputTransformerTest.java
@@ -655,8 +655,8 @@ public class ImageInputTransformerTest {
     private static Map<NitfAttribute, Object> initAttributesToBeAsserted() {
         //key value pair of attributes and expected getAttributes
         Map<NitfAttribute, Object> map = new HashMap<>();
-        map.put(NitfHeaderAttribute.FILE_PROFILE_NAME_ATTRIBUTE, "NITF_TWO_ONE");
-        map.put(NitfHeaderAttribute.FILE_VERSION_ATTRIBUTE, "NITF_TWO_ONE");
+        map.put(NitfHeaderAttribute.FILE_PROFILE_NAME_ATTRIBUTE, "NITF");
+        map.put(NitfHeaderAttribute.FILE_VERSION_ATTRIBUTE, "2.1");
         map.put(NitfHeaderAttribute.COMPLEXITY_LEVEL_ATTRIBUTE, 3);
         map.put(NitfHeaderAttribute.STANDARD_TYPE_ATTRIBUTE, "BF01");
         map.put(NitfHeaderAttribute.ORIGINATING_STATION_ID_ATTRIBUTE, "i_3001a");


### PR DESCRIPTION
#### What does this PR do?
NITF metacard format and format-version was being set incorrectly to "NITF_TWO_ONE" and "NITF_TWO_ZERO".  Updated the NITF transformer to set the format and version correctly.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@rzwiefel @dcruver 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@beyelerb

#### How should this be tested?
Verify ingested NITF 2.1, 2.0, and NSIF 1.0 files have media.format and media.format-version attributes set correctly.

#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-306](https://codice.atlassian.net/browse/CAL-306)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
