### PR TITLE
CAL-271 added quick start guide to docs template

### DIFF
--- a/distribution/docs/src/main/jdocs/jbake.properties
+++ b/distribution/docs/src/main/jdocs/jbake.properties
@@ -6,6 +6,7 @@ render.archive=false
 render.feed=false
 output.extension=.adoc
 template.documentation.file=documentation.ftl
+template.quickStart.file=quickstart.ftl
 template.managing.file=managing.ftl
 template.managingIntro.file=managing.ftl
 template.installing.file=managing.ftl


### PR DESCRIPTION
#### What does this PR do?

updates `jbake.properties` for including the Quick Start Tutorial in the templated documentation.

#### Who is reviewing it?

@vinamartin @Lambeaux @ahoffer @jrnorth @troymohl 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

@clockard 
@coyotesqrl
@lessarderic
@pklinef
@shaundmorris

#### How should this be tested?

- compare attached pdf to existing documentation for completeness.
- "New" `-contents.adoc` files are existing content with headers added. Content review is OPTIONAL.

#### Any background context you want to provide?'

- moved the quickstart closer to the beginning of the documentation.

#### What are the relevant tickets?

[CAL-271](https://codice.atlassian.net/browse/CAL-271)
#### Screenshots (if appropriate)

[jdocumentation.pdf](https://github.com/codice/alliance/files/1069040/jdocumentation.pdf)

#### Checklist:
- [x] Documentation Updated
	- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
