### PR TITLE
CAL-310 Typo in version for alliance-catalog-core-api in feature file

### DIFF
--- a/catalog/security/security-app/src/main/resources/features.xml
+++ b/catalog/security/security-app/src/main/resources/features.xml
@@ -16,7 +16,7 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
 
-    <feature name="alliance-catalog-core-api" install="manual" version="${project.version" description="Alliance catalog extension APIs">
+    <feature name="alliance-catalog-core-api" install="manual" version="${project.version}" description="Alliance catalog extension APIs">
         <bundle>mvn:org.codice.alliance.catalog.core/catalog-core-api/${project.version}</bundle>
     </feature>
 


### PR DESCRIPTION
Typo in version for alliance-catalog-core-api in catalog/security/security-app/src/main/resources/features.xml causes the feature to have an invalid version.

#### What does this PR do?
Typo in version for alliance-catalog-core-api in catalog/security/security-app/src/main/resources/features.xml causes the feature to have an invalid version.

The typo declares the version "${project.version" resulting in the feature to have a version of 0.0.0.__project_version.

This PR adds trailing curly brace to resolve the issue.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@bdeining 
@brianfelix 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@pklinef

#### How should this be tested?
Build Alliance, run it, check feature:list and confirm alliance-catalog-core-api feature has the appropriate version as opposed to 0.0.0.__project_version

#### Any background context you want to provide?
#### What are the relevant tickets?
[CAL-310](https://codice.atlassian.net/browse/CAL-310)

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
