### PR TITLE
CAL-314 Renamed main log filename from ddf.log to alliance.log

### DIFF
--- a/distribution/common/src/main/resources/common-bin.xml
+++ b/distribution/common/src/main/resources/common-bin.xml
@@ -23,6 +23,8 @@
             <excludes>
                 <exclude>**/demos/**</exclude>
                 <exclude>bin/**</exclude>
+                <exclude>etc/org.ops4j.pax.logging.cfg</exclude>
+                <exclude>etc/log4j2.config.xml</exclude>
                 <exclude>etc/org.apache.karaf.features.cfg</exclude>
                 <!-- Karaf comes with a README in deploy folder which throws warnings in log -->
                 <exclude>deploy/*</exclude>

--- a/distribution/common/src/main/resources/etc/log4j2.config.xml
+++ b/distribution/common/src/main/resources/etc/log4j2.config.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<Configuration status="WARN">
+    <Properties>
+        <Property name="log-pattern">%-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %X{bundle.id}
+            - %X{bundle.name} - %X{bundle.version} | %m%n
+        </Property>
+    </Properties>
+
+    <Appenders>
+        <PaxOsgi name="osgi-platformLogging"
+                 filter="org.codice.ddf.platform.logging.LoggingService"/>
+
+        <PaxOsgi name="osgi-all" filter="*"/>
+
+        <Syslog name="syslog" facility="AUTH" host="localhost" protocol="UDP" port="514"/>
+
+        <Console name="stdout" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{ABSOLUTE} | ${log-pattern}"/>
+        </Console>
+
+        <RollingFile name="out" fileName="${sys:karaf.data}/log/alliance.log"
+                     filePattern="${sys:karaf.data}/log/alliance.log-%d{yyyy-MM-dd-HH}-%i.log.gz">
+            <PatternLayout pattern="%d{ISO8601} | ${log-pattern}"/>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="200 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="10"/>
+        </RollingFile>
+
+        <RollingFile name="ingestError" append="true"
+                     fileName="${sys:karaf.data}/log/ingest_error.log"
+                     filePattern="${sys:karaf.data}/log/ingest_error.log-%d{yyyy-MM-dd-HH}-%i.log.gz">
+            <PatternLayout pattern="%d{ABSOLUTE} | ${log-pattern}"/>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="200 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="10"/>
+        </RollingFile>
+
+        <RollingFile name="securityMain" append="true" ignoreExceptions="false"
+                     fileName="${sys:karaf.data}/log/security.log"
+                     filePattern="${sys:karaf.data}/log/security.log-%d{yyyy-MM-dd-HH}-%i.log.gz">
+            <PatternLayout pattern="[%-5p] %d{ISO8601} | %-16.16t | %-15.20c{1} |  %m%n"/>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="200 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="10"/>
+        </RollingFile>
+
+        <RollingFile name="securityBackup" append="true" ignoreExceptions="false"
+                     fileName="${sys:karaf.data}/log/securityBackup.log"
+                     filePattern="${sys:karaf.data}/log/securityBackup.log-%d{yyyy-MM-dd-HH}-%i.log.gz">
+            <PatternLayout pattern="[%-5p] %d{ISO8601} | %-16.16t | %-15.20c{1} |  %m%n"/>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="200 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="10"/>
+        </RollingFile>
+
+        <Failover name="securityFailover" primary="securityMain">
+            <Failovers>
+                <AppenderRef ref="securityBackup"/>
+            </Failovers>
+        </Failover>
+
+        <RollingFile name="solr" append="true"
+                     fileName="${sys:karaf.data}/log/solr.log"
+                     filePattern="${sys:karaf.data}/log/solr.log-%d{yyyy-MM-dd-HH}-%i.log.gz">
+            <PatternLayout pattern="%d{ABSOLUTE} | ${log-pattern}"/>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="200 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="10"/>
+        </RollingFile>
+
+        <RollingFile name="artemis" append="true"
+                     fileName="${sys:karaf.data}/log/artemis.log"
+                     filePattern="${sys:karaf.data}/log/artemis.log-%d{yyyy-MM-dd-HH}-%i.log.gz">
+            <PatternLayout pattern="%d{ABSOLUTE} | ${log-pattern}"/>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="200 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="10"/>
+        </RollingFile>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="securityLogger" level="info" additivity="false">
+            <AppenderRef ref="securityFailover"/>
+            <AppenderRef ref="syslog"/>
+            <AppenderRef ref="osgi-platformLogging"/>
+        </Logger>
+
+        <Logger name="org.apache.karaf.jaas.modules.audit" level="info" additivity="false">
+            <AppenderRef ref="securityFailover"/>
+            <AppenderRef ref="syslog"/>
+            <AppenderRef ref="osgi-platformLogging"/>
+        </Logger>
+
+        <Logger name="ingestLogger" level="info" additivity="false">
+            <AppenderRef ref="ingestError"/>
+            <AppenderRef ref="syslog"/>
+            <AppenderRef ref="osgi-platformLogging"/>
+        </Logger>
+
+        <Logger name="org.apache.solr" level="info" additivity="false">
+            <AppenderRef ref="solr"/>
+            <AppenderRef ref="syslog"/>
+            <AppenderRef ref="osgi-platformLogging"/>
+        </Logger>
+
+        <Logger name="org.apache.activemq.artemis" level="info" additivity="false">
+            <AppenderRef ref="artemis"/>
+            <AppenderRef ref="syslog"/>
+            <AppenderRef ref="osgi-platformLogging"/>
+        </Logger>
+
+        <Logger name="org.apache.lucene" level="info" additivity="false">
+            <AppenderRef ref="solr"/>
+            <AppenderRef ref="syslog"/>
+            <AppenderRef ref="osgi-platformLogging"/>
+        </Logger>
+
+        <!-- CXF and Solr logging is verbose.  Default setting to WARN.  This can be changed in the karaf console. -->
+        <Logger name="org.apache.cxf" level="warn"/>
+        <Logger name="lux.solr" level="warn"/>
+        <Logger name="org.ops4j.pax.web.jsp" level="warn"/>
+        <Logger name="org.apache.aries.spifly" level="warn"/>
+        <Logger name="org.apache.cxf.jaxrs.impl.WebApplicationExceptionMapper" level="error"/>
+        <Logger name="org.apache.cxf.phase.PhaseInterceptorChain" level="error"/>
+
+        <Root level="info">
+            <AppenderRef ref="out"/>
+            <AppenderRef ref="osgi-all"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/distribution/common/src/main/resources/etc/org.ops4j.pax.logging.cfg
+++ b/distribution/common/src/main/resources/etc/org.ops4j.pax.logging.cfg
@@ -1,0 +1,129 @@
+################################################################################
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+################################################################################
+
+# In order to switch to Log4j2 and be able to take advantage of the newer appenders,
+# such as the Failover appender, uncomment the following line and remove all the
+# configuration beneath it.
+#
+# This change can be made permanent (or done in another way, depending upon
+# the implementation choices made) when we have upgraded to Karaf 4.1.0
+# https://codice.atlassian.net/browse/DDF-2132
+#
+# org.ops4j.pax.logging.log4j2.config.file = ${karaf.etc}/log4j2.config.xml
+
+# Root logger
+log4j.rootLogger=INFO, out, osgi:*
+log4j.throwableRenderer=org.apache.log4j.OsgiThrowableRenderer
+
+# Security logger
+log4j.logger.securityLogger=INFO, security, syslog, osgi:org.codice.ddf.platform.logging.LoggingService
+log4j.additivity.securityLogger=false
+
+# Ingest Logger
+log4j.logger.ingestLogger = INFO, ingestError, syslog, osgi:org.codice.ddf.platform.logging.LoggingService
+log4j.additivity.ingestLogger=false
+
+# Solr Logger
+log4j.logger.org.apache.solr = INFO, solr, syslog, osgi:org.codice.ddf.platform.logging.LoggingService
+log4j.additivity.org.apache.solr = false
+log4j.logger.org.apache.lucene = INFO, solr, syslog, osgi:org.codice.ddf.platform.logging.LoggingService
+log4j.additivity.org.apache.lucene = false
+
+# Artemis Logger
+log4j.logger.org.apache.activemq.artemis = INFO, artemis, syslog, osgi:org.codice.ddf.platform.logging.LoggingService
+log4j.additivity.org.apache.activemq.artemis=false
+
+# LogAuditLoginModule logger
+log4j.logger.org.apache.karaf.jaas.modules.audit.LogAuditLoginModule=INFO, security, syslog, osgi:org.codice.ddf.platform.logging.LoggingService
+log4j.additivity.org.apache.karaf.jaas.modules.audit=false
+
+# Syslog appender
+log4j.appender.syslog=org.apache.log4j.net.SyslogAppender
+log4j.appender.syslog.layout=org.apache.log4j.PatternLayout
+log4j.appender.syslog.layout.ConversionPattern=%d{ISO8601} | %-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %X{bundle.id} - %X{bundle.name} - %X{bundle.version} | %m%n
+log4j.appender.syslog.facility=AUTH
+# this should be set to loghost generally when a syslog host is configured
+log4j.appender.syslog.syslogHost=localhost
+
+# CONSOLE appender not used by default
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} | %-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %X{bundle.id} - %X{bundle.name} - %X{bundle.version} | %m%n
+
+# File appender
+log4j.appender.out=org.apache.log4j.RollingFileAppender
+log4j.appender.out.layout=org.apache.log4j.PatternLayout
+log4j.appender.out.layout.ConversionPattern=%d{ISO8601} | %-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %X{bundle.id} - %X{bundle.name} - %X{bundle.version} | %m%n
+log4j.appender.out.file=${karaf.data}/log/alliance.log
+log4j.appender.out.append=true
+log4j.appender.out.maxFileSize=20MB
+log4j.appender.out.maxBackupIndex=10
+
+# Ingest Error File appender
+log4j.appender.ingestError=org.apache.log4j.RollingFileAppender
+log4j.appender.ingestError.layout=org.apache.log4j.PatternLayout
+log4j.appender.ingestError.layout.ConversionPattern=%d{ISO8601} | %-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %X{bundle.id} - %X{bundle.name} - %X{bundle.version} | %m%n
+log4j.appender.ingestError.file=${karaf.data}/log/ingest_error.log
+log4j.appender.ingestError.append=true
+log4j.appender.ingestError.maxFileSize=20MB
+log4j.appender.ingestError.maxBackupIndex=10
+
+# Security File appender
+log4j.appender.security=org.apache.log4j.RollingFileAppender
+log4j.appender.security.layout=org.apache.log4j.PatternLayout
+log4j.appender.security.layout.ConversionPattern=[%-5p] %d{ISO8601} | %-16.16t | %-15.20c{1} |  %m%n
+log4j.appender.security.file=${karaf.data}/log/security.log
+log4j.appender.security.append=true
+log4j.appender.security.maxFileSize=20MB
+log4j.appender.security.maxBackupIndex=10
+
+# Solr File appender
+log4j.appender.solr=org.apache.log4j.RollingFileAppender
+log4j.appender.solr.layout=org.apache.log4j.PatternLayout
+log4j.appender.solr.layout.ConversionPattern=%d{ISO8601} | %-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %X{bundle.id} - %X{bundle.name} - %X{bundle.version} | %m%n
+log4j.appender.solr.file=${karaf.data}/log/solr.log
+log4j.appender.solr.append=true
+log4j.appender.solr.maxFileSize=20MB
+log4j.appender.solr.maxBackupIndex=10
+
+# Artemis File appender
+log4j.appender.artemis=org.apache.log4j.RollingFileAppender
+log4j.appender.artemis.layout=org.apache.log4j.PatternLayout
+log4j.appender.artemis.layout.ConversionPattern=%d{ISO8601} | %-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %X{bundle.id} - %X{bundle.name} - %X{bundle.version} | %m%n
+log4j.appender.artemis.file=${karaf.data}/log/artemis.log
+log4j.appender.artemis.append=true
+log4j.appender.artemis.maxFileSize=20MB
+log4j.appender.artemis.maxBackupIndex=10
+
+# Sift appender
+log4j.appender.sift=org.apache.log4j.sift.MDCSiftingAppender
+log4j.appender.sift.key=bundle.name
+log4j.appender.sift.default=karaf
+log4j.appender.sift.appender=org.apache.log4j.FileAppender
+log4j.appender.sift.appender.layout=org.apache.log4j.PatternLayout
+log4j.appender.sift.appender.layout.ConversionPattern=%d{ABSOLUTE} | %-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %m%n
+log4j.appender.sift.appender.file=${karaf.data}/log/$\\{bundle.name\\}.log
+log4j.appender.sift.appender.append=true
+
+# CXF and Solr logging is verbose.  Default setting to WARN.  This can be changed in the karaf console.
+log4j.logger.org.apache.cxf = WARN
+log4j.logger.lux.solr = WARN
+log4j.logger.org.ops4j.pax.web.jsp = WARN
+log4j.logger.org.apache.aries.spifly = WARN
+log4j.logger.org.apache.cxf.phase.PhaseInterceptorChain = ERROR


### PR DESCRIPTION
#### What does this PR do?
This PR renames the main log filename from `ddf.log` to `alliance.log`.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@vinamartin @alexaabrd @josephthweatt 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@clockard 
@figliold 
#### How should this be tested?

- Confirm that the log file in `/data/log` is named `alliance.log` and contains the regular log entries.
- Confirm that the documentation uses `alliance.log`, not `ddf.log`.

#### Any background context you want to provide?
Alliance used to pull these 2 log configuration files from DDF, which caused the log file name to be `ddf.log`. The 2 added files in this PR are copied exactly from DDF, except the text `ddf.log` is replaced with `alliance.log`.
#### What are the relevant tickets?
[CAL-314](https://codice.atlassian.net/browse/CAL-314)
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/8041246/27293256-b71a8a5a-54ca-11e7-9f81-e3b1abd22ce1.png)
![image](https://user-images.githubusercontent.com/8041246/27293261-bb1799fe-54ca-11e7-8148-67a042f6ec59.png)
#### Checklist:
- [ ] Documentation Updated
	- [ ] Change Log Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
