### PR TITLE
CAL-312 Added CPE suppression for CVEs exposed through karaf dependency on pax-web-jsp

### DIFF
--- a/dependency-check-maven-config.xml
+++ b/dependency-check-maven-config.xml
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://www.owasp.org/index.php/OWASP_Dependency_Check_Suppression">
 
+    <!-- ddf kernel -->
+    <suppress>
+        <notes>
+            Karaf 4.1.1 uses pax-web-jsp 6.0.3 which is a dependency of ddf-kernel and contains
+            several CVEs: CVE-2016-8735, CVE-2014-0230, CVE-2013-2185, CVE-2011-3190, CVE-2009-3548.
+            None of these vulnerabilities are exposed through this code, so Apache must mitigate
+            them.
+            <![CDATA[file name: kernel-2.11.0-SNAPSHOT.zip: pax-web-jsp-6.0.3.jar]]>
+        </notes>
+        <sha1>6fe07b3e7c731219ee2d70e04b179f4b34bd3c16</sha1>
+        <cpe>cpe:/a:apache:tomcat</cpe>
+    </suppress>
     <!-- tika -->
     <suppress>
         <notes>


### PR DESCRIPTION
#### What does this PR do?
Karaf 4.1.1 uses pax-web-jsp 6.0.3 which is a dependency of ddf-kernel and contains several CVEs. None of these vulnerabilities are exposed through this code, so Apache must mitigate them.
kernel-2.11.0-SNAPSHOT.zip: pax-web-jsp-6.0.3.jar: CVE-2016-8735, CVE-2014-0230, CVE-2013-2185, CVE-2011-3190, CVE-2009-3548

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@emmberk @vinamartin @alexaabrd 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@clockard  @pklinef 

#### How should this be tested?
Read the CVEs and make a determination if this CPE is the correct approach.

#### Any background context you want to provide?
These CVEs do not cause the DDF owasp check to fail, but instead affect alliance only.

#### What are the relevant tickets?
[CAL-312](https://codice.atlassian.net/browse/CAL-312)
