### PR TITLE
CAL-321 Adds failover log back to logging config

### DIFF
--- a/distribution/common/src/main/resources/etc/log4j2.config.xml
+++ b/distribution/common/src/main/resources/etc/log4j2.config.xml
@@ -12,7 +12,7 @@
  *
  **/
 -->
-<Configuration status="WARN">
+<Configuration status="FATAL">
     <Properties>
         <Property name="log-pattern">%-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %X{bundle.id}
             - %X{bundle.name} - %X{bundle.version} | %m%n
@@ -61,11 +61,7 @@
             <DefaultRolloverStrategy max="10"/>
         </RollingFile>
 
-        <!--TODO DDF-3073
-        The karaf upgrade from 4.0.7 to 4.1.1 introduced a bug with the log4j2 failover
-        appender: "ERROR appender Failover has no parameter that matches element Failovers". See
-        https://issues.apache.org/jira/browse/LOG4J2-1163.-->
-        <!--<RollingFile name="securityBackup" append="true" ignoreExceptions="false"
+        <RollingFile name="securityBackup" append="true" ignoreExceptions="false"
                      fileName="${sys:karaf.data}/log/securityBackup.log"
                      filePattern="${sys:karaf.data}/log/securityBackup.log-%d{yyyy-MM-dd-HH}-%i.log.gz">
             <PatternLayout pattern="[%-5p] %d{ISO8601} | %-16.16t | %-15.20c{1} |  %m%n"/>
@@ -73,13 +69,14 @@
                 <SizeBasedTriggeringPolicy size="20 MB"/>
             </Policies>
             <DefaultRolloverStrategy max="10"/>
-        </RollingFile>-->
+        </RollingFile>
 
-        <!--<Failover name="securityFailover" primary="securityMain">
+        <!-- It is recommended to change the default directory of this log file -->
+        <Failover name="securityFailover" primary="securityMain">
             <Failovers>
                 <AppenderRef ref="securityBackup"/>
             </Failovers>
-        </Failover>-->
+        </Failover>
 
         <RollingFile name="solr" append="true"
                      fileName="${sys:karaf.data}/log/solr.log"
@@ -104,15 +101,13 @@
 
     <Loggers>
         <Logger name="securityLogger" level="info" additivity="false">
-            <!--<AppenderRef ref="securityFailover"/>-->
-            <AppenderRef ref="securityMain"/>
+            <AppenderRef ref="securityFailover"/>
             <AppenderRef ref="syslog"/>
             <AppenderRef ref="osgi-platformLogging"/>
         </Logger>
 
         <Logger name="org.apache.karaf.jaas.modules.audit" level="info" additivity="false">
-            <!--<AppenderRef ref="securityFailover"/>-->
-            <AppenderRef ref="securityMain"/>
+            <AppenderRef ref="securityFailover"/>
             <AppenderRef ref="syslog"/>
             <AppenderRef ref="osgi-platformLogging"/>
         </Logger>

--- a/distribution/common/src/main/resources/etc/org.ops4j.pax.logging.cfg
+++ b/distribution/common/src/main/resources/etc/org.ops4j.pax.logging.cfg
@@ -20,6 +20,8 @@
 # In order to switch to the xml-style configuration for Log4j2 in ${karaf.etc}/log4j2.config.xml,
 # uncomment the following line and remove all the configuration beneath it. This change has not been
 # made default because the xml-style configuration causes log entries to be missing from the itests.
+# However, because failover logging capabilities are only available for the xml-style configuration,
+# this step is required for security hardening.
 #
 # org.ops4j.pax.logging.log4j2.config.file = ${karaf.etc}/log4j2.config.xml
 
@@ -37,7 +39,6 @@ log4j2.rootLogger.appenderRef.osgi-all.ref = osgi-all
 log4j2.logger.securityLogger.name = securityLogger
 log4j2.logger.securityLogger.level = INFO
 log4j2.logger.securityLogger.additivity = false
-#log4j2.logger.securityLogger.appenderRef.securityFailover.ref = securityFailover
 log4j2.logger.securityLogger.appenderRef.securityMain.ref = securityMain
 log4j2.logger.securityLogger.appenderRef.syslog.ref = syslog
 log4j2.logger.securityLogger.appenderRef.osgi-platformLogging.ref = osgi-platformLogging
@@ -46,7 +47,6 @@ log4j2.logger.securityLogger.appenderRef.osgi-platformLogging.ref = osgi-platfor
 log4j2.logger.org_apache_karaf_jaas_modules_audit.name = org.apache.karaf.jaas.modules.audit
 log4j2.logger.org_apache_karaf_jaas_modules_audit.level = INFO
 log4j2.logger.org_apache_karaf_jaas_modules_audit.additivity = false
-#log4j2.logger.org_apache_karaf_jaas_modules_audit.appenderRef.securityFailover.ref = securityFailover
 log4j2.logger.org_apache_karaf_jaas_modules_audit.appenderRef.securityMain.ref = securityMain
 log4j2.logger.org_apache_karaf_jaas_modules_audit.appenderRef.syslog.ref = syslog
 log4j2.logger.org_apache_karaf_jaas_modules_audit.appenderRef.osgi-platformLogging.ref = osgi-platformLogging
@@ -167,33 +167,6 @@ log4j2.appender.securityMain.policies.size.size = 20MB
 log4j2.appender.securityMain.strategy.type = DefaultRolloverStrategy
 log4j2.appender.securityMain.strategy.max = 10
 
-# TODO DDF-3073
-# The karaf upgrade from 4.0.7 to 4.1.1 introduced a bug with the log4j2 failover appender: "ERROR
-# appender Failover has no parameter that matches element Failovers". See
-# https://issues.apache.org/jira/browse/LOG4J2-1163.
-
-## securityBackup
-#log4j2.appender.securityBackup.type = RollingFile
-#log4j2.appender.securityBackup.name = securityBackup
-#log4j2.appender.securityBackup.fileName = ${karaf.data}/log/securityBackup.log
-#log4j2.appender.securityBackup.filePattern = ${karaf.data}/log/securityBackup.log-%d{yyyy-MM-dd-HH}-%i.log.gz
-#log4j2.appender.securityBackup.append = true
-#log4j2.appender.securityBackup.ignoreExceptions = false
-#log4j2.appender.securityBackup.layout.type = PatternLayout
-#log4j2.appender.securityBackup.layout.pattern = [%-5p] %d{ISO8601} | %-16.16t | %-15.20c{1} |  %m%n
-#log4j2.appender.securityBackup.policies.type = Policies
-#log4j2.appender.securityBackup.policies.size.type = SizeBasedTriggeringPolicy
-#log4j2.appender.securityBackup.policies.size.size = 20MB
-#log4j2.appender.securityBackup.strategy.type = DefaultRolloverStrategy
-#log4j2.appender.securityBackup.strategy.max = 10
-
-## securityFailover
-#log4j2.appender.securityFailover.type = Failover
-#log4j2.appender.securityFailover.name = securityFailover
-#log4j2.appender.securityFailover.primary = securityMain
-#log4j2.appender.securityFailover.failovers.type = Failovers
-#log4j2.appender.securityFailover.failovers.appenderRef.securityBackup.ref = securityBackup
-
 # solr
 log4j2.appender.solr.type = RollingFile
 log4j2.appender.solr.name = solr
@@ -221,3 +194,5 @@ log4j2.appender.artemis.policies.size.type = SizeBasedTriggeringPolicy
 log4j2.appender.artemis.policies.size.size = 20MB
 log4j2.appender.artemis.strategy.type = DefaultRolloverStrategy
 log4j2.appender.artemis.strategy.max = 10
+
+# Setting custom configurations using log:set from the console will append those configurations below this line


### PR DESCRIPTION
#### What does this PR do?
Adds failover log back to logging configuration.
With the Karaf upgrade, there is an issue with the pax logging configuration that makes it unavailable to use through our default configuration, however, when using the log4j2.config.xml file failover seems to be functional (though errors populate the log).

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@emmberk 
@mcalcote 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@figliold 

#### How should this be tested?

- Create a disk image and mount it (Here's an example of how to do so on a mac: https://support.apple.com/kb/PH22247?locale=en_US&viewlocale=en_US)
- Unzip the Alliance
- Configure the Alliance's logging configuration per the documentation and setup the securityMain appender to write to a log file inside of the disk image
- Start up the Alliance
- Verify logs are written to the security log inside the disk image
- Begin to fill up the disk image (for instance: http://www.skorks.com/2010/03/how-to-quickly-generate-a-large-file-on-the-command-line-with-linux/)
- Verify that when the disk is full, the security backup log is written to