### PR TITLE
CAL-322 Update Surefire to account for Spock tests

### DIFF
--- a/catalog/imaging/imaging-plugin-nitf/src/test/groovy/org/codice/alliance/plugin/nitf/NitfPreStoragePluginSpec.groovy
+++ b/catalog/imaging/imaging-plugin-nitf/src/test/groovy/org/codice/alliance/plugin/nitf/NitfPreStoragePluginSpec.groovy
@@ -11,13 +11,13 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
+package org.codice.alliance.plugin.nitf
 
-import org.codice.alliance.plugin.nitf.NitfPreStoragePlugin
 import spock.lang.Specification
 import spock.lang.Unroll
 
 @Unroll
-class NitfPreStoragePluginTest extends Specification {
+class NitfPreStoragePluginSpec extends Specification {
 
     def "Building derived image filename from \"#ftitle\"" (String ftitle, String expectedFname) {
         setup:

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/TextAttributeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/TextAttributeTest.java
@@ -30,7 +30,7 @@ import org.codice.imaging.nitf.core.text.TextSegment;
 import org.junit.Before;
 import org.junit.Test;
 
-public class TestTextAttribute {
+public class TextAttributeTest {
 
     public static final int TEXT_ATTACHMENT_LEVEL = 0;
 

--- a/catalog/security/banner-marking/src/test/groovy/org/codice/alliance/security/banner/marking/BannerCommonMarkingExtractorSpec.groovy
+++ b/catalog/security/banner-marking/src/test/groovy/org/codice/alliance/security/banner/marking/BannerCommonMarkingExtractorSpec.groovy
@@ -22,7 +22,7 @@ import spock.lang.Unroll
 
 import static org.codice.alliance.security.banner.marking.BannerMarkings.ClassificationLevel.*
 
-class BannerCommonMarkingExtractorTest extends Specification {
+class BannerCommonMarkingExtractorSpec extends Specification {
     private BannerCommonMarkingExtractor extractor
     private Metacard metacard
     private BannerMarkings bannerMarkings

--- a/catalog/security/banner-marking/src/test/groovy/org/codice/alliance/security/banner/marking/BannerMarkingsSpec.groovy
+++ b/catalog/security/banner-marking/src/test/groovy/org/codice/alliance/security/banner/marking/BannerMarkingsSpec.groovy
@@ -26,7 +26,7 @@ import static org.codice.alliance.security.banner.marking.BannerMarkings.DissemC
 import static org.codice.alliance.security.banner.marking.BannerMarkings.MarkingType.*
 import static org.codice.alliance.security.banner.marking.BannerMarkings.OtherDissemControl.*
 
-class BannerMarkingsTest extends Specification {
+class BannerMarkingsSpec extends Specification {
     def 'test type and classification'() {
         when:
         def bannerMarkings = BannerMarkings.parseMarkings(markings)

--- a/catalog/security/banner-marking/src/test/groovy/org/codice/alliance/security/banner/marking/Dod520001MarkingExtractorSpec.groovy
+++ b/catalog/security/banner-marking/src/test/groovy/org/codice/alliance/security/banner/marking/Dod520001MarkingExtractorSpec.groovy
@@ -19,7 +19,7 @@ import ddf.catalog.data.impl.MetacardTypeImpl
 import spock.lang.Specification
 import spock.lang.Unroll
 
-class Dod520001MarkingExtractorTest extends Specification {
+class Dod520001MarkingExtractorSpec extends Specification {
     private Dod520001MarkingExtractor extractor
     private Metacard metacard
     private BannerMarkings bannerMarkings

--- a/catalog/security/banner-marking/src/test/groovy/org/codice/alliance/security/banner/marking/ValidationErrorSpec.groovy
+++ b/catalog/security/banner-marking/src/test/groovy/org/codice/alliance/security/banner/marking/ValidationErrorSpec.groovy
@@ -15,7 +15,7 @@ package org.codice.alliance.security.banner.marking
 
 import spock.lang.Specification
 
-class ValidationErrorTest extends Specification {
+class ValidationErrorSpec extends Specification {
     def 'test ctors'() {
         expect:
         new ValidationError('message', 'appendix', 'para').message == 'message'

--- a/pom.xml
+++ b/pom.xml
@@ -295,8 +295,6 @@
                         </argLine>
                         <includes>
                             <include>**/*Test.java</include>
-                            <include>**/Test*.java</include>
-                            <include>**/*TestCase.java</include>
                             <include>**/*Spec.class</include>
                         </includes>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -293,6 +293,12 @@
                     <configuration>
                         <argLine>${argLine} -Duser.timezone=UTC -Dddf.version=${ddf.version}
                         </argLine>
+                        <includes>
+                            <include>**/*Test.java</include>
+                            <include>**/Test*.java</include>
+                            <include>**/*TestCase.java</include>
+                            <include>**/*Spec.class</include>
+                        </includes>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
#### What does this PR do?
- Updates Surefire to include Spock tests that end in `*Spec.class`.
- Removes unused surefire includes
- Renames some tests classes to comply with test guide lines

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@vinamartin @lessarderic @emmberk 

#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
@coyotesqrl
@lessarderic

#### How should this be tested?
Run unit tests to ensure coverage numbers are still met.

#### What are the relevant tickets?
[CAL-322](https://codice.atlassian.net/browse/CAL-322)

#### Checklist:
- [ ] Documentation Updated
- [ ] Change Log Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
