### PR TITLE
CAL-311 Updated suppressions for geowebcache based on latest owasp findings

### DIFF
--- a/dependency-check-maven-config.xml
+++ b/dependency-check-maven-config.xml
@@ -286,6 +286,7 @@
             gwc-web-1.5.0.war: commons-collections-3.1.jar
             gwc-web-1.5.0.war: postgresql-8.4-701.jdbc3.jar
             geowebcache-server-standalone-0.7.0.war: gwc-sqlite-1.9.1.jar
+            geowebcache-server-standalone-0.7.0.war: sqlite-jdbc-3.8.6.jar
             geowebcache-server-standalone-0.7.0.war: commons-fileupload-1.2.1.jar
         </notes>
         <cve>CVE-2016-3092</cve>
@@ -300,6 +301,7 @@
         <cve>CVE-2015-3416</cve>
         <cve>CVE-2015-3415</cve>
         <cve>CVE-2015-3414</cve>
+        <cve>CVE-2017-10989</cve>
     </suppress>
     <!-- end of geowebcache vulnerabilities -->
     <suppress>


### PR DESCRIPTION
#### What does this PR do?
Added another CVE to the suppression list for geowebcache.

#### Choose 2 committers to review/merge the PR.
@clockard
@coyotesqrl
@stustison

#### Any background context you want to provide?
`[ERROR] One or more dependencies were identified with vulnerabilities that have a CVSS score greater then '7.0': 
[ERROR] 
[ERROR] geowebcache-server-standalone-0.7.0.war: gwc-sqlite-1.9.1.jar: CVE-2017-10989
[ERROR] geowebcache-server-standalone-0.7.0.war: sqlite-jdbc-3.8.6.jar: CVE-2017-10989`

https://github.com/codice/alliance/blob/master/dependency-check-maven-config.xml#L279

[CAL-311](https://codice.atlassian.net/browse/CAL-311)