### PR TITLE
CAL-299 Update deploy command to retry failed deployments

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,7 +103,7 @@ pipeline {
                 withMaven(maven: 'M3', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings') {
                     checkout scm
                     sh 'mvn javadoc:aggregate -DskipStatic=true -DskipTests=true'
-                    sh 'mvn deploy -T 1C -DskipStatic=true -DskipTests=true'
+                    sh 'mvn deploy -T 1C -DskipStatic=true -DskipTests=true -DretryFailedDeploymentCount=10'
                 }
             }
         }


### PR DESCRIPTION
#### What does this PR do?
Added `-DretryFailedDeploymentCount=10` to the deploy command

#### Who is reviewing it? 
@oconnormi @clockard @shaundmorris @LinkMJB 

#### Select relevant component teams: 
@codice/build 

#### Any background context you want to provide?
This change matches the command used in the legacy jenkins deploy jobs.
