### PR TITLE
CAL-325 change ClassificationLevel and SciControl to be public instead of package-private

### DIFF
--- a/catalog/security/banner-marking/src/main/java/org/codice/alliance/security/banner/marking/BannerMarkings.java
+++ b/catalog/security/banner-marking/src/main/java/org/codice/alliance/security/banner/marking/BannerMarkings.java
@@ -35,7 +35,7 @@ public class BannerMarkings implements Serializable {
     private static final List<String> NATO_CLASS_QUALIFIERS = ImmutableList.of("ATOMAL", "BALK",
             "BOHEMIA");
 
-    enum ClassificationLevel {
+    public enum ClassificationLevel {
         UNCLASSIFIED("UNCLASSIFIED", "U"), RESTRICTED("RESTRICTED", "R"), CONFIDENTIAL(
                 "CONFIDENTIAL", "C"), SECRET("SECRET", "S"), TOP_SECRET("TOP SECRET", "TS");
 
@@ -73,7 +73,7 @@ public class BannerMarkings implements Serializable {
         US, FGI, JOINT
     }
 
-    enum DissemControl {
+    public enum DissemControl {
         IMCON("IMCON", "CONTROLLED IMAGERY"),
         NOFORN("NOFORN", "NOT RELEASABLE TO FOREIGN NATIONALS"),
         PROPIN("PROPIN", "CAUTION-PROPRIETARY INFORMATION INVOLVED"),
@@ -153,7 +153,7 @@ public class BannerMarkings implements Serializable {
         }
     }
 
-    static class SciControl implements Serializable {
+    public static class SciControl implements Serializable {
         private final String control;
 
         private final Map<String, List<String>> compartments;


### PR DESCRIPTION
#### What does this PR do?
change ClassificationLevel and SciControl to be public instead of package-private
#### Who is reviewing it? 
@coyotesqrl 
@rzwiefel 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)
#### Choose 2 committers to review/merge the PR.
(please choose ONLY two committers from below, delete the rest)

@bdeining
@jlcsmith
#### How should this be tested?
Run unit tests and itests.
#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-325](https://codice.atlassian.net/browse/CAL-325)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
