### PR TITLE
CAL-333 Add nitf support for STDIDC

### DIFF
--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/AbstractNitfMetacardType.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/AbstractNitfMetacardType.java
@@ -30,6 +30,7 @@ import org.codice.alliance.transformer.nitf.common.NitfHeaderAttribute;
 import org.codice.alliance.transformer.nitf.common.PiaimcAttribute;
 import org.codice.alliance.transformer.nitf.common.PiaprdAttribute;
 import org.codice.alliance.transformer.nitf.common.PiatgbAttribute;
+import org.codice.alliance.transformer.nitf.common.StdidcAttribute;
 import org.codice.alliance.transformer.nitf.gmti.IndexedMtirpbAttribute;
 import org.codice.alliance.transformer.nitf.gmti.MtirpbAttribute;
 
@@ -77,6 +78,7 @@ public abstract class AbstractNitfMetacardType extends MetacardTypeImpl {
         descriptors.addAll(getDescriptors(PiaimcAttribute.getAttributes()));
         descriptors.addAll(getDescriptors(PiaprdAttribute.getAttributes()));
         descriptors.addAll(getDescriptors(PiatgbAttribute.getAttributes()));
+        descriptors.addAll(getDescriptors(StdidcAttribute.getAttributes()));
         descriptors.addAll(new CoreAttributes().getAttributeDescriptors());
         descriptors.addAll(new AssociationsAttributes().getAttributeDescriptors());
         descriptors.addAll(new ContactAttributes().getAttributeDescriptors());

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/StdidcAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/StdidcAttribute.java
@@ -1,0 +1,218 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.transformer.nitf.common;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.MissingResourceException;
+import java.util.function.Function;
+
+import org.codice.alliance.transformer.nitf.ExtNitfUtility;
+import org.codice.imaging.nitf.core.tre.Tre;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.data.AttributeType;
+import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.types.Location;
+
+/**
+ * TRE for "STDIDC "Standard ID"
+ */
+public class StdidcAttribute extends NitfAttributeImpl<Tre> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NitfAttributeImpl.class);
+
+    private static final List<NitfAttribute<Tre>> ATTRIBUTES = new ArrayList<>();
+
+    private static final String PREFIX = ExtNitfUtility.EXT_NITF_PREFIX + "stdidc.";
+
+    public static final String ACQUISITION_DATE_SHORT_NAME = "ACQUISITION_DATE";
+
+    public static final String COUNTRY_SHORT_NAME = "COUNTRY";
+
+    public static final String LOCATION_SHORT_NAME = "LOCATION";
+
+    public static final String WAC_SHORT_NAME = "WAC";
+
+    public static final String MISSION_SHORT_NAME = "MISSION";
+
+    public static final String OP_NUM_SHORT_NAME = "OP_NUM";
+
+    public static final String PASS_SHORT_NAME = "PASS";
+
+    public static final String REPLAY_REGEN_SHORT_NAME = "REPLAY_REGEN";
+
+    public static final String REPRO_NUM_SHORT_NAME = "REPRO_NUM";
+
+    public static final String START_COLUMN_SHORT_NAME = "START_COLUMN";
+
+    public static final String START_ROW_SHORT_NAME = "START_ROW";
+
+    public static final String START_SEGMENT_SHORT_NAME = "START_SEGMENT";
+
+    public static final String END_COLUMN_SHORT_NAME = "END_COLUMN";
+
+    public static final String END_ROW_SHORT_NAME = "END_ROW";
+
+    public static final String END_SEGMENT_SHORT_NAME = "END_SEGMENT";
+
+    public static final String ACQUISITION_DATE = PREFIX + "acquisition-date";
+
+    public static final String COUNTRY = PREFIX + "country";
+
+    public static final String LOCATION = PREFIX + "location";
+
+    public static final String WAC = PREFIX + "wac";
+
+    public static final String MISSION = PREFIX + "mission";
+
+    public static final String OP_NUM = PREFIX + "op-num";
+
+    public static final String PASS = PREFIX + "pass";
+
+    public static final String REPLAY_REGEN = PREFIX + "replay-regen";
+
+    public static final String REPRO_NUM = PREFIX + "repo-num";
+
+    public static final String START_COLUMN = PREFIX + "start-column";
+
+    public static final String START_ROW = PREFIX + "start-row";
+
+    public static final String START_SEGMENT = PREFIX + "start-segment";
+
+    public static final String END_COLUMN = PREFIX + "end-column";
+
+    public static final String END_ROW = PREFIX + "end-row";
+
+    public static final String END_SEGMENT = PREFIX + "end-segment";
+
+    static final StdidcAttribute ACQUISITION_DATE_ATTRIBUTE = new StdidcAttribute(ACQUISITION_DATE,
+            ACQUISITION_DATE_SHORT_NAME,
+            tre -> TreUtility.convertToDate(tre, ACQUISITION_DATE_SHORT_NAME),
+            BasicTypes.DATE_TYPE);
+
+    static final StdidcAttribute COUNTRY_ATTRIBUTE = new StdidcAttribute(COUNTRY,
+            COUNTRY_SHORT_NAME,
+            tre -> TreUtility.convertToString(tre, COUNTRY_SHORT_NAME),
+            BasicTypes.STRING_TYPE);
+
+    static final StdidcAttribute COUNTRY_ALPHA3_ATTRIBUTE =
+            new StdidcAttribute(Location.COUNTRY_CODE,
+                    COUNTRY_SHORT_NAME,
+                    tre -> getAlpha3CountryCode(TreUtility.convertToString(tre,
+                            COUNTRY_SHORT_NAME)),
+                    BasicTypes.STRING_TYPE);
+
+    static final StdidcAttribute LOCATION_ATTRIBUTE = new StdidcAttribute(LOCATION,
+            LOCATION_SHORT_NAME,
+            tre -> TreUtility.convertToString(tre, LOCATION_SHORT_NAME),
+            BasicTypes.STRING_TYPE);
+
+    static final StdidcAttribute WAC_ATTRIBUTE = new StdidcAttribute(WAC,
+            WAC_SHORT_NAME,
+            tre -> TreUtility.convertToString(tre, WAC_SHORT_NAME),
+            BasicTypes.STRING_TYPE);
+
+    static final StdidcAttribute MISSION_ATTRIBUTE = new StdidcAttribute(MISSION,
+            MISSION_SHORT_NAME,
+            tre -> TreUtility.convertToString(tre, MISSION_SHORT_NAME),
+            BasicTypes.STRING_TYPE);
+
+    static final StdidcAttribute OP_NUM_ATTRIBUTE = new StdidcAttribute(OP_NUM,
+            OP_NUM_SHORT_NAME,
+            tre -> TreUtility.convertToString(tre, OP_NUM_SHORT_NAME),
+            BasicTypes.STRING_TYPE);
+
+    static final StdidcAttribute PASS_ATTRIBUTE = new StdidcAttribute(PASS,
+            PASS_SHORT_NAME,
+            tre -> TreUtility.convertToString(tre, PASS_SHORT_NAME),
+            BasicTypes.STRING_TYPE);
+
+    static final StdidcAttribute REPLAY_REGEN_ATTRIBUTE = new StdidcAttribute(REPLAY_REGEN,
+            REPLAY_REGEN_SHORT_NAME,
+            tre -> TreUtility.convertToString(tre, REPLAY_REGEN_SHORT_NAME),
+            BasicTypes.STRING_TYPE);
+
+    static final StdidcAttribute REPRO_NUM_ATTRIBUTE = new StdidcAttribute(REPRO_NUM,
+            REPRO_NUM_SHORT_NAME,
+            tre -> TreUtility.convertToString(tre, REPRO_NUM_SHORT_NAME),
+            BasicTypes.STRING_TYPE);
+
+    static final StdidcAttribute START_COLUMN_ATTRIBUTE = new StdidcAttribute(START_COLUMN,
+            START_COLUMN_SHORT_NAME,
+            tre -> TreUtility.convertToString(tre, START_COLUMN_SHORT_NAME),
+            BasicTypes.STRING_TYPE);
+
+    static final StdidcAttribute START_ROW_ATTRIBUTE = new StdidcAttribute(START_ROW,
+            START_ROW_SHORT_NAME,
+            tre -> TreUtility.convertToString(tre, START_ROW_SHORT_NAME),
+            BasicTypes.STRING_TYPE);
+
+    static final StdidcAttribute START_SEGMENT_ATTRIBUTE = new StdidcAttribute(START_SEGMENT,
+            START_SEGMENT_SHORT_NAME,
+            tre -> TreUtility.convertToString(tre, START_SEGMENT_SHORT_NAME),
+            BasicTypes.STRING_TYPE);
+
+    static final StdidcAttribute END_COLUMN_ATTRIBUTE = new StdidcAttribute(END_COLUMN,
+            END_COLUMN_SHORT_NAME,
+            tre -> TreUtility.convertToString(tre, END_COLUMN_SHORT_NAME),
+            BasicTypes.STRING_TYPE);
+
+    static final StdidcAttribute END_ROW_ATTRIBUTE = new StdidcAttribute(END_ROW,
+            END_ROW_SHORT_NAME,
+            tre -> TreUtility.convertToString(tre, END_ROW_SHORT_NAME),
+            BasicTypes.STRING_TYPE);
+
+    static final StdidcAttribute END_SEGMENT_ATTRIBUTE = new StdidcAttribute(END_SEGMENT,
+            END_SEGMENT_SHORT_NAME,
+            tre -> TreUtility.convertToString(tre, END_SEGMENT_SHORT_NAME),
+            BasicTypes.STRING_TYPE);
+
+    private StdidcAttribute(String longName, String shortName,
+            Function<Tre, Serializable> accessorFunction, AttributeType attributeType) {
+        super(longName, shortName, accessorFunction, attributeType);
+        ATTRIBUTES.add(this);
+    }
+
+    public static List<NitfAttribute<Tre>> getAttributes() {
+        return Collections.unmodifiableList(ATTRIBUTES);
+    }
+
+    /**
+     * Get the alpha3 country code for and alpha2 country code.
+     * in alpha2 code.
+     * @param alpha2CountryCode the alpha2 country code.
+     * @return Returns null if null is passed in. If the alpha3 code lookup fails it will return the passed in alpha2 code. Otherwise returns the alpha3 country code.
+     */
+    private static String getAlpha3CountryCode(String alpha2CountryCode) {
+        if (alpha2CountryCode == null) {
+            return alpha2CountryCode;
+        }
+
+        try {
+            return new Locale(Locale.ENGLISH.getLanguage(), alpha2CountryCode).getISO3Country();
+        } catch (MissingResourceException e) {
+            LOGGER.debug(
+                    "Failed to convert country code {} to alpha-3 format. Returning the original alpha2 country code",
+                    alpha2CountryCode,
+                    e);
+            return alpha2CountryCode;
+        }
+    }
+
+}

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/TreDescriptor.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/TreDescriptor.java
@@ -28,7 +28,8 @@ public enum TreDescriptor {
     MTIRPB(MtirpbAttribute.getAttributes()),
     PIAIMC(PiaimcAttribute.getAttributes()),
     PIAPRD(PiaprdAttribute.getAttributes()),
-    PIATGB(PiatgbAttribute.getAttributes());
+    PIATGB(PiatgbAttribute.getAttributes()),
+    STDIDC(StdidcAttribute.getAttributes());
 
     private List<NitfAttribute<Tre>> nitfAttributes;
 

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/StdidcAttributeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/StdidcAttributeTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.transformer.nitf.common;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.Serializable;
+
+import org.codice.imaging.nitf.core.tre.Tre;
+import org.junit.Before;
+import org.junit.Test;
+
+public class StdidcAttributeTest {
+
+    private Tre tre;
+
+    @Before
+    public void setup() {
+        tre = mock(Tre.class);
+    }
+
+    @Test
+    public void testValidCountryCode() throws Exception {
+        when(tre.getFieldValue(StdidcAttribute.COUNTRY_SHORT_NAME)).thenReturn("US");
+        Serializable actual = StdidcAttribute.COUNTRY_ALPHA3_ATTRIBUTE.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is("USA"));
+        actual = StdidcAttribute.COUNTRY_ATTRIBUTE.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is("US"));
+    }
+
+    @Test
+    public void testInvalidCountryCode() throws Exception {
+        when(tre.getFieldValue(StdidcAttribute.COUNTRY_SHORT_NAME)).thenReturn("0");
+        Serializable actual = StdidcAttribute.COUNTRY_ALPHA3_ATTRIBUTE.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is("0"));
+        actual = StdidcAttribute.COUNTRY_ATTRIBUTE.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is("0"));
+    }
+
+    @Test
+    public void testEmptyCountryCode() throws Exception {
+        when(tre.getFieldValue(StdidcAttribute.COUNTRY_SHORT_NAME)).thenReturn(null);
+        Serializable actual = StdidcAttribute.COUNTRY_ALPHA3_ATTRIBUTE.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, is(nullValue()));
+        actual = StdidcAttribute.COUNTRY_ATTRIBUTE.getAccessorFunction()
+                .apply(tre);
+        assertThat(actual, nullValue());
+    }
+}

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/gmti/GmtiMetacardTypeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/gmti/GmtiMetacardTypeTest.java
@@ -31,6 +31,7 @@ import org.codice.alliance.transformer.nitf.common.NitfHeaderAttribute;
 import org.codice.alliance.transformer.nitf.common.PiaimcAttribute;
 import org.codice.alliance.transformer.nitf.common.PiaprdAttribute;
 import org.codice.alliance.transformer.nitf.common.PiatgbAttribute;
+import org.codice.alliance.transformer.nitf.common.StdidcAttribute;
 import org.junit.Test;
 
 import ddf.catalog.data.AttributeDescriptor;
@@ -69,6 +70,7 @@ public class GmtiMetacardTypeTest {
         descriptors.addAll(AbstractNitfMetacardType.getDescriptors(PiatgbAttribute.getAttributes()));
         descriptors.addAll(AbstractNitfMetacardType.getDescriptors(PiaprdAttribute.getAttributes()));
         descriptors.addAll(AbstractNitfMetacardType.getDescriptors(IndexedPiaprdAttribute.getAttributes()));
+        descriptors.addAll(AbstractNitfMetacardType.getDescriptors(StdidcAttribute.getAttributes()));
         assertThat(gmtiCardType.getAttributeDescriptors(),
                 containsInAnyOrder(descriptors.toArray(new AttributeDescriptor[descriptors.size()])));
     }

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageMetacardTypeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageMetacardTypeTest.java
@@ -31,6 +31,7 @@ import org.codice.alliance.transformer.nitf.common.NitfHeaderAttribute;
 import org.codice.alliance.transformer.nitf.common.PiaimcAttribute;
 import org.codice.alliance.transformer.nitf.common.PiaprdAttribute;
 import org.codice.alliance.transformer.nitf.common.PiatgbAttribute;
+import org.codice.alliance.transformer.nitf.common.StdidcAttribute;
 import org.codice.alliance.transformer.nitf.gmti.IndexedMtirpbAttribute;
 import org.codice.alliance.transformer.nitf.gmti.MtirpbAttribute;
 import org.junit.Test;
@@ -76,6 +77,7 @@ public class ImageMetacardTypeTest {
         descriptors.addAll(AbstractNitfMetacardType.getDescriptors(PiatgbAttribute.getAttributes()));
         descriptors.addAll(AbstractNitfMetacardType.getDescriptors(PiaprdAttribute.getAttributes()));
         descriptors.addAll(AbstractNitfMetacardType.getDescriptors(IndexedPiaprdAttribute.getAttributes()));
+        descriptors.addAll(AbstractNitfMetacardType.getDescriptors(StdidcAttribute.getAttributes()));
         assertThat(imageCardType.getAttributeDescriptors(),
                 containsInAnyOrder(descriptors.toArray(new AttributeDescriptor[descriptors.size()])));
     }

--- a/distribution/docs/src/main/resources/_contents/_formats/supported-file-formats-contents.adoc
+++ b/distribution/docs/src/main/resources/_contents/_formats/supported-file-formats-contents.adoc
@@ -212,6 +212,23 @@ ${branding} has the capability to extract ISR-specific metadata from supported f
 ** `ext.nitf.aimidb.country-code`
 ** `ext.nitf.aimidb.location`
 
+* NITF Standard ID (STDIDC) Extended Attributes
+** `ext.nitf.stdidc.acquisition-date`
+** `ext.nitf.stdidc.country`
+** `ext.nitf.stdidc.location`
+** `ext.nitf.stdidc.wac`
+** `ext.nitf.stdidc.mission`
+** `ext.nitf.stdidc.op-num`
+** `ext.nitf.stdidc.pass`
+** `ext.nitf.stdidc.replay-regen`
+** `ext.nitf.stdidc.repo-num`
+** `ext.nitf.stdidc.start-column`
+** `ext.nitf.stdidc.start-row`
+** `ext.nitf.stdidc.start-segment`
+** `ext.nitf.stdidc.end-column`
+** `ext.nitf.stdidc.end-row`
+** `ext.nitf.stdidc.end-segment`
+
 * NITF Header Extended Attributes
 ** `ext.nitf.file-profile-name`
 ** `ext.nitf.file-version`


### PR DESCRIPTION
#### What does this PR do?
Add nitf support for STDIDC
- Also set the location.country-code based on the STDIDC_COUNTRY
#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)
@emmberk @mcalcote 
#### Choose 2 committers to review/merge the PR.
(please choose ONLY two committers from below, delete the rest)
@bdeining
@coyotesqrl

#### How should this be tested?
Install alliance and ingest a nitf with a populated  stdidc tre
Verify that the ext.nitf.stdidc.country is populated with a 2 character country code
Verify that the location.country-code is populated with a 3 character country code

#### What are the relevant tickets?
[CAL-333](https://codice.atlassian.net/browse/CAL-333)
#### Screenshots (if appropriate)
#### Checklist:
- [X] Documentation Updated
- [X] Update / Add Unit Tests

