### PR TITLE
CAL-334 removed the dependency flag on the catalog-core-api bundle to…

### DIFF
--- a/catalog/imaging/imaging-app/src/main/resources/features.xml
+++ b/catalog/imaging/imaging-app/src/main/resources/features.xml
@@ -26,7 +26,7 @@
              description="The Imaging Application provides support for ingesting and searching for NITF products.::Imaging">
         <feature prerequisite="true">catalog-app</feature>
         <feature prerequisite="true">platform-usng4j</feature>
-        <bundle dependency="true">mvn:org.codice.alliance.catalog.core/catalog-core-api/${project.version}</bundle>
+        <bundle>mvn:org.codice.alliance.catalog.core/catalog-core-api/${project.version}</bundle>
         <bundle>mvn:org.codice.alliance.imaging/imaging-nitf-api/${project.version}</bundle>
         <bundle>mvn:org.codice.alliance.imaging/imaging-nitf-impl/${project.version}</bundle>
         <bundle>mvn:org.codice.alliance.imaging/imaging-service-api/${project.version}</bundle>


### PR DESCRIPTION
… ensure it is included in that kar.

#### What does this PR do?
allows the imaging-app to be installed on a vanilla DDF
#### Choose 2 committers to review/merge the PR.
@bdeining
@coyotesqrl
#### How should this be tested?
build alliance, startup a DDF 2.11 instance. Install imaging-app kar either through the deploy dir or the admin ui.
#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-334](https://codice.atlassian.net/browse/CAL-334)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
