### PR TITLE
CAL-331 Banner markings extractor rejects when conflicting security markings found

### DIFF
--- a/catalog/security/banner-marking/pom.xml
+++ b/catalog/security/banner-marking/pom.xml
@@ -51,6 +51,11 @@
             <version>${ddf.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.codice.alliance.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/catalog/security/banner-marking/src/main/java/org/codice/alliance/security/banner/marking/MarkingMismatchException.java
+++ b/catalog/security/banner-marking/src/main/java/org/codice/alliance/security/banner/marking/MarkingMismatchException.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.alliance.security.banner.marking;
+
+public class MarkingMismatchException extends RuntimeException {
+
+    public MarkingMismatchException(String message) {
+        super(message);
+    }
+}

--- a/distribution/docs/src/main/jdocs/content/_banner-markings/banner-markings-extractor-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_banner-markings/banner-markings-extractor-contents.adoc
@@ -1,0 +1,18 @@
+:title: Banner Markings Extractor
+:type: architecture
+:status: unpublished
+:order: 00
+:summary: Banner Markings extractor.
+
+${branding} will extract banner markings and translate markings into a format that ${branding}
+can handle.
+
+[WARNING]
+====
+If other transformers or extractors have already assigned security markings to the
+security attributes that the Banner Markings Extractor extracted from the banner markings,
+and the pre-existim markings do not match those extracted from the banner markigns, then
+the ingest will be rejected due to prevent a data spill, since the correct markings
+cannot be determined.
+====
+

--- a/distribution/docs/src/main/jdocs/content/_banner-markings/banner-markings-intro-contents.adoc
+++ b/distribution/docs/src/main/jdocs/content/_banner-markings/banner-markings-intro-contents.adoc
@@ -1,0 +1,8 @@
+:title: Banner Markings
+:type: architectureIntro
+:status: unpublished
+:children: Banner Markings Extractor
+:order: 00
+:summary: Introduction to Banner Markings operations.
+
+${branding} performs operations that use the Banner Markings on a resource.

--- a/distribution/sdk/pom.xml
+++ b/distribution/sdk/pom.xml
@@ -35,6 +35,7 @@
         <module>sample-nsili-server</module>
         <module>sample-nsili-client</module>
         <module>sdk-app</module>
+        <module>sample-content-metadata-extractor</module>
     </modules>
     <build>
         <plugins>
@@ -44,6 +45,13 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/distribution/sdk/sample-content-metadata-extractor/pom.xml
+++ b/distribution/sdk/sample-content-metadata-extractor/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sdk</artifactId>
+        <groupId>org.codice.alliance.distribution</groupId>
+        <version>0.3.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.codice.alliance.sdk.extraction</groupId>
+    <artifactId>sample-content-metadata-extractor</artifactId>
+    <packaging>bundle</packaging>
+    <name>Alliance :: SDK :: Sample Content Metadata Extractor</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.codice.alliance.security</groupId>
+            <artifactId>banner-marking</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- The maven-bundle-plugin is required for this artifact to be an OSGi bundle. -->
+            <!-- Add in additional imports that this bundle requires using a comma-separated list. -->
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Export-Package/>
+                        <Embed-Dependency>
+                            catalog-core-api-impl,
+                            platform-util,
+                            banner-marking
+                        </Embed-Dependency>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/distribution/sdk/sample-content-metadata-extractor/src/main/java/org/codice/alliance/sdk/extraction/SampleContentMetadataExtractor.java
+++ b/distribution/sdk/sample-content-metadata-extractor/src/main/java/org/codice/alliance/sdk/extraction/SampleContentMetadataExtractor.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.alliance.sdk.extraction;
+
+import java.io.InputStream;
+
+import org.codice.alliance.catalog.core.api.types.Security;
+import org.codice.alliance.security.banner.marking.MarkingExtractor;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+
+public class SampleContentMetadataExtractor extends MarkingExtractor {
+
+    @Override
+    public void process(InputStream input, Metacard metacard) {
+        metacard.setAttribute(new AttributeImpl(Security.CLASSIFICATION, "S"));
+        metacard.setAttribute(new AttributeImpl(Security.OWNER_PRODUCER, "GBR"));
+    }
+
+}

--- a/distribution/sdk/sample-content-metadata-extractor/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/distribution/sdk/sample-content-metadata-extractor/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+    <bean id="sample.markingExtractor"
+          class="org.codice.alliance.sdk.extraction.SampleContentMetadataExtractor"/>
+
+    <service ref="sample.markingExtractor" ranking="10" interface="ddf.catalog.content.operation.ContentMetadataExtractor"/>
+</blueprint>

--- a/distribution/sdk/sdk-app/src/main/resources/features.xml
+++ b/distribution/sdk/sdk-app/src/main/resources/features.xml
@@ -38,4 +38,11 @@
         </bundle>
     </feature>
 
+    <feature name="sample-content-metadata-extractor" version="${project.version}" install="manual"
+             description="SDK sample content metadata extractor">
+        <bundle>
+            mvn:org.codice.alliance.sdk.extraction/sample-content-metadata-extractor/${project.version}
+        </bundle>
+    </feature>
+
 </features>

--- a/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/BannerMarkingsTest.java
+++ b/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/BannerMarkingsTest.java
@@ -28,7 +28,7 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.Optional;
 
-import org.codice.alliance.security.banner.marking.BannerCommonMarkingExtractor;
+import org.codice.alliance.catalog.core.api.types.Security;
 import org.codice.alliance.security.banner.marking.Dod520001MarkingExtractor;
 import org.codice.alliance.test.itests.common.AbstractAllianceIntegrationTest;
 import org.codice.ddf.itests.common.annotations.BeforeExam;
@@ -48,7 +48,7 @@ import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.InputTransformer;
 
 /**
- * Tests the {@link BannerCommonMarkingExtractor} and {@link Dod520001MarkingExtractor}
+ * Tests the {@link org.codice.alliance.security.banner.marking.BannerCommonMarkingExtractor} and {@link Dod520001MarkingExtractor}
  * content extractors.
  */
 @RunWith(PaxExam.class)
@@ -75,15 +75,13 @@ public class BannerMarkingsTest extends AbstractAllianceIntegrationTest {
     public void testUsMarkingSimpleText() throws Exception {
         Metacard metacard = getMetacard("secret_us.txt");
 
-        Attribute attribute = getAttribute(metacard,
-                BannerCommonMarkingExtractor.SECURITY_CLASSIFICATION);
+        Attribute attribute = getAttribute(metacard, Security.CLASSIFICATION);
         assertThat(attribute.getValue(), equalTo("S"));
 
-        attribute = getAttribute(metacard, BannerCommonMarkingExtractor.SECURITY_OWNER_PRODUCER);
+        attribute = getAttribute(metacard, Security.OWNER_PRODUCER);
         assertThat(attribute.getValue(), equalTo("USA"));
 
-        attribute = getAttribute(metacard,
-                BannerCommonMarkingExtractor.SECURITY_CLASSIFICATION_SYSTEM);
+        attribute = getAttribute(metacard, Security.CLASSIFICATION_SYSTEM);
         assertThat(attribute.getValue(), equalTo("USA"));
     }
 
@@ -91,15 +89,13 @@ public class BannerMarkingsTest extends AbstractAllianceIntegrationTest {
     public void testUsMarkingSimpleWordDoc() throws Exception {
         Metacard metacard = getMetacard("topsecret_us.docx");
 
-        Attribute attribute = getAttribute(metacard,
-                BannerCommonMarkingExtractor.SECURITY_CLASSIFICATION);
+        Attribute attribute = getAttribute(metacard, Security.CLASSIFICATION);
         assertThat(attribute.getValue(), equalTo("TS"));
 
-        attribute = getAttribute(metacard, BannerCommonMarkingExtractor.SECURITY_OWNER_PRODUCER);
+        attribute = getAttribute(metacard, Security.OWNER_PRODUCER);
         assertThat(attribute.getValue(), equalTo("USA"));
 
-        attribute = getAttribute(metacard,
-                BannerCommonMarkingExtractor.SECURITY_CLASSIFICATION_SYSTEM);
+        attribute = getAttribute(metacard, Security.CLASSIFICATION_SYSTEM);
         assertThat(attribute.getValue(), equalTo("USA"));
     }
 
@@ -107,15 +103,13 @@ public class BannerMarkingsTest extends AbstractAllianceIntegrationTest {
     public void testCosmicMarkingSimplePdf() throws Exception {
         Metacard metacard = getMetacard("topsecret_cosmic.pdf");
 
-        Attribute attribute = getAttribute(metacard,
-                BannerCommonMarkingExtractor.SECURITY_CLASSIFICATION);
+        Attribute attribute = getAttribute(metacard, Security.CLASSIFICATION);
         assertThat(attribute.getValue(), equalTo("CTS-B"));
 
-        attribute = getAttribute(metacard, BannerCommonMarkingExtractor.SECURITY_OWNER_PRODUCER);
+        attribute = getAttribute(metacard, Security.OWNER_PRODUCER);
         assertThat(attribute.getValue(), equalTo("NATO"));
 
-        attribute = getAttribute(metacard,
-                BannerCommonMarkingExtractor.SECURITY_CLASSIFICATION_SYSTEM);
+        attribute = getAttribute(metacard, Security.CLASSIFICATION_SYSTEM);
         assertThat(attribute.getValue(), equalTo("NATO"));
     }
 
@@ -123,20 +117,18 @@ public class BannerMarkingsTest extends AbstractAllianceIntegrationTest {
     public void testUsMarkingCodewordsAndDissem() throws Exception {
         Metacard metacard = getMetacard("us_codewords_dissem.txt");
 
-        Attribute attribute = getAttribute(metacard,
-                BannerCommonMarkingExtractor.SECURITY_CLASSIFICATION);
+        Attribute attribute = getAttribute(metacard, Security.CLASSIFICATION);
         assertThat(attribute.getValue(), equalTo("TS"));
 
-        attribute = getAttribute(metacard, BannerCommonMarkingExtractor.SECURITY_OWNER_PRODUCER);
+        attribute = getAttribute(metacard, Security.OWNER_PRODUCER);
         assertThat(attribute.getValue(), equalTo("USA"));
 
-        attribute = getAttribute(metacard, BannerCommonMarkingExtractor.SECURITY_CODEWORDS);
+        attribute = getAttribute(metacard, Security.CODEWORDS);
         List<Serializable> attributes = attribute.getValues();
         assertThat(attributes.size(), is(2));
         assertThat(attributes, containsInAnyOrder("TK-ABC X Y Z", "COMINT"));
 
-        attribute = getAttribute(metacard,
-                BannerCommonMarkingExtractor.SECURITY_DISSEMINATION_CONTROLS);
+        attribute = getAttribute(metacard, Security.DISSEMINATION_CONTROLS);
         attributes = attribute.getValues();
         assertThat(attributes.size(), is(1));
         assertThat(attributes, containsInAnyOrder("ORCON"));
@@ -152,9 +144,20 @@ public class BannerMarkingsTest extends AbstractAllianceIntegrationTest {
         // The invalid marking has the HCS-X SCI marking without NOFORN
         Metacard metacard = getMetacard("invalid.txt");
 
-        Attribute attribute =
-                metacard.getAttribute(BannerCommonMarkingExtractor.SECURITY_CLASSIFICATION);
+        Attribute attribute = metacard.getAttribute(Security.CLASSIFICATION);
         assertNull(attribute);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testBannerMarkingMismatch() throws Exception {
+        //start up the sample extractor
+        getServiceManager().startFeature(true, "sample-content-metadata-extractor");
+
+        try {
+            getMetacard("topsecret_cosmic.pdf");
+        } finally {
+            getServiceManager().stopFeature(true, "sample-content-metadata-extractor");
+        }
     }
 
     private Metacard getMetacard(String fileName)


### PR DESCRIPTION
#### What does this PR do?
Sets the Banner Markings extractor to throw a runtime exception and fail the ingest when security markings derived from the banner markings do not match those already present on a metacard (which would have been derived from other means). The reason for this is that if there is a mismatch in derived markings, it could be caused by an error when the document had markings updated and the true markings of the document cannot be determined. The ingest is rejected to avoid a data spill.

#### Who is reviewing it? 
@AzGoalie 
@ahoffer 
@mweser 
@jhunzik 

#### Choose 2 committers to review/merge the PR.
@coyotesqrl
@stustison
@bdeining 

#### How should this be tested?
Attempt to ingest a metacard that will have mismatch markings extracted from the metadata and the banner markings. The ingest should fail.

#### Any background context you want to provide?
#### What are the relevant tickets?
[CAL-331](https://codice.atlassian.net/browse/CAL-331)

#### Checklist:
- [x] Documentation Updated
- [X] Update / Add Unit Tests
- [x] Update / Add Integration Tests
