### PR TITLE
CAL-327 replaced 'localhost' in example URLs in docs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,8 +88,8 @@
         <cal-branding>Alliance</cal-branding>
         <admin-console>Admin Console</admin-console>
         <command-console>Command Console</command-console>
-        <public_url>http://localhost:8181</public_url>
-        <secure_url>https://localhost:8993</secure_url>
+        <public_url>\http://{FQDN}:{PORT}</public_url>
+        <secure_url>\https://{FQDN}:{PORT}</secure_url>
         <!--Needed for documentation formatting-->
         <at-symbol>@</at-symbol>
         <variable-prefix>${</variable-prefix>


### PR DESCRIPTION
#### What does this PR do?

- Replaces references to `localhost` in documentation example URLs to `{FQDN}:{PORT}` to reflect likely system changes made at install. 
- disabled these example links so they will not link to unresolvable URLs.

#### Who is reviewing it? 

@mcalcote @vinamartin @emmberk @Lambeaux @jrnorth @ahoffer 

#### Choose 2 committers to review/merge the PR. 

@clockard
@coyotesqrl
@lessarderic
@pklinef
@ricklarsen - Documentation
@shaundmorris
@stustison

#### How should this be tested? (List steps with links to updated documentation)

- builds successfully
- references to `localhost:8993` or `localhost:8991` replaced with new values of maven property.

#### What are the relevant tickets?
[DDF-3227](https://codice.atlassian.net/browse/DDF-3227)
[CAL-327](https://codice.atlassian.net/browse/DDF-327)

#### Screenshots (if appropriate)

[documentation.pdf](https://github.com/codice/alliance/files/1278685/documentation.pdf)

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.

