### PR TITLE
CAL-345 Update pom and feature files to reflect new third-party module maven coordinates

### DIFF
--- a/distribution/test/itests/test-itests-alliance/pom.xml
+++ b/distribution/test/itests/test-itests-alliance/pom.xml
@@ -78,13 +78,13 @@
 
         <!--start ddf dependencies-->
         <dependency>
-            <groupId>ddf.test.thirdparty</groupId>
+            <groupId>ddf.thirdparty</groupId>
             <artifactId>rest-assured</artifactId>
             <version>${ddf.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>ddf.test.thirdparty</groupId>
+            <groupId>ddf.thirdparty</groupId>
             <artifactId>restito</artifactId>
             <version>${ddf.version}</version>
             <scope>test</scope>

--- a/distribution/test/itests/test-itests-dependencies-app/pom.xml
+++ b/distribution/test/itests/test-itests-dependencies-app/pom.xml
@@ -59,12 +59,12 @@
             <version>${ddf.version}</version>
         </dependency>
         <dependency>
-            <groupId>ddf.test.thirdparty</groupId>
+            <groupId>ddf.thirdparty</groupId>
             <artifactId>rest-assured</artifactId>
             <version>${ddf.version}</version>
         </dependency>
         <dependency>
-            <groupId>ddf.test.thirdparty</groupId>
+            <groupId>ddf.thirdparty</groupId>
             <artifactId>restito</artifactId>
             <version>${ddf.version}</version>
         </dependency>

--- a/distribution/test/itests/test-itests-dependencies-app/src/main/filtered-resources/features.xml
+++ b/distribution/test/itests/test-itests-dependencies-app/src/main/filtered-resources/features.xml
@@ -36,12 +36,12 @@
 
         <bundle>mvn:org.apache.httpcomponents/httpcore-osgi/${httpcore.version}</bundle>
         <bundle>mvn:org.apache.httpcomponents/httpclient-osgi/${httpclient.version}</bundle>
-        <bundle>mvn:ddf.test.thirdparty/rest-assured/${ddf.version}</bundle>
+        <bundle>mvn:ddf.thirdparty/rest-assured/${ddf.version}</bundle>
 
         <bundle>wrap:mvn:ddf.security/ddf-security-common/${ddf.version}$Bundle-SymbolicName=itest-test-security-common</bundle>
         <bundle>mvn:ddf.test.itests/test-itests-common/${ddf.version}</bundle>
 
-        <bundle>mvn:ddf.test.thirdparty/restito/${ddf.version}</bundle>
+        <bundle>mvn:ddf.thirdparty/restito/${ddf.version}</bundle>
 
         <bundle>wrap:mvn:ddf.platform.util/platform-util/${ddf.version}</bundle>
 


### PR DESCRIPTION
#### What does this PR do?
Updates the maven coordinates of DDF versions of Restito and RestAssured as a follow on to https://github.com/codice/ddf/pull/2349.

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)
@tbatie 
@brendan-hofmann 
@AzGoalie 

#### Choose 2 committers to review/merge the PR.
(please choose ONLY two committers from below, delete the rest)
@coyotesqrl
@rzwiefel 

#### How should this be tested?
#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-345](https://codice.atlassian.net/browse/CAL-345)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [X] Update / Add Integration Tests
