### PR TITLE
Added a dependency on jaxb-xjc 2.2

### DIFF
--- a/distribution/alliance/pom.xml
+++ b/distribution/alliance/pom.xml
@@ -94,6 +94,11 @@
             <classifier>features</classifier>
             <type>xml</type>
         </dependency>
+		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-xjc</artifactId>
+			<version>2.2</version>
+		</dependency>		
         <dependency>
             <groupId>ddf.ui</groupId>
             <artifactId>search-ui-app</artifactId>


### PR DESCRIPTION
#### What does this PR do?
The alliance distro has a dependency on spatial-app 2.11.0-SNAPSHOT
...which depends on spatial-kml-transformer 2.11.0-SNAPSHOT
...which depends on JavaAPIForKML 2.2.0
...which depends on jaxb-xjc 2.2-SNAPSHOT

jaxb-xjc 2.2-SNAPSHOT is not hosted publicly on any common mvn repos, which makes building alliance impossible.

Adding a dependency on jaxb-xjc 2.2 (not the snapshot) fixes this and allows the build to complete.


#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)
@brendan-hofmann @clockard @jlcsmith 

#### Choose 2 committers to review/merge the PR.
(please choose ONLY two committers from below, delete the rest)

@bdeining 
@lessarderic 

#### How should this be tested?
#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-xxx](https://codice.atlassian.net/browse/CAL-xxx)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
