### PR TITLE
CAL-308 Updated NSILI mapping of subjectCategoryCode in both directions

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/org/codice/alliance/catalog/core/api/impl/types/IsrAttributes.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/org/codice/alliance/catalog/core/api/impl/types/IsrAttributes.java
@@ -131,7 +131,7 @@ public class IsrAttributes implements Isr, MetacardType {
             true /* indexed */,
             true /* stored */,
             true /* tokenized */,
-            false /* multivalued */,
+            true /* multivalued */,
             BasicTypes.STRING_TYPE));
     DESCRIPTORS.add(
         new AttributeDescriptorImpl(

--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/ResultDAGConverter.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/ResultDAGConverter.java
@@ -1790,9 +1790,9 @@ public class ResultDAGConverter {
         attribute,
         NsiliConstants.TARGET_NUMBER);
 
-    addStrAttribute(
+    addValStrAttribute(
         graph,
-        metacard.getAttribute(Isr.TARGET_CATEGORY_CODE),
+        metacard.getAttribute(Isr.NATO_REPORTING_CODE),
         orb,
         resultAttributes,
         addedAttributes,

--- a/catalog/nsili/catalog-nsili-common/src/test/java/org/codice/alliance/nsili/common/ResultDAGConverterTest.java
+++ b/catalog/nsili/catalog-nsili-common/src/test/java/org/codice/alliance/nsili/common/ResultDAGConverterTest.java
@@ -23,6 +23,7 @@ import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.ResultImpl;
 import ddf.catalog.data.types.Core;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -51,6 +52,9 @@ public class ResultDAGConverterTest {
 
   private static final Date TEST_CREATE_DATE = new Date(1000);
 
+  private static final String[] SAMPLE_CODES = {"01", "02"};
+  private static final List<Serializable> REPORTING_CODE_LIST = Arrays.asList(SAMPLE_CODES);
+
   private ORB orb;
 
   private POA rootPOA;
@@ -76,10 +80,21 @@ public class ResultDAGConverterTest {
             + NsiliConstants.NSIL_CARD
             + "."
             + NsiliConstants.SOURCE_LIBRARY;
+    String subjCategoryAttr =
+        NsiliConstants.NSIL_PRODUCT
+            + ":"
+            + NsiliConstants.NSIL_PART
+            + ":"
+            + NsiliConstants.NSIL_COMMON
+            + "."
+            + NsiliConstants.SUBJECT_CATEGORY_TARGET;
 
     DAG dag =
         ResultDAGConverter.convertResult(result, orb, rootPOA, new ArrayList<>(), new HashMap<>());
     assertThat(checkDagContains(dag, sourceAttr), is(true));
+    assertThat(checkDagContains(dag, subjCategoryAttr), is(true));
+    String subjCategoryValue = ResultDAGConverter.getAttributeMap(dag).get(subjCategoryAttr);
+    assertThat(subjCategoryValue, is(String.join(", ", SAMPLE_CODES)));
 
     List<String> singleAttrList = new ArrayList<>();
     singleAttrList.add(
@@ -305,6 +320,7 @@ public class ResultDAGConverterTest {
     metacard.setAttribute(new AttributeImpl(Isr.CLOUD_COVER, 1.0));
     metacard.setAttribute(
         new AttributeImpl(Isr.NATIONAL_IMAGERY_INTERPRETABILITY_RATING_SCALE, 1.0));
+    metacard.setAttribute(new AttributeImpl(Isr.NATO_REPORTING_CODE, REPORTING_CODE_LIST));
 
     return metacard;
   }

--- a/catalog/nsili/catalog-nsili-transformer/src/main/java/org/codice/alliance/nsili/transformer/DAGConverter.java
+++ b/catalog/nsili/catalog-nsili-transformer/src/main/java/org/codice/alliance/nsili/transformer/DAGConverter.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.lang.StringUtils;
 import org.codice.alliance.catalog.core.api.impl.types.IsrAttributes;
 import org.codice.alliance.catalog.core.api.types.Isr;
@@ -312,8 +313,12 @@ public class DAGConverter {
             new AttributeImpl(IsrAttributes.PLATFORM_NAME, getString(node.value)));
         break;
       case NsiliConstants.SUBJECT_CATEGORY_TARGET:
-        metacard.setAttribute(
-            new AttributeImpl(IsrAttributes.TARGET_CATEGORY_CODE, getString(node.value)));
+        String categoryCodes = getString(node.value);
+        if (categoryCodes != null) {
+          List<Serializable> codes =
+              Stream.of(categoryCodes.split(",")).map(String::trim).collect(Collectors.toList());
+          metacard.setAttribute(new AttributeImpl(IsrAttributes.NATO_REPORTING_CODE, codes));
+        }
         break;
       case NsiliConstants.TARGET_NUMBER:
         metacard.setAttribute(new AttributeImpl(IsrAttributes.TARGET_ID, getString(node.value)));

--- a/catalog/nsili/catalog-nsili-transformer/src/test/java/org/codice/alliance/nsili/transformer/DAGConverterTest.java
+++ b/catalog/nsili/catalog-nsili-transformer/src/test/java/org/codice/alliance/nsili/transformer/DAGConverterTest.java
@@ -133,7 +133,11 @@ public class DAGConverterTest {
 
   private static final String COM_SOURCE = "TestSourceSystem";
 
-  private static final String COM_SUBJECT_CATEGORY_TARGET = "Airfields";
+  private static final String TGT1 = "01";
+
+  private static final String TGT2 = "02";
+
+  private static final String COM_SUBJECT_CATEGORY_TARGET = TGT1 + ", " + TGT2;
 
   private static final String COM_TARGET_NUMBER = "123-456-7890";
 
@@ -461,9 +465,12 @@ public class DAGConverterTest {
     assertThat(stanagSourceAttr, notNullValue());
     assertThat(stanagSourceAttr.getValue().toString(), is(COM_SOURCE));
 
-    Attribute subjCatTgtAttr = metacard.getAttribute(Isr.TARGET_CATEGORY_CODE);
+    Attribute subjCatTgtAttr = metacard.getAttribute(Isr.NATO_REPORTING_CODE);
     assertThat(subjCatTgtAttr, notNullValue());
-    assertThat(subjCatTgtAttr.getValue().toString(), is(COM_SUBJECT_CATEGORY_TARGET));
+    List<Serializable> reportingCodes = subjCatTgtAttr.getValues();
+    assertThat(reportingCodes.size(), is(2));
+    assertThat(reportingCodes, hasItem(TGT1));
+    assertThat(reportingCodes, hasItem(TGT2));
 
     Attribute tgtNumAttr = metacard.getAttribute(Isr.TARGET_ID);
     assertThat(tgtNumAttr, notNullValue());


### PR DESCRIPTION
#### What does this PR do?
Changes the NSIL Transformer to map COMMON.subjectCategoryCode to the isr.nato-reporting-code. The old CAL-308 PR was closed and this one replaces it. Updated with the code formatting and review comments addressed from the previous PR.

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)
@dcruver 
@troymohl
@ricklarsen 

#### Choose 2 committers to review/merge the PR.
(please choose ONLY two committers from below, delete the rest)

@bdeining
@jlcsmith

#### How should this be tested?
Verify that the value(s) from subjectCategoryCode are set in isr.nato-reporting-code
(don't have test case available, verify the unit test and expected results and that it passes)

#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-308](https://codice.atlassian.net/browse/CAL-308)

#### Screenshots (if appropriate)
#### Checklist:
- [X] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
