### PR TITLE
CAL-349 Modified bin.xml & its pom to include new DDF startup dependency

### DIFF
--- a/distribution/alliance/pom.xml
+++ b/distribution/alliance/pom.xml
@@ -173,6 +173,12 @@
             <type>jar</type>
         </dependency>
         <dependency>
+            <groupId>ddf.platform.osgi</groupId>
+            <artifactId>platform-osgi-configadmin</artifactId>
+            <version>${ddf.version}</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
             <groupId>org.codice.alliance.distribution</groupId>
             <artifactId>console-branding</artifactId>
             <version>${project.version}</version>

--- a/distribution/alliance/src/main/descriptors/bin.xml
+++ b/distribution/alliance/src/main/descriptors/bin.xml
@@ -23,4 +23,16 @@
         <componentDescriptor>target/dependencies/common-bin.xml</componentDescriptor>
     </componentDescriptors>
 
+    <!-- We need this because the feature service is not up when we want to provision our
+own config admin -->
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>system/ddf/platform/osgi/platform-osgi-configadmin/${ddf.version}
+            </outputDirectory>
+            <includes>
+                <include>ddf.platform.osgi:platform-osgi-configadmin</include>
+            </includes>
+        </dependencySet>
+    </dependencySets>
+
 </assembly>

--- a/distribution/alliance/src/main/descriptors/bin.xml
+++ b/distribution/alliance/src/main/descriptors/bin.xml
@@ -29,8 +29,10 @@ own config admin -->
         <dependencySet>
             <outputDirectory>system/ddf/platform/osgi/platform-osgi-configadmin/${ddf.version}
             </outputDirectory>
+            <outputFileNameMapping>${artifact.artifactId}-${ddf.version}.${artifact.extension}
+            </outputFileNameMapping>
             <includes>
-                <include>ddf.platform.osgi:platform-osgi-configadmin</include>
+                <include>ddf.platform.osgi:platform-osgi-configadmin:jar:${ddf.version}</include>
             </includes>
         </dependencySet>
     </dependencySets>


### PR DESCRIPTION
#### What does this PR do?
Packages a newly required dependency with the Alliance distribution stemming from codice/ddf#2260 whose absence prevents Karaf from starting up

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)
@Lambeaux @brjeter @emmberk @adimka 

#### Choose 2 committers to review/merge the PR.
(please choose ONLY two committers from below, delete the rest)
@bdeining
@coyotesqrl

#### How should this be tested?
Full CI build

#### Any background context you want to provide?
Without this fix, Alliance/Karaf fails to startup with the following sequence
```
karaf: Enabling Java debug options: -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
Listening for transport dt_socket at address: 5005
System starting up. Press Enter to open the shell during startup...
Error installing bundle listed in startup.properties with url: mvn:ddf.platform.osgi/platform-osgi-configadmin/2.11.0-SNAPSHOT and startlevel: 10
```
and then the process dies

#### What are the relevant tickets?
[CAL-349](https://codice.atlassian.net/browse/CAL-349)

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
