### PR TITLE
CAL-353 [0.3.x] Handles non UTF-8 country codes

### DIFF
--- a/libs/klv/src/main/java/org/codice/alliance/libs/klv/KlvHandlerFactoryImpl.java
+++ b/libs/klv/src/main/java/org/codice/alliance/libs/klv/KlvHandlerFactoryImpl.java
@@ -117,8 +117,7 @@ public class KlvHandlerFactoryImpl implements KlvHandlerFactory {
 
     handlers.put(
         Stanag4609TransportStreamParser.OBJECT_COUNTRY_CODES,
-        new ListOfBasicKlvDataTypesHandler<>(
-            AttributeNameConstants.OBJECT_COUNTRY_CODES, KlvString.class));
+        new ObjectCountryCodesHandler(AttributeNameConstants.OBJECT_COUNTRY_CODES));
 
     handlers.put(
         Stanag4609TransportStreamParser.TIMESTAMP,

--- a/libs/klv/src/main/java/org/codice/alliance/libs/klv/ObjectCountryCodesHandler.java
+++ b/libs/klv/src/main/java/org/codice/alliance/libs/klv/ObjectCountryCodesHandler.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.libs.klv;
+
+import ddf.catalog.data.Attribute;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Optional;
+import org.apache.tika.parser.txt.CharsetDetector;
+import org.apache.tika.parser.txt.CharsetMatch;
+import org.codice.ddf.libs.klv.KlvDataElement;
+import org.codice.ddf.libs.klv.data.raw.KlvBytes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This handler expects a KlvBytes object which should hold the country code value. It detects the
+ * country code charset encoding and generates the string using the proper encoding.
+ */
+public class ObjectCountryCodesHandler extends BaseKlvHandler {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ObjectCountryCodesHandler.class);
+
+  private String countryCode = "";
+
+  public ObjectCountryCodesHandler(String attributeName) {
+    super(attributeName);
+  }
+
+  @Override
+  public Optional<Attribute> asAttribute() {
+    return asAttribute(Collections.singletonList(countryCode));
+  }
+
+  @Override
+  public void accept(KlvDataElement klvDataElement) {
+    if (!(klvDataElement instanceof KlvBytes)) {
+      LOGGER.debug(
+          "non-KlvString data was passed to the ObjectCountryCodesHandler: name = {} klvDataElement = {}",
+          klvDataElement.getName(),
+          klvDataElement);
+      return;
+    }
+
+    String elementValue;
+    byte[] bytes = ((KlvBytes) klvDataElement).getValue();
+
+    CharsetDetector charsetDetector = new CharsetDetector();
+    charsetDetector.setText(bytes);
+    try {
+      CharsetMatch charsetMatch = charsetDetector.detect();
+      elementValue = new String(bytes, charsetMatch.getName());
+    } catch (IOException e) {
+      LOGGER.trace(
+          "Unable to detect encoding for Object Country Codes, Country Code value may be malformed");
+      elementValue = new String(bytes);
+    }
+
+    countryCode = elementValue;
+  }
+
+  @Override
+  public void reset() {
+    countryCode = "";
+  }
+}

--- a/libs/klv/src/test/java/org/codice/alliance/libs/klv/KlvUtilities.java
+++ b/libs/klv/src/test/java/org/codice/alliance/libs/klv/KlvUtilities.java
@@ -34,6 +34,7 @@ import org.codice.ddf.libs.klv.KlvDecodingException;
 import org.codice.ddf.libs.klv.data.Klv;
 import org.codice.ddf.libs.klv.data.numerical.KlvInt;
 import org.codice.ddf.libs.klv.data.numerical.KlvIntegerEncodedFloatingPoint;
+import org.codice.ddf.libs.klv.data.raw.KlvBytes;
 import org.mockito.ArgumentCaptor;
 
 class KlvUtilities {
@@ -46,7 +47,7 @@ class KlvUtilities {
    * @return an argument captor of the attribute created by the processor
    */
   public static ArgumentCaptor<Attribute> testKlvProcessor(
-      KlvProcessor klvProcessor, String stangField, List<Serializable> input) {
+      KlvProcessor klvProcessor, String stanagField, List<Serializable> input) {
 
     Attribute attribute = mock(Attribute.class);
 
@@ -68,7 +69,8 @@ class KlvUtilities {
 
     KlvProcessor.Configuration configuration = new KlvProcessor.Configuration();
 
-    klvProcessor.process(Collections.singletonMap(stangField, klvHandler), metacard, configuration);
+    klvProcessor.process(
+        Collections.singletonMap(stanagField, klvHandler), metacard, configuration);
 
     ArgumentCaptor<Attribute> argumentCaptor = ArgumentCaptor.forClass(Attribute.class);
 
@@ -124,6 +126,27 @@ class KlvUtilities {
             klvBytes);
 
     return (KlvIntegerEncodedFloatingPoint) decodedKlvContext.getDataElementByName(name);
+  }
+
+  /**
+   * Generates a KlvBytes object from a name and byte array
+   *
+   * @param name name of the klv data element
+   * @param bytes value of the klv data element
+   * @return klv data element
+   * @throws KlvDecodingException
+   */
+  public static KlvBytes createTestBytes(String name, byte[] bytes) throws KlvDecodingException {
+    final byte[] byteArray = new byte[bytes.length + 2];
+    byteArray[0] = -8;
+    byteArray[1] = (byte) bytes.length;
+    System.arraycopy(bytes, 0, byteArray, 2, bytes.length);
+
+    final KlvBytes klvBytes = new KlvBytes(new byte[] {-8}, name);
+    final KlvContext decodedKlvContext =
+        decodeKLV(Klv.KeyLength.OneByte, Klv.LengthEncoding.OneByte, klvBytes, byteArray);
+
+    return (KlvBytes) decodedKlvContext.getDataElementByName(name);
   }
 
   private static KlvContext decodeKLV(

--- a/libs/klv/src/test/java/org/codice/alliance/libs/klv/ObjectCountryCodesHandlerTest.java
+++ b/libs/klv/src/test/java/org/codice/alliance/libs/klv/ObjectCountryCodesHandlerTest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.libs.klv;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.UnsupportedEncodingException;
+import org.codice.ddf.libs.klv.KlvDecodingException;
+import org.codice.ddf.libs.klv.data.raw.KlvBytes;
+import org.junit.Test;
+
+public class ObjectCountryCodesHandlerTest {
+
+  private String name = "testCountryCode";
+
+  private String testString = "AUS";
+
+  @Test
+  public void testUTF8CountryCodeRemainsUTF8()
+      throws UnsupportedEncodingException, KlvDecodingException {
+    KlvBytes countryCodeElement = KlvUtilities.createTestBytes(name, testString.getBytes("UTF-8"));
+
+    ObjectCountryCodesHandler objectCountryCodesHandler =
+        new ObjectCountryCodesHandler("objectCountryCode");
+    objectCountryCodesHandler.accept(countryCodeElement);
+    assertThat(objectCountryCodesHandler.asAttribute().get().getValue(), is(testString));
+  }
+
+  @Test
+  public void testUTF16CountryCodeIsHandled()
+      throws UnsupportedEncodingException, KlvDecodingException {
+    KlvBytes countryCodeElement =
+        KlvUtilities.createTestBytes(name, testString.getBytes("UTF-16BE"));
+
+    ObjectCountryCodesHandler objectCountryCodesHandler =
+        new ObjectCountryCodesHandler("objectCountryCode");
+    objectCountryCodesHandler.accept(countryCodeElement);
+    assertThat(objectCountryCodesHandler.asAttribute().get().getValue(), is(testString));
+  }
+}

--- a/libs/stanag4609/src/main/java/org/codice/alliance/libs/stanag4609/Stanag4609TransportStreamParser.java
+++ b/libs/stanag4609/src/main/java/org/codice/alliance/libs/stanag4609/Stanag4609TransportStreamParser.java
@@ -32,6 +32,7 @@ import org.codice.ddf.libs.klv.data.numerical.KlvLong;
 import org.codice.ddf.libs.klv.data.numerical.KlvShort;
 import org.codice.ddf.libs.klv.data.numerical.KlvUnsignedByte;
 import org.codice.ddf.libs.klv.data.numerical.KlvUnsignedShort;
+import org.codice.ddf.libs.klv.data.raw.KlvBytes;
 import org.codice.ddf.libs.klv.data.set.KlvLocalSet;
 import org.codice.ddf.libs.klv.data.text.KlvString;
 import org.codice.ddf.libs.mpeg.transport.MpegTransportStreamMetadataExtractor;
@@ -385,7 +386,7 @@ public class Stanag4609TransportStreamParser {
 
     securityLocalSetContext.addDataElement(
         new KlvUnsignedByte(new byte[] {12}, OBJECT_COUNTRY_CODING_METHOD));
-    securityLocalSetContext.addDataElement(new KlvString(new byte[] {13}, OBJECT_COUNTRY_CODES));
+    securityLocalSetContext.addDataElement(new KlvBytes(new byte[] {13}, OBJECT_COUNTRY_CODES));
 
     localSetContext.addDataElement(
         new KlvLocalSet(new byte[] {48}, SECURITY_LOCAL_METADATA_SET, securityLocalSetContext));


### PR DESCRIPTION
#### What does this PR do?
Creates a handler to handle non-UTF-8 country code values. 

#### Who is reviewing it? 
@brendan-hofmann @glenhein 
@ahoffer @mcalcote @garrettfreibott 

#### Choose 2 committers to review/merge the PR.
@rzwiefel 
@lessarderic

#### What are the relevant tickets?
[CAL-353](https://codice.atlassian.net/browse/CAL-353)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
