### PR TITLE
(0.3.x) CAL-351 Separated static analysis into two steps, formatted jenkinsfile, added Codecov check

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,36 +50,36 @@ pipeline {
             // TODO CAL-296 refactor this stage from scripted syntax to declarative syntax to match the rest of the stages - https://issues.jenkins-ci.org/browse/JENKINS-41334
             steps {
                 parallel(
-                        linux: {
-                            node('linux-large') {
-                                retry(3) {
-                                    checkout scm
-                                }
-                                timeout(time: 1, unit: 'HOURS') {
-                                    // TODO: Maven downgraded to work around a linux build issue. Falling back to system java to work around a linux build issue. re-investigate upgrading later
-                                    withMaven(maven: 'Maven 3.3.9', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}', options: [artifactsPublisher(disabled: true), dependenciesFingerprintPublisher(disabled: true, includeScopeCompile: false, includeScopeProvided: false, includeScopeRuntime: false, includeSnapshotVersions: false)]) {
-                                        sh 'mvn install -pl !$DOCS -DskipStatic=true -DskipTests=true -T 1C'
-                                        sh 'mvn clean install -B -T 1C -pl !$ITESTS -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/$CHANGE_TARGET'
-                                        sh 'mvn install -B -pl $ITESTS -nsu'
-                                    }
-                                }
+                    linux: {
+                        node('linux-large') {
+                            retry(3) {
+                                checkout scm
                             }
-                        },
-                        windows: {
-                            node('proxmox-windows') {
-                                bat 'git config --system core.longpaths true'
-                                retry(3) {
-                                    checkout scm
-                                }
-                                timeout(time: 1, unit: 'HOURS') {
-                                    withMaven(maven: 'M35', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS}', options: [artifactsPublisher(disabled: true), dependenciesFingerprintPublisher(disabled: true, includeScopeCompile: false, includeScopeProvided: false, includeScopeRuntime: false, includeSnapshotVersions: false)]) {
-                                        bat 'mvn install -pl !%DOCS% -DskipStatic=true -DskipTests=true -T 1C'
-                                        bat 'mvn clean install -B -T 1C -pl !%ITESTS% -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/%CHANGE_TARGET%'
-                                        bat 'mvn install -B -pl %ITESTS% -nsu'
-                                    }
+                            timeout(time: 1, unit: 'HOURS') {
+                                // TODO: Maven downgraded to work around a linux build issue. Falling back to system java to work around a linux build issue. re-investigate upgrading later
+                                withMaven(maven: 'Maven 3.3.9', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}', options: [artifactsPublisher(disabled: true), dependenciesFingerprintPublisher(disabled: true, includeScopeCompile: false, includeScopeProvided: false, includeScopeRuntime: false, includeSnapshotVersions: false)]) {
+                                    sh 'mvn install -pl !$DOCS -DskipStatic=true -DskipTests=true -T 1C'
+                                    sh 'mvn clean install -B -T 1C -pl !$ITESTS -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/$CHANGE_TARGET'
+                                    sh 'mvn install -B -pl $ITESTS -nsu'
                                 }
                             }
                         }
+                    },
+                    windows: {
+                        node('proxmox-windows') {
+                            bat 'git config --system core.longpaths true'
+                            retry(3) {
+                                checkout scm
+                            }
+                            timeout(time: 1, unit: 'HOURS') {
+                                withMaven(maven: 'M35', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS}', options: [artifactsPublisher(disabled: true), dependenciesFingerprintPublisher(disabled: true, includeScopeCompile: false, includeScopeProvided: false, includeScopeRuntime: false, includeSnapshotVersions: false)]) {
+                                    bat 'mvn install -pl !%DOCS% -DskipStatic=true -DskipTests=true -T 1C'
+                                    bat 'mvn clean install -B -T 1C -pl !%ITESTS% -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/%CHANGE_TARGET%'
+                                    bat 'mvn install -B -pl %ITESTS% -nsu'
+                                }
+                            }
+                        }
+                    }
                 )
             }
         }
@@ -89,120 +89,75 @@ pipeline {
             // TODO CAL-296 refactor this stage from scripted syntax to declarative syntax to match the rest of the stages - https://issues.jenkins-ci.org/browse/JENKINS-41334
             steps{
                 parallel(
-                        linux: {
-                            node('linux-large') {
-                                retry(3) {
-                                    checkout scm
-                                }
-                                timeout(time: 1, unit: 'HOURS') {
-                                    // TODO: Maven downgraded to work around a linux build issue. Falling back to system java to work around a linux build issue. re-investigate upgrading later
-                                    withMaven(maven: 'Maven 3.3.9', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}') {
-                                        sh 'mvn clean install -B -T 1C -pl !$ITESTS'
-                                        sh 'mvn install -B -pl $ITESTS -nsu'
-                                    }
-                                }
+                    linux: {
+                        node('linux-large') {
+                            retry(3) {
+                                checkout scm
                             }
-                        },
-                        windows: {
-                            node('proxmox-windows') {
-                                bat 'git config --system core.longpaths true'
-                                retry(3) {
-                                    checkout scm
-                                }
-                                timeout(time: 1, unit: 'HOURS') {
-                                    withMaven(maven: 'M35', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS}') {
-                                        bat 'mvn clean install -B -T 1C -pl !%ITESTS%'
-                                        bat 'mvn install -B -pl %ITESTS% -nsu'
-                                    }
+                            timeout(time: 1, unit: 'HOURS') {
+                                // TODO: Maven downgraded to work around a linux build issue. Falling back to system java to work around a linux build issue. re-investigate upgrading later
+                                withMaven(maven: 'Maven 3.3.9', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}') {
+                                    sh 'mvn clean install -B -T 1C -pl !$ITESTS'
+                                    sh 'mvn install -B -pl $ITESTS -nsu'
                                 }
                             }
                         }
+                    },
+                    windows: {
+                        node('proxmox-windows') {
+                            bat 'git config --system core.longpaths true'
+                            retry(3) {
+                                checkout scm
+                            }
+                            timeout(time: 1, unit: 'HOURS') {
+                                withMaven(maven: 'M35', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS}') {
+                                    bat 'mvn clean install -B -T 1C -pl !%ITESTS%'
+                                    bat 'mvn install -B -pl %ITESTS% -nsu'
+                                }
+                            }
+                        }
+                    }
                 )
             }
         }
-        stage('Static Analysis') {
+        stage('Security Analysis') {
             steps {
                 parallel(
-                        owasp: {
-                            node('linux-large') {
-                                retry(3) {
-                                    checkout scm
-                                }
-                                withMaven(maven: 'M35', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}') {
-                                    script {
-                                        // If this build is not a pull request, run full owasp scan. Otherwise run incremntal scan
-                                        if (env.CHANGE_ID == null) {
-                                            sh 'mvn install -q -B -Powasp -DskipTests=true -DskipStatic=true -pl !$DOCS'
-                                        } else {
-                                            sh 'mvn install -q -B -Powasp -DskipTests=true -DskipStatic=true -pl !$DOCS -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/$CHANGE_TARGET'
-                                        }
-                                    }
-                                }
+                    owasp: {
+                        node('linux-large') {
+                            retry(3) {
+                                checkout scm
                             }
-                        },
-                        sonarqube: {
-                            node('linux-large') {
-                                retry(3) {
-                            checkout scm
-                                }
-                                withMaven(maven: 'M35', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}') {
-                                    withCredentials([string(credentialsId: 'SonarQubeGithubToken', variable: 'SONARQUBE_GITHUB_TOKEN'), string(credentialsId: 'sonarqube-token', variable: 'SONAR_TOKEN')]) {
-                                        script {
-                                            // If this build is not a pull request, run sonar scan. otherwise run incremental scan
-                                            if (env.CHANGE_ID == null) {
-                                                sh 'mvn -q -B -Dfindbugs.skip=true -Dcheckstyle.skip=true org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.host.url=https://sonarqube.com -Dsonar.login=$SONAR_TOKEN  -Dsonar.organization=codice -Dsonar.projectKey=org.codice.alliance -pl !$DOCS,!$ITESTS'
-                                            } else {
-                                                echo "Currently Sonar is not run for pull requests"
-                                                // sh 'mvn -q -B -Dfindbugs.skip=true -Dcheckstyle.skip=true org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.github.pullRequest=${CHANGE_ID} -Dsonar.github.oauth=${SONARQUBE_GITHUB_TOKEN} -Dsonar.analysis.mode=preview -Dsonar.host.url=https://sonarqube.com -Dsonar.login=$SONAR_TOKEN  -Dsonar.organization=codice -Dsonar.projectKey=org.codice.alliance -pl !$DOCS,!$ITESTS -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/$CHANGE_TARGET'
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        // Coverity will be skipped on all PR builds
-                        coverity: {
-                            node('linux-medium') {
+                            withMaven(maven: 'M35', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}') {
                                 script {
-                                    if (env.BRANCH_NAME != 'master') {
-                                        echo "Coverity is only run on master"
+                                    // If this build is not a pull request, run full owasp scan. Otherwise run incremntal scan
+                                    if (env.CHANGE_ID == null) {
+                                        sh 'mvn install -q -B -Powasp -DskipTests=true -DskipStatic=true -pl !$DOCS'
                                     } else {
-                                        retry(3) {
-                                            checkout scm
-                                        }
-                                        withMaven(maven: 'M35', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LINUX_MVN_RANDOM}') {
-                                            withCredentials([string(credentialsId: 'alliance-coverity-token', variable: 'COVERITY_TOKEN')]) {
-                                                withEnv(["PATH=${tool 'coverity-linux'}/bin:${env.PATH}"]) {
-                                                    configFileProvider([configFile(fileId: 'coverity-maven-settings', replaceTokens: true, variable: 'MAVEN_SETTINGS')]) {
-                                                        sh 'cov-build --dir cov-int mvn -DskipTests=true -DskipStatic=true install -pl !$DOCS --settings $MAVEN_SETTINGS'
-                                                        sh 'tar czvf alliance.tgz cov-int'
-                                                        sh 'curl --form token=$COVERITY_TOKEN --form email=cmp-security-team@connexta.com --form file=@alliance.tgz --form version="master" --form description="Description: Alliance CI Build" https://scan.coverity.com/builds?project=codice%2Falliance'
-                                                    }
-                                                }
-                                            }
-                                        }
+                                        sh 'mvn install -q -B -Powasp -DskipTests=true -DskipStatic=true -pl !$DOCS -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/$CHANGE_TARGET'
                                     }
                                 }
                             }
-                        },
-                        nodeJsSecurity: {
-                            node('linux-small') {
-                                retry(3) {
-                                    checkout scm
-                                }
-                                script {
-                                    def packageFiles = findFiles(glob: '**/package.json')
-                                    for (int i = 0; i < packageFiles.size(); i++) {
-                                        dir(packageFiles[i].path.split('package.json')[0]) {
-                                            echo "Scanning ${packageFiles[i].name}"
-                                            nodejs(configId: 'npmrc-default', nodeJSInstallationName: 'nodejs') {
-                                                sh 'nsp check'
-                                            }
+                        }
+                    },
+                    nodeJsSecurity: {
+                        node('linux-small') {
+                            retry(3) {
+                                checkout scm
+                            }
+                            script {
+                                def packageFiles = findFiles(glob: '**/package.json')
+                                for (int i = 0; i < packageFiles.size(); i++) {
+                                    dir(packageFiles[i].path.split('package.json')[0]) {
+                                        echo "Scanning ${packageFiles[i].name}"
+                                        nodejs(configId: 'npmrc-default', nodeJSInstallationName: 'nodejs') {
+                                            sh 'nsp check'
                                         }
                                     }
                                 }
                             }
                         }
+                    }
                 )
             }
         }
@@ -227,6 +182,72 @@ pipeline {
                     sh 'mvn javadoc:aggregate -DskipStatic=true -DskipTests=true'
                     sh 'mvn deploy -T 1C -DskipStatic=true -DskipTests=true -DretryFailedDeploymentCount=10'
                 }
+            }
+        }
+        stage('Quality Analysis') {
+            steps {
+                parallel(
+                    sonarqube: {
+                        node('linux-large') {
+                            retry(3) {
+                        checkout scm
+                            }
+                            withMaven(maven: 'M35', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}') {
+                                withCredentials([string(credentialsId: 'SonarQubeGithubToken', variable: 'SONARQUBE_GITHUB_TOKEN'), string(credentialsId: 'sonarqube-token', variable: 'SONAR_TOKEN')]) {
+                                    script {
+                                        // If this build is not a pull request, run sonar scan. otherwise run incremental scan
+                                        if (env.CHANGE_ID == null) {
+                                            sh 'mvn -q -B -Dfindbugs.skip=true -Dcheckstyle.skip=true org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.host.url=https://sonarqube.com -Dsonar.login=$SONAR_TOKEN  -Dsonar.organization=codice -Dsonar.projectKey=org.codice.alliance -pl !$DOCS,!$ITESTS'
+                                        } else {
+                                            echo "Currently Sonar is not run for pull requests"
+                                            // sh 'mvn -q -B -Dfindbugs.skip=true -Dcheckstyle.skip=true org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.github.pullRequest=${CHANGE_ID} -Dsonar.github.oauth=${SONARQUBE_GITHUB_TOKEN} -Dsonar.analysis.mode=preview -Dsonar.host.url=https://sonarqube.com -Dsonar.login=$SONAR_TOKEN  -Dsonar.organization=codice -Dsonar.projectKey=org.codice.alliance -pl !$DOCS,!$ITESTS -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/$CHANGE_TARGET'
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    // Coverity will be skipped on all PR builds
+                    coverity: {
+                        node('linux-medium') {
+                            script {
+                                if (env.BRANCH_NAME != 'master') {
+                                    echo "Coverity is only run on master"
+                                } else {
+                                    retry(3) {
+                                        checkout scm
+                                    }
+                                    withMaven(maven: 'M35', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LINUX_MVN_RANDOM}') {
+                                        withCredentials([string(credentialsId: 'alliance-coverity-token', variable: 'COVERITY_TOKEN')]) {
+                                            withEnv(["PATH=${tool 'coverity-linux'}/bin:${env.PATH}"]) {
+                                                configFileProvider([configFile(fileId: 'coverity-maven-settings', replaceTokens: true, variable: 'MAVEN_SETTINGS')]) {
+                                                    sh 'cov-build --dir cov-int mvn -DskipTests=true -DskipStatic=true install -pl !$DOCS --settings $MAVEN_SETTINGS'
+                                                    sh 'tar czvf alliance.tgz cov-int'
+                                                    sh 'curl --form token=$COVERITY_TOKEN --form email=cmp-security-team@connexta.com --form file=@alliance.tgz --form version="master" --form description="Description: Alliance CI Build" https://scan.coverity.com/builds?project=codice%2Falliance'
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    codecov: {
+                        node('linux-large') {
+                            script {
+                                retry(3) {
+                                    checkout scm
+                                }
+                                withMaven(maven: 'M35', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}') {
+                                    withCredentials([string(credentialsId: 'DDF_CodeCov', variable: 'CODECOV_TOKEN')]) {
+                                        sh 'mvn clean install -B -T 1C -pl !$ITESTS'
+                                        sh 'curl -s https://codecov.io/bash | bash -s - -t ${CODECOV_TOKEN}'
+                                    }
+                                }
+                            }
+                        }
+                    }
+                )
             }
         }
     }


### PR DESCRIPTION
#### What does this PR do?
The static analysis step is now quality analysis and security analysis steps. The quality checks have been moved after the deploy step and codecov was added as another parallel task. The jenkinsfile was also formatted.

#### Who is reviewing it? 
@emanns95 @oconnormi @LinkMJB 

#### Choose 2 committers to review/merge the PR.
@clockard @shaundmorris @rzwiefel 

#### How should this be tested?
Run a multibranch pipeline build with this jenkinsfile

Any background context you want to provide?

The quality analysis stage contains items that should inform the development team without failing the build. However the security analysis stage must still be passed for the build to deploy.

#### What are the relevant tickets?

[CAL-351](https://codice.atlassian.net/browse/CAL-351)