### PR TITLE
[0.3.x] CAL-355 Fixed Download Chip as JPEG and as NITF

### DIFF
--- a/catalog/imaging/imaging-actionprovider-chip/pom.xml
+++ b/catalog/imaging/imaging-actionprovider-chip/pom.xml
@@ -95,6 +95,13 @@
             <artifactId>jquery</artifactId>
             <version>1.11.0</version>
         </dependency>
+        <!--Spock dependencies-->
+        <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>spock-shaded</artifactId>
+            <version>${ddf.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <resources>
@@ -138,17 +145,17 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.72</minimum>
+                                            <minimum>0.96</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.69</minimum>
+                                            <minimum>0.83</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.70</minimum>
+                                            <minimum>0.78</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/imaging/imaging-actionprovider-chip/pom.xml
+++ b/catalog/imaging/imaging-actionprovider-chip/pom.xml
@@ -27,6 +27,7 @@
     <properties>
         <timestamp>${maven.build.timestamp}</timestamp>
         <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
+        <components.font.awesome.version>4.6.3</components.font.awesome.version>
     </properties>
     <name>Alliance :: Imaging :: Action Provider :: Chip</name>
     <dependencies>
@@ -87,7 +88,7 @@
         <dependency>
             <groupId>org.webjars.bower</groupId>
             <artifactId>components-font-awesome</artifactId>
-            <version>4.6.3</version>
+            <version>${components.font.awesome.version}</version>
         </dependency>
         <dependency>
             <groupId>org.webjars.bower</groupId>

--- a/catalog/imaging/imaging-actionprovider-chip/src/main/resources/chipping.html
+++ b/catalog/imaging/imaging-actionprovider-chip/src/main/resources/chipping.html
@@ -21,7 +21,7 @@
         <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
 
         <script src="/chipping/jquery/1.11.0/dist/jquery.min.js"></script>
-        <link rel="stylesheet" type="text/css" href="/chipping/components-font-awesome/4.6.4/css/font-awesome.min.css">
+        <link rel="stylesheet" type="text/css" href="/chipping/components-font-awesome/${components.font.awesome.version}/css/font-awesome.min.css">
         <link href="/chipping/components-bootstrap/3.1.1/css/bootstrap.css" rel="stylesheet">
         <link href="css/index.css?bust=${timestamp}" rel="stylesheet">
     </head>

--- a/catalog/imaging/imaging-actionprovider-chip/src/main/webapp/js/chipping.js
+++ b/catalog/imaging/imaging-actionprovider-chip/src/main/webapp/js/chipping.js
@@ -27,7 +27,7 @@ function setUrlParameters() {
             source = parameter[1];
         }
     });
-    overviewUrl = "/services/catalog/" + id + "?transform=resource&qualifier=overview";
+    overviewUrl = "/services/catalog/sources/" + source + "/" + id + "?transform=resource&qualifier=overview";
 }
 
 function mouseDown(e) {

--- a/catalog/imaging/imaging-actionprovider-chip/src/test/groovy/org/codice/alliance/imaging/chip/actionprovider/ImageChipActionProviderSpec.groovy
+++ b/catalog/imaging/imaging-actionprovider-chip/src/test/groovy/org/codice/alliance/imaging/chip/actionprovider/ImageChipActionProviderSpec.groovy
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.imaging.chip.actionprovider
+
+import ddf.action.Action
+import ddf.catalog.data.impl.AttributeImpl
+import ddf.catalog.data.impl.MetacardImpl
+import ddf.catalog.data.impl.MetacardTypeImpl
+import ddf.catalog.data.impl.types.CoreAttributes
+import ddf.catalog.data.types.Core
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static org.codice.alliance.imaging.chip.actionprovider.ImagingChipActionProvider.NITF_IMAGE_METACARD_TYPE
+
+class ImageChipActionProviderSpec extends Specification {
+
+    public static final String METACARD_ID = "metacardId"
+    public static final METACARD_SOURCE_ID = "metacardSourceId"
+
+    @Unroll
+    def 'test canHandle different derived resource URLs'(
+            final String derivedResourceUriStringFormat) {
+        given:
+            final imagingChipActionProvider = new ImagingChipActionProvider()
+
+            final metacard = new MetacardImpl()
+            final metacardSourceId = "metacardSourceId"
+        
+            metacard.setType(new MetacardTypeImpl(NITF_IMAGE_METACARD_TYPE, Collections.singletonList(new CoreAttributes())))
+            metacard.setId(METACARD_ID)
+            metacard.setSourceId(metacardSourceId)
+            metacard.setLocation("POLYGON ((0.1234 2.222, 0.4444 1.222, 0.1234 1.222, 0.1234 2.222, 0.1234 2.222))")
+            metacard.setResourceURI(new URI("someValidUriString"))
+            final originalDerivedResourceUriString = String.format(derivedResourceUriStringFormat, "original")
+            final overviewDerivedResourceUriString = String.format(derivedResourceUriStringFormat, "overview")
+            metacard.setAttribute(new AttributeImpl(Core.DERIVED_RESOURCE_URI, [originalDerivedResourceUriString, overviewDerivedResourceUriString]))
+
+        expect:
+            imagingChipActionProvider.canHandle(metacard)
+
+        where:
+            derivedResourceUriStringFormat                                                                                                                                  | _
+            "content:" + METACARD_ID + "#%s"                                                                                                                                | _
+            "http://derivedResourceHost:5678/services/catalog/sources/derivedResourceSourceId/derivedResourceMetacardId?transform=resource&qualifier=%s"                    | _
+    }
+
+    @Unroll
+    def 'test can construct chipping URL for different derived resource URLs'(
+            final String derivedResourceUriStringFormat,
+            final String expectedChippingUrlString) {
+        given:
+            final imagingChipActionProvider = new ImagingChipActionProvider()
+
+            final metacard = new MetacardImpl()
+
+            metacard.setType(new MetacardTypeImpl("isr.image", Collections.singletonList(new CoreAttributes())))
+            metacard.setId(METACARD_ID)
+            metacard.setSourceId(METACARD_SOURCE_ID)
+            metacard.setLocation("POLYGON ((0.1234 2.222, 0.4444 1.222, 0.1234 1.222, 0.1234 2.222, 0.1234 2.222))")
+            metacard.setResourceURI(new URI("someValidUriString"))
+            final originalDerivedResourceUriString = String.format(derivedResourceUriStringFormat, "original")
+            final overviewDerivedResourceUriString = String.format(derivedResourceUriStringFormat, "overview")
+            metacard.setAttribute(new AttributeImpl(Core.DERIVED_RESOURCE_URI, [originalDerivedResourceUriString, overviewDerivedResourceUriString]))
+
+            // canHandle is always called before getActions
+            imagingChipActionProvider.canHandle(metacard)
+
+        when:
+            final actions = imagingChipActionProvider.getActions(metacard)
+
+        then:
+            actions.size() == 1
+            final Action action = actions.get(0)
+            action.getId() == ImagingChipActionProvider.ID
+            action.getDescription() == ImagingChipActionProvider.DESCRIPTION
+            action.getTitle() == ImagingChipActionProvider.TITLE
+            action.getUrl() == new URL(expectedChippingUrlString)
+
+        where:
+            derivedResourceUriStringFormat                                                                                                               || expectedChippingUrlString
+            "content:" + METACARD_ID + "#%s"                                                                                                             || "https://localhost:8993/chipping/chipping.html?id=" + METACARD_ID + "&source=" + METACARD_SOURCE_ID
+            "http://derivedResourceHost:5678/services/catalog/sources/derivedResourceSourceId/derivedResourceMetacardId?transform=resource&qualifier=%s" || "http://derivedResourceHost:5678/chipping/chipping.html?id=derivedResourceMetacardId&source=derivedResourceSourceId"
+    }
+
+    @Unroll
+    def 'test cannot construct chipping URL for different derived resource URLs'(final String derivedResourceUriStringFormat) {
+        given:
+            final imagingChipActionProvider = new ImagingChipActionProvider()
+
+            final metacard = new MetacardImpl()
+            final metacardSourceId = "metacardSourceId"
+
+            metacard.setType(new MetacardTypeImpl("isr.image", Collections.singletonList(new CoreAttributes())))
+            metacard.setId(METACARD_ID)
+            metacard.setSourceId(metacardSourceId)
+            metacard.setLocation("POLYGON ((0.1234 2.222, 0.4444 1.222, 0.1234 1.222, 0.1234 2.222, 0.1234 2.222))")
+            metacard.setResourceURI(new URI("someValidUriString"))
+            final originalDerivedResourceUriString = String.format(derivedResourceUriStringFormat, "original")
+            final overviewDerivedResourceUriString = String.format(derivedResourceUriStringFormat, "overview")
+            metacard.setAttribute(new AttributeImpl(Core.DERIVED_RESOURCE_URI, [originalDerivedResourceUriString, overviewDerivedResourceUriString]))
+
+            // canHandle is always called before getActions
+            imagingChipActionProvider.canHandle(metacard)
+
+        when:
+            final actions = imagingChipActionProvider.getActions(metacard)
+
+        then:
+            actions.isEmpty()
+
+        where:
+            derivedResourceUriStringFormat                                                                                                                                  | _
+            "https://:5678/services/catalog/sources/derivedResourceSourceId/derivedResourceMetacardId?transform=resource&qualifier=%s"                                      | _
+            "notHttpNorHttpsProtocol://derivedResourceHost:5678/services/catalog/sources/derivedResourceSourceId/derivedResourceMetacardId?transform=resource&qualifier=%s" | _
+            "http://example.com/services/catalog/sources/derivedResourceSourceId/derivedResourceMetacardId?transform=resource&qualifier=%s"                                 | _
+            "http://derivedResourceHost:5678/not/the/normal/path?transform=resource&qualifier=%s"                                                                           | _
+            "http://derivedResourceHost:5678/services/catalog/sources/derivedResourceSourceId/derivedResourceMetacardId?notThe=normalQuery&qualifier=%s"                    | _
+    }
+}

--- a/catalog/imaging/imaging-actionprovider-chip/src/test/java/org/codice/alliance/imaging/chip/actionprovider/ImageChipActionProviderTest.java
+++ b/catalog/imaging/imaging-actionprovider-chip/src/test/java/org/codice/alliance/imaging/chip/actionprovider/ImageChipActionProviderTest.java
@@ -13,19 +13,15 @@
  */
 package org.codice.alliance.imaging.chip.actionprovider;
 
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
-import ddf.action.Action;
 import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.MetacardTypeImpl;
 import ddf.catalog.data.impl.types.CoreAttributes;
 import ddf.catalog.data.types.Core;
-import java.util.Arrays;
-import java.util.List;
+import java.util.Collections;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -50,7 +46,8 @@ public class ImageChipActionProviderTest {
 
     imageMetacard = new MetacardImpl();
     imageMetacard.setType(
-        new MetacardTypeImpl(NITF_IMAGE_METACARD_TYPE, Arrays.asList(new CoreAttributes())));
+        new MetacardTypeImpl(
+            NITF_IMAGE_METACARD_TYPE, Collections.singletonList(new CoreAttributes())));
     imageMetacard.setId(ID);
     imageMetacard.setSourceId(SOURCE);
     imageMetacard.setLocation(LOCATION);
@@ -72,7 +69,8 @@ public class ImageChipActionProviderTest {
   @Test
   public void testDoesNotHandleNonImageryMetacard() {
     imageMetacard.setType(
-        new MetacardTypeImpl("Non Imagery MetacardType", Arrays.asList(new CoreAttributes())));
+        new MetacardTypeImpl(
+            "Non Imagery MetacardType", Collections.singletonList(new CoreAttributes())));
     assertThat(imagingChipActionProvider.canHandle(imageMetacard), is(false));
   }
 
@@ -91,63 +89,19 @@ public class ImageChipActionProviderTest {
   @Test
   public void testDoesNotHandleNoOriginalDerivedResource() {
     imageMetacard.setAttribute(
-        new AttributeImpl(
-            Core.DERIVED_RESOURCE_URI, "content:73baa01ad925463b962084477d19fde0#NotOriginal"));
+        new AttributeImpl(Core.DERIVED_RESOURCE_URI, "content:someMetacardId#overview"));
     assertThat(imagingChipActionProvider.canHandle(imageMetacard), is(false));
   }
 
   @Test
-  public void testCanHandleOriginalDerivedResource() {
+  public void testDoesNotHandleNoOverviewDerivedResource() {
     imageMetacard.setAttribute(
-        new AttributeImpl(
-            Core.DERIVED_RESOURCE_URI,
-            "https://example.com/download?transform=resource&qualifier=original"));
-    assertThat(imagingChipActionProvider.canHandle(imageMetacard), is(true));
-  }
-
-  @Test
-  public void testDoesNotHandleNonOverviewDerivedResource() {
-    imageMetacard.setAttribute(
-        new AttributeImpl(
-            Core.DERIVED_RESOURCE_URI,
-            "https://example.com/download?transform=resource&qualifier=notoriginal"));
+        new AttributeImpl(Core.DERIVED_RESOURCE_URI, "content:someMetacardId#original"));
     assertThat(imagingChipActionProvider.canHandle(imageMetacard), is(false));
-  }
-
-  @Test
-  public void testCanHandleImageryMetacard() {
-    assertThat(imagingChipActionProvider.canHandle(imageMetacard), is(true));
   }
 
   @Test
   public void testGetId() {
     assertThat(imagingChipActionProvider.getId(), is(ImagingChipActionProvider.ID));
-  }
-
-  @Test
-  public void testGetActionsNullMetacard() {
-    assertThat(imagingChipActionProvider.getActions(null), hasSize(0));
-  }
-
-  @Test
-  public void testGetActionsCanNotHandleMetacard() {
-    imageMetacard.setLocation(null);
-    assertThat(imagingChipActionProvider.getActions(imageMetacard), hasSize(0));
-  }
-
-  @Test
-  public void testGetActionsMetacard() {
-    List<Action> actions = imagingChipActionProvider.getActions(imageMetacard);
-    assertThat(actions, hasSize(1));
-
-    Action action = actions.get(0);
-    assertThat(action.getId(), is(ImagingChipActionProvider.ID));
-    assertThat(action.getDescription(), is(ImagingChipActionProvider.DESCRIPTION));
-    assertThat(action.getTitle(), is(ImagingChipActionProvider.TITLE));
-
-    String url = action.getUrl().toString();
-    assertThat(url, containsString(ImagingChipActionProvider.PATH));
-    assertThat(url, containsString("id=" + ID));
-    assertThat(url, containsString("source=" + SOURCE));
   }
 }

--- a/catalog/imaging/imaging-transformer-chipping/src/main/java/org/codice/alliance/imaging/chip/transformer/CatalogInputAdapter.java
+++ b/catalog/imaging/imaging-transformer-chipping/src/main/java/org/codice/alliance/imaging/chip/transformer/CatalogInputAdapter.java
@@ -107,4 +107,8 @@ public class CatalogInputAdapter {
 
     return qualifiedUri.get(0);
   }
+
+  public String getResourceSiteName(Metacard metacard) {
+    return metacard.getSourceId();
+  }
 }

--- a/catalog/imaging/imaging-transformer-chipping/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/imaging/imaging-transformer-chipping/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -36,9 +36,9 @@
                interface="org.codice.alliance.imaging.chip.service.api.ChipService"/>
 
     <camelContext xmlns="http://camel.apache.org/schema/blueprint"
-                  id="imagingServiceCamelContext"
+                  id="jpegChippingServiceCamelContext"
                   trace="true">
-        <proxy id="chipTransformer"
+        <proxy id="jpegChippingTransformer"
                serviceInterface="org.codice.alliance.imaging.chip.transformer.ImagingChipTransformer"
                serviceUrl="direct:start"/>
 
@@ -49,11 +49,14 @@
                 <bean ref="catalogOutputAdapter" method="wrapException"/>
             </onException>
 
+            <setHeader headerName="resource-site-name">
+                <method ref="catalogInputAdapter" method="getResourceSiteName(${body})"/>
+            </setHeader>
             <setHeader headerName="overview-image-request">
                 <method ref="catalogInputAdapter" method="buildReadRequest(${body}, 'overview')"/>
             </setHeader>
             <setHeader headerName="overview-image-response">
-                <method ref="catalogFramework" method="getLocalResource(${header.overview-image-request})"/>
+                <method ref="catalogFramework" method="getResource(${header.overview-image-request}, ${header.resource-site-name})"/>
             </setHeader>
             <setHeader headerName="overview-image">
                 <method ref="catalogOutputAdapter" method="getImage(${header.overview-image-response})"/>
@@ -63,7 +66,7 @@
                 <method ref="catalogInputAdapter" method="buildReadRequest(${body}, 'original')"/>
             </setHeader>
             <setHeader headerName="original-image-response">
-                <method ref="catalogFramework" method="getLocalResource(${header.original-image-request})"/>
+                <method ref="catalogFramework" method="getResource(${header.original-image-request}, ${header.resource-site-name})"/>
             </setHeader>
             <setBody>
                 <method ref="catalogOutputAdapter" method="getImage(${header.original-image-response})"/>
@@ -85,21 +88,21 @@
     </camelContext>
 
     <service interface="ddf.catalog.transform.MetacardTransformer"
-             ref="chipTransformer">
+             ref="jpegChippingTransformer">
         <service-properties>
             <entry key="id" value="overview-chip"/>
             <entry key="shortname" value="jpeg-chip"/>
-            <entry key="title" value="Chip image..."/>
+            <entry key="title" value="Chip as jpeg..."/>
             <entry key="description"
-                   value="Converts an overview image to a chip."/>
+                   value="Converts an overview image to a jpeg chip."/>
             <entry key="generateActionProvider" value="false"/>
         </service-properties>
     </service>
 
     <camelContext xmlns="http://camel.apache.org/schema/blueprint"
-                  id="nitfImagingServiceCamelContext"
+                  id="nitfChippingServiceCamelContext"
                   trace="true">
-        <proxy id="nitfChipTransformer"
+        <proxy id="nitfChippingTransformer"
                serviceInterface="org.codice.alliance.imaging.chip.transformer.ImagingChipTransformer"
                serviceUrl="direct:start"/>
 
@@ -110,11 +113,14 @@
                 <bean ref="catalogOutputAdapter" method="wrapException"/>
             </onException>
 
+            <setHeader headerName="resource-site-name">
+                <method ref="catalogInputAdapter" method="getResourceSiteName(${body})"/>
+            </setHeader>
             <setHeader headerName="original-nitf-request">
                 <method ref="catalogInputAdapter" method="buildReadRequest(${body})"/>
             </setHeader>
             <setHeader headerName="original-nitf-response">
-                <method ref="catalogFramework" method="getLocalResource(${header.original-nitf-request})"/>
+                <method ref="catalogFramework" method="getResource(${header.original-nitf-request}, ${header.resource-site-name})"/>
             </setHeader>
             <setHeader headerName="original-nitf">
                 <method ref="catalogOutputAdapter" method="getNitfSegmentsFlow(${header.original-nitf-response})"/>
@@ -124,7 +130,7 @@
                 <method ref="catalogInputAdapter" method="buildReadRequest(${body}, 'overview')"/>
             </setHeader>
             <setHeader headerName="overview-image-response">
-                <method ref="catalogFramework" method="getLocalResource(${header.overview-image-request})"/>
+                <method ref="catalogFramework" method="getResource(${header.overview-image-request}, ${header.resource-site-name})"/>
             </setHeader>
             <setHeader headerName="overview-image">
                 <method ref="catalogOutputAdapter" method="getImage(${header.overview-image-response})"/>
@@ -134,7 +140,7 @@
                 <method ref="catalogInputAdapter" method="buildReadRequest(${body}, 'original')"/>
             </setHeader>
             <setHeader headerName="original-image-response">
-                <method ref="catalogFramework" method="getLocalResource(${header.original-image-request})"/>
+                <method ref="catalogFramework" method="getResource(${header.original-image-request}, ${header.resource-site-name})"/>
             </setHeader>
             <setBody>
                 <method ref="catalogOutputAdapter" method="getImage(${header.original-image-response})"/>
@@ -156,11 +162,11 @@
     </camelContext>
 
     <service interface="ddf.catalog.transform.MetacardTransformer"
-             ref="nitfChipTransformer">
+             ref="nitfChippingTransformer">
         <service-properties>
             <entry key="id" value="overview-chip"/>
             <entry key="shortname" value="nitf-chip"/>
-            <entry key="title" value="Chip nitf..."/>
+            <entry key="title" value="Chip as nitf..."/>
             <entry key="description"
                    value="Converts an overview image to a nitf chip."/>
             <entry key="generateActionProvider" value="false"/>

--- a/catalog/imaging/imaging-transformer-chipping/src/test/java/org/codice/alliance/imaging/chip/transformer/CatalogInputAdapterTest.java
+++ b/catalog/imaging/imaging-transformer-chipping/src/test/java/org/codice/alliance/imaging/chip/transformer/CatalogInputAdapterTest.java
@@ -96,4 +96,14 @@ public class CatalogInputAdapterTest {
     ResourceRequest resourceRequest = catalogInputAdapter.buildReadRequest(metacard);
     assertThat(resourceRequest.getAttributeValue(), is(id));
   }
+
+  @Test
+  public void testGetResourceSiteName() {
+    final String siteName = "siteNameValue";
+    MetacardImpl metacard = new MetacardImpl();
+    metacard.setSourceId(siteName);
+
+    String resourceSiteName = catalogInputAdapter.getResourceSiteName(metacard);
+    assertThat(resourceSiteName, is(siteName));
+  }
 }


### PR DESCRIPTION
#### What does this PR do?

- Fixed handling resources from remote sources in the imaging-transformer-chipping
    - The chipping transformer now specifies the source when retrieving the overview, original, and NITF from the Catalog.

- Fixed fetching the overview image for remote resources in the imaging-actionprovider-chip
    - The chipping UI now uses the source name to get the overview image instead of assuming a local source.

- Updated the imaging-actionprovider-chip to better parse the chipping url from the derived resource uris if possible
    - More error handling was added, and the parsing logic was updated to grab the source id from the derived image URI instead of from the metacard source id.

- Updated the components-font-awesome version in imaging-actionprovider-chip to match the pom

#### Who is reviewing it? 
@peterhuffer @AzGoalie @lcrosenbu 
#### Choose 2 committers to review/merge the PR.
@clockard
@rzwiefel
#### How should this be tested?
1. Startup and install 2 instances of Alliance.
2. In Alliance A, install a chippable (must have an image and location) NITF.
3. In Alliance B, install a chippable (must have an image and location) NITF.
4. In Alliance A, add Alliance B as a CSW Federated Source.
5. In Alliance A, add Alliance B as a another kind of federated source.
6. For each source, open the `Inspector`->`Action` tab for the result.
    - `View original` should download the original image jpeg.
    - `View overview` should download the overview image jpeg.
    - `Chip Image` should open a new chipping page.
        - The overview image should appear correctly.
        - The `Download Chip as JPEG` button should download a jpeg chip.
        - The `Download Chip as NITF` button should download a NITF chip.

#### Any background context you want to provide?
https://github.com/codice/alliance/pull/278 added a work-around to try use the chipping url of the remote system instead of the local chipping url. The motivation for this is that chipping the image on the remote system saves the overhead of having to download the overview, original, and NITF and then chip locally instead of just downloading the chip. Furthermore, CSW does not support qualifiers. This means that the derived resource attributes in the metacard are populated with uris for remote systems.

Currently, constructing the remote URL only works for derived resource URIs that look like the default-configured derived resource URLs in Alliance: `[http or https]://[derived resource host]:[derived resource port]/services/catalog/sources/[derived resource source id]/[derived resource metacard id]?transform=resource&qualifier=[original or overview]`. This PR does not change this known limitation.

|  | Local  | Other federated sources that support qualifiers | CSW |
|---------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `resource-uri` | `content:<metacard id>` | `content:<metacard id>` | `<Alliance B>/services/catalog/sources/<Alliance B sitename>/<metacard id>?transform=resource` |
| `resource.derived-uri` | `content:<metacard id>#original` `content:<metacard id>#overview` | `content:<metacard id>#original` `content:<metacard id>#overview` | `<Alliance B>/services/catalog/sources/<Alliance B sitename>/<metacard id>?transform=resource&qualifier=original` `<Alliance B>/services/catalog/sources/<Alliance B sitename>/<metacard id>?transform=resource&qualifier=overview` |
| `resource-download-url` | `<Alliance A>/services/catalog/sources/<Alliance A sitename>/<metacard id>?transform=resource` | `<Alliance A>/services/catalog/sources/<source id>/<metacard id>?transform=resource` | `<Alliance A>/services/catalog/sources/<source id>/<metacard id>?transform=resource` |
| `resource.derived-download-url` | `<Alliance A>/services/catalog/sources/<Alliance A sitename>/<metacard id>?transform=resource&qualifier=original` `<Alliance A>/services/catalog/sources/<Alliance A sitename>/<metacard id>?transform=resource&qualifier=overview` | `<Alliance A>/services/catalog/sources/<source id>/<metacard id>?transform=resource&qualifier=original` `<Alliance A>/services/catalog/sources/<source id>/<metacard id>?transform=resource&qualifier=overview` | `<Alliance B>/services/catalog/sources/<Alliance B sitename>/<metacard id>?transform=resource&qualifier=original` `<Alliance B>/services/catalog/sources/<Alliance B sitename>/<metacard id>?transform=resource&qualifier=overview` |
| Expected chipping url | `<Alliance A>/chipping/chipping.html?id=<metacard id>&source=<Alliance A sitename>` | `<AllianceA>/chipping/chipping.html?id=<metacard id>&source=<source id>` | `<Alliance B>/chipping/chipping.html?id=<metacard id>&source=<Alliance B sitename>` |

#### What are the relevant tickets?
[CAL-355](https://codice.atlassian.net/browse/CAL-355)
#### Screenshots
![image](https://user-images.githubusercontent.com/8041246/31469558-e7e84ed0-ae96-11e7-9652-c44c26448008.png)
![image](https://user-images.githubusercontent.com/8041246/31199080-2632f1ae-a90b-11e7-979b-beb9329c26e5.png)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
