### PR TITLE
[0.3.x] CAL-353 Handles non-UTF8 country codes

### DIFF
--- a/catalog/video/video-mpegts-stream/pom.xml
+++ b/catalog/video/video-mpegts-stream/pom.xml
@@ -25,6 +25,7 @@
     <artifactId>video-mpegts-stream</artifactId>
     <name>Alliance :: Video :: Stream</name>
     <packaging>bundle</packaging>
+
     <dependencies>
 
         <dependency>
@@ -59,6 +60,13 @@
             <groupId>org.codice.ddf</groupId>
             <artifactId>klv</artifactId>
             <version>${ddf.version}</version>
+            <exclusions>
+                <exclusion>
+                    <!-- This is already being pulled in by another dependency and causes classpath issues in unit tests -->
+                    <groupId>org.opengis</groupId>
+                    <artifactId>geoapi</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/libs/stanag4609/src/main/java/org/codice/alliance/libs/stanag4609/Stanag4609TransportStreamParser.java
+++ b/libs/stanag4609/src/main/java/org/codice/alliance/libs/stanag4609/Stanag4609TransportStreamParser.java
@@ -33,6 +33,7 @@ import org.codice.ddf.libs.klv.data.numerical.KlvShort;
 import org.codice.ddf.libs.klv.data.numerical.KlvUnsignedByte;
 import org.codice.ddf.libs.klv.data.numerical.KlvUnsignedShort;
 import org.codice.ddf.libs.klv.data.set.KlvLocalSet;
+import org.codice.ddf.libs.klv.data.text.KlvEncodingDetectedString;
 import org.codice.ddf.libs.klv.data.text.KlvString;
 import org.codice.ddf.libs.mpeg.transport.MpegTransportStreamMetadataExtractor;
 import org.slf4j.Logger;
@@ -385,7 +386,8 @@ public class Stanag4609TransportStreamParser {
 
     securityLocalSetContext.addDataElement(
         new KlvUnsignedByte(new byte[] {12}, OBJECT_COUNTRY_CODING_METHOD));
-    securityLocalSetContext.addDataElement(new KlvString(new byte[] {13}, OBJECT_COUNTRY_CODES));
+    securityLocalSetContext.addDataElement(
+        new KlvEncodingDetectedString(new byte[] {13}, OBJECT_COUNTRY_CODES));
 
     localSetContext.addDataElement(
         new KlvLocalSet(new byte[] {48}, SECURITY_LOCAL_METADATA_SET, securityLocalSetContext));


### PR DESCRIPTION
#### What does this PR do?
Handles a country code that may not be UTF-8 encoded by detecting its encoding.
Uses : https://github.com/codice/ddf/pull/2426

#### Who is reviewing it? 
@brendan-hofmann @glenhein 
@ahoffer @mcalcote @garrettfreibott 

#### Choose 2 committers to review/merge the PR.
@rzwiefel 
@lessarderic

#### What are the relevant tickets?
[CAL-353](https://codice.atlassian.net/browse/CAL-353)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
