### PR TITLE
CAL-291 fix typo in docs, broken link

### DIFF
--- a/distribution/docs/src/main/resources/content/_configuring/banner-markings-content-extractor.adoc
+++ b/distribution/docs/src/main/resources/content/_configuring/banner-markings-content-extractor.adoc
@@ -70,7 +70,7 @@ shall be included in the first line of text ... ._
 ====
 
 However, after installing the Banner Markings Extractor, check the configuration of the
- <<metacard_attribute_security_policy_plugin, Metacard Attribute Security Policy Plugin>>
+ <<_metacard_attribute_security_policy_plugin, Metacard Attribute Security Policy Plugin>>
  and ensure the desired policy is configured. This is a typical (but not exhaustive configuration):
 
 .[[common_security_attribute_mappings]]Common Security Attribute Mappings
@@ -95,7 +95,8 @@ However, after installing the Banner Markings Extractor, check the configuration
 
 These settings rename the security attributes used by the
  <<_configuring_filtering_policies,XACML policies>> and the
-the  <<_security_pdp,Policy Decision Point>> (PDP). If the attribute names are not changed,
+the  <<_security_pdp,Policy Decision Point>> (PDP).
+If the attribute names are not changed,
 the security policies would not work as expected.
 [WARNING]
 ====


### PR DESCRIPTION
#### What does this PR do?

fixes a malformed link in documentation.

#### Who is reviewing it? 
@mcalcote @vinamartin @ahoffer 

#### Choose 2 committers to review/merge the PR.
(please choose ONLY two committers from below, delete the rest)

@clockard
@coyotesqrl
@lessarderic
@pklinef
@rzwiefel
@shaundmorris
@ricklarsen - Documentation

#### How should this be tested?
-builds successfully
-link works

#### Any background context you want to provide?
n/a

#### What are the relevant tickets?

[CAL-291](https://codice.atlassian.net/browse/CAL-291)

#### Screenshots (if appropriate)

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
