### PR TITLE
[0.3.x] CAL-361 Update MpegTsInputTransformer to use correct DCMI data type

### DIFF
--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/NitfImageTransformer.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/NitfImageTransformer.java
@@ -24,6 +24,7 @@ import com.vividsolutions.jts.geom.PrecisionModel;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.data.types.Core;
+import ddf.catalog.data.types.constants.core.DataType;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
@@ -46,7 +47,7 @@ public class NitfImageTransformer extends SegmentHandler {
   private static final GeometryFactory GEOMETRY_FACTORY =
       new GeometryFactory(new PrecisionModel(PrecisionModel.FLOATING), 4326);
 
-  private static final String IMAGE_DATATYPE = "Image";
+  private static final String IMAGE_DATATYPE = DataType.IMAGE.toString();
 
   public Metacard transform(NitfSegmentsFlow nitfSegmentsFlow, Metacard metacard)
       throws IOException {

--- a/catalog/video/video-mpegts-transformer/src/main/java/org/codice/alliance/transformer/video/MpegTsInputTransformer.java
+++ b/catalog/video/video-mpegts-transformer/src/main/java/org/codice/alliance/transformer/video/MpegTsInputTransformer.java
@@ -21,6 +21,7 @@ import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.types.Core;
+import ddf.catalog.data.types.constants.core.DataType;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.InputTransformer;
 import java.io.IOException;
@@ -53,7 +54,7 @@ public class MpegTsInputTransformer implements InputTransformer {
 
   public static final String CONTENT_TYPE = "video/mp2t";
 
-  public static final String DATA_TYPE = "Video";
+  public static final String DATA_TYPE = DataType.MOVING_IMAGE.toString();
 
   private static final Logger LOGGER = LoggerFactory.getLogger(MpegTsInputTransformer.class);
 

--- a/distribution/test/itests/test-itests-dependencies-app/src/main/filtered-resources/features.xml
+++ b/distribution/test/itests/test-itests-dependencies-app/src/main/filtered-resources/features.xml
@@ -21,7 +21,7 @@
     </feature>
 
     <feature name="third-party-dependencies">
-        <bundle>mvn:commons-io/commons-io/2.5</bundle>
+        <bundle>mvn:commons-io/commons-io/${commons-io.version}</bundle>
         <bundle>wrap:mvn:org.awaitility/awaitility/${awaitility.version}</bundle>
         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.hamcrest/${hamcrest-all.version}</bundle>
         <bundle>wrap:mvn:org.codice.imaging.nitf/codice-imaging-nitf-core-api/${nitf-imaging.version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <cxf.version>3.1.11</cxf.version>
         <karaf.version>4.1.2</karaf.version>
         <commons-lang.version>2.6</commons-lang.version>
-        <commons-io.version>2.1</commons-io.version>
+        <commons-io.version>2.5</commons-io.version>
         <guava.version>18.0</guava.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>1.5.6</asciidoctor.maven.plugin.version>
@@ -74,7 +74,6 @@
         <jcodec.version>0.2.0_1</jcodec.version>
         <mpegts-streamer.version>0.1.0_2</mpegts-streamer.version>
         <commons-collections4.version>4.1</commons-collections4.version>
-        <commons-io.version>2.1</commons-io.version>
         <node.version>v7.4.0</node.version>
         <yarn.version>v0.21.2</yarn.version>
         <netty.version>4.1.5.Final</netty.version>


### PR DESCRIPTION
#### What does this PR do?
 Update MpegTsInputTransformer to use correct DCMI data type
#### Who is reviewing it? 
@emmberk 
#### Choose 2 committers to review/merge the PR.
(please choose ONLY two committers from below, delete the rest)

@andrewkfiedler
@bdeining
@lessarderic

#### How should this be tested?
Install Alliance and start the Video app
Ingest an Mpeg ts file and verify you can search and find the metacard.

#### What are the relevant tickets?

[CAL-361](https://codice.atlassian.net/browse/CAL-361)

