### PR TITLE
CAL-362 Updated nsp Static Analysis stage to only scan projects using browserify or webpack

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -149,9 +149,12 @@ pipeline {
                                 def packageFiles = findFiles(glob: '**/package.json')
                                 for (int i = 0; i < packageFiles.size(); i++) {
                                     dir(packageFiles[i].path.split('package.json')[0]) {
-                                        echo "Scanning ${packageFiles[i].name}"
-                                        nodejs(configId: 'npmrc-default', nodeJSInstallationName: 'nodejs') {
-                                            sh 'nsp check'
+                                        def packageFile = readJSON file: 'package.json'
+                                        if (packageFile.scripts =~ /.*webpack.*/ || packageFile.containsKey("browserify")) {
+                                            nodejs(configId: 'npmrc-default', nodeJSInstallationName: 'nodejs') {
+                                                echo "Scanning ${packageFiles[i].path}"
+                                                sh 'nsp check'
+                                            }
                                         }
                                     }
                                 }


### PR DESCRIPTION
#### What does this PR do?

Changes the node security scan to only scan projects that are actually packaging dependencies

#### Who is reviewing it?
 
@mcalcote @LinkMJB 

#### Choose 2 committers to review/merge the PR.

@clockard @shaundmorris 

#### What are the relevant tickets?

[CAL-362](https://codice.atlassian.net/browse/CAL-362)
