### PR TITLE
[0.3.x] CAL-364 Standardized docs references to ALLIANCE_HOME directory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <ddf.version>2.11.1</ddf.version>
+        <ddf.version>2.11.2-SNAPSHOT</ddf.version>
         <ddf.support.version>2.3.9</ddf.support.version>
         <ddf.scm.connection.url />
         <snapshots.repository.url />
@@ -88,6 +88,7 @@
         <command-console>Command Console</command-console>
         <public_url>\http://{FQDN}:{PORT}</public_url>
         <secure_url>\https://{FQDN}:{PORT}</secure_url>
+        <home_directory>&lt;ALLIANCE_HOME&gt;</home_directory>
         <!--Needed for documentation formatting-->
         <at-symbol>@</at-symbol>
         <variable-prefix>${</variable-prefix>


### PR DESCRIPTION
#### What does this PR do?

Replaces inconsistent references to the DDF_HOME directory with a maven property to ensure consistent usage. 
#### Who is reviewing it? 
@mcalcote @vinamartin @ahoffer @rzwiefel @garrettfreibott @emmberk 

#### Choose 2 committers to review/merge the PR. 

@clockard
@coyotesqrl
@lessarderic
@pklinef
@ricklarsen - Documentation
@rzwiefel
@shaundmorris

#### How should this be tested? (List steps with links to updated documentation)

- All references to `${branding}_HOME`, `INSTALL_HOME`, or `INSTALLATION_DIR` (or others) have been replaced with the ${home_directory} property.

#### What are the relevant tickets?
[DDF-3391](https://codice.atlassian.net/browse/DDF-3391)
(Depends on changes from https://github.com/codice/ddf/pull/2538
[CAL-364](https://codice.atlassian.net/browse/CAL-364)


#### Screenshots (if appropriate)
#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
