### PR TITLE
[0.3.x] CAL-348 Added Documentation for NITF FSCTLH and FSREL mappings

### DIFF
--- a/distribution/docs/src/main/resources/content/_metadataAttributes/NITF-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/NITF-table.adoc
@@ -1,13 +1,14 @@
-:title: NITF ACFTB Attribute Mappings
+:title: General NITF Attribute Mappings
 :type: subAppendix
 :order: 000
 :parent: Format-specific Attribute Mappings
 :status: published
-:summary: NITF Attribute Mappings.
+:summary: General NITF Attribute Mappings.
 
-== {title}
+// all NITF mapping tables should live under this section
+== NITF Attribute Mappings
 
-.[[NITF_ACFTB_Attribute_Mappings]]NITF Attribute Mappings
+.General NITF Attribute Mappings
 [cols="2" options="header"]
 |===
 

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_Header-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_Header-table.adoc
@@ -1,11 +1,14 @@
 :title: NITF Header Attribute Mappings
 :type: subAppendix
-:order: 006
+:order: 001
 :parent: Format-specific Attribute Mappings
 :status: published
 :summary: NITF Header Attribute Mappings.
 
-.[[NITF_Header_Attribute_Mappings]]NITF Header Attribute Mappings
+// all NITF header mappings should live under this section
+=== NITF Header Attribute Mappings
+
+.NITF Header Attribute Mappings
 [cols="5" options="header"]
 |===
 

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_Header-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_Header-table.adoc
@@ -138,33 +138,29 @@ else current time
 |String
 |true
 
-// TODO CAL-348 Document NITF to DDF Catalog Taxonomy Security Mappings
-//|NitfHeader.FSCTLH
-//|TODO
-//|security.dissemination-controls
-//|String
-//|true
+|NitfHeader.FSCTLH
+|none
+|security.dissemination-controls
+|String
+|true
 
-// TODO CAL-348 Document NITF to DDF Catalog Taxonomy Security Mappings
-//|NitfHeader.FSCTLH
-//|TODO
-//|ext.nitf.file-control-and-handling
-//|String
-//|true
+|NitfHeader.FSCTLH
+|none
+|ext.nitf.file-control-and-handling
+|String
+|true
 
-// TODO CAL-348 Document NITF to DDF Catalog Taxonomy Security Mappings
-//|NitfHeader.FSREL
-//|TODO
-//|security.releasability
-//|String
-//|true
+|NitfHeader.FSREL
+|none
+|security.releasability
+|String
+|true
 
-// TODO CAL-348 Document NITF to DDF Catalog Taxonomy Security Mappings
-//|NitfHeader.FSREL
-//|TODO
-//|ext.nitf.file-releasing-instructions
-//|String
-//|true
+|NitfHeader.FSREL
+|none
+|ext.nitf.file-releasing-instructions
+|String
+|true
 
 |NitfHeader.ONAME
 |none

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_Segment_Graphic-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_Segment_Graphic-table.adoc
@@ -1,11 +1,14 @@
 :title: NITF Graphic Segment Attribute Mappings
 :type: subAppendix
-:order: 005
+:order: 002
 :parent: Format-specific Attribute Mappings
 :status: published
 :summary: NITF Graphic Segment Attribute Mappings.
 
-.[[NITF_Graphic_Segment_Attribute_Mappings]]NITF Graphic Segment Attribute Mappings
+// all NITF segment mapping tables should live under this section
+=== NITF Segment Attribute Mappings
+
+.NITF Graphic Segment Attribute Mappings
 [cols="5" options="header"]
 |===
 

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_Segment_Image-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_Segment_Image-table.adoc
@@ -1,11 +1,11 @@
 :title: NITF Image Segment Attribute Mappings
 :type: subAppendix
-:order: 008
+:order: 003
 :parent: Format-specific Attribute Mappings
 :status: published
 :summary: NITF Image Segment Attribute Mappings.
 
-.[[NITF_Image_Segment_Attribute_Mappings]]NITF Image Segment Attribute Mappings
+.NITF Image Segment Attribute Mappings
 [cols="5" options="header"]
 |===
 

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_Segment_Label-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_Segment_Label-table.adoc
@@ -1,11 +1,11 @@
 :title: NITF Label Segment Attribute Mappings
 :type: subAppendix
-:order: 009
+:order: 004
 :parent: Format-specific Attribute Mappings
 :status: published
 :summary: NITF Label Segment Attribute Mappings.
 
-.[[NITF_Label_Segment_Attribute_Mappings]]NITF Label Segment Attribute Mappings
+.NITF Label Segment Attribute Mappings
 [cols="5" options="header"]
 |===
 

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_Segment_Symbol-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_Segment_Symbol-table.adoc
@@ -1,11 +1,11 @@
 :title: NITF Symbol Segment Attribute Mappings
 :type: subAppendix
-:order: 015
+:order: 005
 :parent: Format-specific Attribute Mappings
 :status: published
 :summary: NITF Symbol Segment Attribute Mappings.
 
-.[[NITF_Symbol_Segment_Attribute_Mappings]]NITF Symbol Segment Attribute Mappings
+.NITF Symbol Segment Attribute Mappings
 [cols="5" options="header"]
 |===
 

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_Segment_Text-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_Segment_Text-table.adoc
@@ -1,11 +1,11 @@
 :title: NITF Text Segment Attribute Mappings
 :type: subAppendix
-:order: 017
+:order: 006
 :parent: Format-specific Attribute Mappings
 :status: published
 :summary: NITF Text Segment Attribute Mappings.
 
-.[[NITF_Text_Segment_Attribute_Mappings]]NITF Text Segment Attribute Mappings
+.NITF Text Segment Attribute Mappings
 [cols="5" options="header"]
 |===
 

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_TRE_ACFTB-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_TRE_ACFTB-table.adoc
@@ -1,11 +1,14 @@
-:title: NITF Aircraft Information Extension (ACFTB) Attribute Mappings
+:title: NITF Aircraft Information Extension (ACFTB) TRE Attribute Mappings
 :type: subAppendix
-:order: 001
-:parent: Metadata Attributes
+:order: 007
+:parent: Format-specific Attribute Mappings
 :status: published
-:summary: NITF Aircraft Information Extension (ACFTB) Attribute Mappings.
+:summary: NITF Aircraft Information Extension (ACFTB) TRE Attribute Mappings.
 
-.NITF Aircraft Information Extension (ACFTB) Attribute Mappings
+// all NITF TRE mapping tables should live under this section
+=== NITF TRE Attribute Mappings
+
+.NITF Aircraft Information Extension (ACFTB) TRE Attribute Mappings
 [cols="5" options="header"]
 |===
 

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_TRE_AIMIDB-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_TRE_AIMIDB-table.adoc
@@ -1,11 +1,11 @@
-:title: NITF Airborne Image Identification (AIMIDB) Attribute Mappings
+:title: NITF Airborne Image Identification (AIMIDB) TRE Attribute Mappings
 :type: subAppendix
-:order: 002
+:order: 008
 :parent: Format-specific Attribute Mappings
 :status: published
-:summary: NITF Airborne Image Identification (AIMIDB) Attribute Mappings.
+:summary: NITF Airborne Image Identification (AIMIDB) TRE Attribute Mappings.
 
-.[[NITF_AIMIDB_Attribute_Mappings]]NITF Airborne Image Identification (AIMIDB) Attribute Mappings
+.NITF Airborne Image Identification (AIMIDB) TRE Attribute Mappings
 [cols="5" options="header"]
 |===
 

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_TRE_CSDIDA-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_TRE_CSDIDA-table.adoc
@@ -1,11 +1,11 @@
-:title: NITF Dataset Identification (CSDIDA) Attribute Mappings
+:title: NITF Dataset Identification (CSDIDA) TRE Attribute Mappings
 :type: subAppendix
-:order: 004
+:order: 009
 :parent: Format-specific Attribute Mappings
 :status: published
-:summary: NITF Dataset Identification (CSDIDA) Attribute Mappings.
+:summary: NITF Dataset Identification (CSDIDA) TRE Attribute Mappings.
 
-.[[NITF_CSDIDA_Attribute_Mappings]]NITF Dataset Identification (CSDIDA) Attribute Mappings
+.NITF Dataset Identification (CSDIDA) TRE Attribute Mappings
 [cols="5" options="header"]
 |===
 

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_TRE_CSEXRA-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_TRE_CSEXRA-table.adoc
@@ -1,11 +1,11 @@
-:title: NITF Exploitation Reference Data (CSEXRA) Attribute Mappings
+:title: NITF Exploitation Reference Data (CSEXRA) TRE Attribute Mappings
 :type: subAppendix
-:order: 003
+:order: 010
 :parent: Format-specific Attribute Mappings
 :status: published
-:summary: NITF Exploitation Reference Data (CSEXRA) Attribute Mappings.
+:summary: NITF Exploitation Reference Data (CSEXRA) TRE Attribute Mappings.
 
-.[[NITF_CSEXRA_Attribute_Mappings]]NITF Exploitation Reference Data (CSEXRA) Attribute Mappings
+.NITF Exploitation Reference Data (CSEXRA) TRE Attribute Mappings
 [cols="5" options="header"]
 |===
 

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_TRE_HISTOA-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_TRE_HISTOA-table.adoc
@@ -1,11 +1,11 @@
-:title: NITF Softcopy History (HISTOA) Attribute Mappings
+:title: NITF Softcopy History (HISTOA) TRE Attribute Mappings
 :type: subAppendix
-:order: 007
+:order: 011
 :parent: Format-specific Attribute Mappings
 :status: published
-:summary: NITF Softcopy History (HISTOA) Attribute Mappings.
+:summary: NITF Softcopy History (HISTOA) TRE Attribute Mappings.
 
-.[[NITF_HISTOA_Attribute_Mappings]]NITF Softcopy History (HISTOA) Attribute Mappings
+.NITF Softcopy History (HISTOA) TRE Attribute Mappings
 [cols="5" options="header"]
 |===
 

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_TRE_MTIRPB-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_TRE_MTIRPB-table.adoc
@@ -1,11 +1,11 @@
-:title: NITF Moving Target Indiciator Report (MTIRPB) Attribute Mappings
+:title: NITF Moving Target Indiciator Report (MTIRPB) TRE Attribute Mappings
 :type: subAppendix
-:order: 011
+:order: 012
 :parent: Format-specific Attribute Mappings
 :status: published
-:summary: NITF Moving Target Indiciator Report (MTIRPB) Attribute Mappings.
+:summary: NITF Moving Target Indiciator Report (MTIRPB) TRE Attribute Mappings.
 
-.[[NITF_MTIRPB_Attribute_Mappings]]NITF Moving Target Indiciator Report (MTIRPB) Attribute Mappings
+.NITF Moving Target Indiciator Report (MTIRPB) TRE Attribute Mappings
 [cols="5" options="header"]
 |===
 

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_TRE_PIAIMC-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_TRE_PIAIMC-table.adoc
@@ -1,11 +1,11 @@
-:title: NITF Profile For Imagery Access Image Support Extensions (PIAIMC) Attribute Mappings
+:title: NITF Profile For Imagery Access Image Support Extensions (PIAIMC) TRE Attribute Mappings
 :type: subAppendix
-:order: 010
+:order: 013
 :parent: Format-specific Attribute Mappings
 :status: published
-:summary: NITF Profile For Imagery Access Image Support Extensions (PIAIMC) Attribute Mappings.
+:summary: NITF Profile For Imagery Access Image Support Extensions (PIAIMC) TRE Attribute Mappings.
 
-.[[NITF_PIAIMC_Attribute_Mappings]]NITF Profile For Imagery Access Image Support Extensions (PIAIMC) Attribute Mappings
+.NITF Profile For Imagery Access Image Support Extensions (PIAIMC) TRE Attribute Mappings
 [cols="5" options="header"]
 |===
 

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_TRE_PIAPRD-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_TRE_PIAPRD-table.adoc
@@ -1,11 +1,11 @@
-:title: NITF Profile For Imagery Access Product (PIAPRD) Attribute Mappings
+:title: NITF Profile For Imagery Access Product (PIAPRD) TRE Attribute Mappings
 :type: subAppendix
 :order: 014
 :parent: Format-specific Attribute Mappings
 :status: published
-:summary: NITF Profile For Imagery Access Product (PIAPRD) Attribute Mappings.
+:summary: NITF Profile For Imagery Access Product (PIAPRD) TRE Attribute Mappings.
 
-.[[NITF_PIAPRD_Attribute_Mappings]]NITF Profile For Imagery Access Product (PIAPRD) Attribute Mappings
+.NITF Profile For Imagery Access Product (PIAPRD) TRE Attribute Mappings
 [cols="5" options="header"]
 |===
 

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_TRE_PIATGB-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_TRE_PIATGB-table.adoc
@@ -1,11 +1,11 @@
-:title: NITF Profile For Imagery Access Target (PIATGB) Attribute Mappings
+:title: NITF Profile For Imagery Access Target (PIATGB) TRE Attribute Mappings
 :type: subAppendix
-:order: 012
+:order: 015
 :parent: Format-specific Attribute Mappings
 :status: published
-:summary: NITF Profile For Imagery Access Target (PIATGB) Attribute Mappings.
+:summary: NITF Profile For Imagery Access Target (PIATGB) TRE Attribute Mappings.
 
-.[[NITF_PIATGB_Attribute_Mappings]]NITF Profile For Imagery Access Target (PIATGB) Attribute Mappings
+.NITF Profile For Imagery Access Target (PIATGB) TRE Attribute Mappings
 [cols="5" options="header"]
 |===
 

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_TRE_STDIDC-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_TRE_STDIDC-table.adoc
@@ -1,11 +1,11 @@
-:title: NITF Standard ID (STDIDC) Attribute Mappings
+:title: NITF Standard ID (STDIDC) TRE Attribute Mappings
 :type: subAppendix
-:order: 013
+:order: 016
 :parent: Format-specific Attribute Mappings
 :status: published
-:summary: NITF Standard ID (STDIDC) Attribute Mappings.
+:summary: NITF Standard ID (STDIDC) TRE Attribute Mappings.
 
-.[[NITF_STDIDC_Attribute_Mappings]]NITF Standard ID (STDIDC) Attribute Mappings
+.NITF Standard ID (STDIDC) TRE Attribute Mappings
 [cols="5" options="header"]
 |===
 


### PR DESCRIPTION
#### What does this PR do?
This PR adds Documentation for NITF FSCTLH and FSREL mappings.
#### Who is reviewing it? 
@peterhuffer @vinamartin 
#### Choose 2 committers to review/merge the PR.
@bdeining
@clockard
#### How should this be tested?
Build the Documentation, and check that the 4 new rows are added to the `NITF Header Attribute Mappings` table.

[documentation.zip](https://github.com/codice/alliance/files/1432296/documentation.zip)
#### What are the relevant tickets?
[CAL-348](https://codice.atlassian.net/browse/CAL-348)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
