### PR TITLE
CAL-368 maps NSIL_FILE.creator and NSIL_STREAM.creator to isr.organiz…

### DIFF
--- a/catalog/nsili/catalog-nsili-transformer/src/main/java/org/codice/alliance/nsili/transformer/DAGConverter.java
+++ b/catalog/nsili/catalog-nsili-transformer/src/main/java/org/codice/alliance/nsili/transformer/DAGConverter.java
@@ -31,7 +31,6 @@ import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.types.ContactAttributes;
 import ddf.catalog.data.impl.types.CoreAttributes;
 import ddf.catalog.data.types.Associations;
-import ddf.catalog.data.types.Contact;
 import ddf.catalog.data.types.Core;
 import ddf.catalog.data.types.DateTime;
 import ddf.catalog.data.types.Location;
@@ -54,6 +53,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang.StringUtils;
 import org.codice.alliance.catalog.core.api.impl.types.IsrAttributes;
+import org.codice.alliance.catalog.core.api.types.Isr;
 import org.codice.alliance.catalog.core.api.types.Security;
 import org.codice.alliance.nsili.common.CorbaUtils;
 import org.codice.alliance.nsili.common.NsiliConstants;
@@ -375,7 +375,7 @@ public class DAGConverter {
 
     switch (node.attribute_name) {
       case NsiliConstants.CREATOR:
-        metacard.setAttribute(new AttributeImpl(Contact.CREATOR_NAME, getString(node.value)));
+        metacard.setAttribute(new AttributeImpl(Isr.ORGANIZATIONAL_UNIT, getString(node.value)));
         break;
       case NsiliConstants.DATE_TIME_DECLARED:
         metacard.setCreatedDate(CorbaUtils.convertDate(node.value));
@@ -551,7 +551,7 @@ public class DAGConverter {
   private void addNsilStreamAttribute(MetacardImpl metacard, Node node) {
     switch (node.attribute_name) {
       case NsiliConstants.CREATOR:
-        metacard.setAttribute(new AttributeImpl(Contact.CREATOR_NAME, getString(node.value)));
+        metacard.setAttribute(new AttributeImpl(Isr.ORGANIZATIONAL_UNIT, getString(node.value)));
         break;
       case NsiliConstants.DATE_TIME_DECLARED:
         metacard.setCreatedDate(CorbaUtils.convertDate(node.value));

--- a/catalog/nsili/catalog-nsili-transformer/src/test/java/org/codice/alliance/nsili/transformer/DAGConverterTest.java
+++ b/catalog/nsili/catalog-nsili-transformer/src/test/java/org/codice/alliance/nsili/transformer/DAGConverterTest.java
@@ -34,7 +34,6 @@ import ddf.catalog.data.impl.types.ContactAttributes;
 import ddf.catalog.data.impl.types.DateTimeAttributes;
 import ddf.catalog.data.impl.types.LocationAttributes;
 import ddf.catalog.data.types.Associations;
-import ddf.catalog.data.types.Contact;
 import ddf.catalog.data.types.Core;
 import ddf.catalog.data.types.DateTime;
 import ddf.catalog.data.types.Location;
@@ -436,7 +435,7 @@ public class DAGConverterTest {
   }
 
   private void checkStreamAttributes(MetacardImpl metacard) {
-    Attribute creatorAttr = metacard.getAttribute(Contact.CREATOR_NAME);
+    Attribute creatorAttr = metacard.getAttribute(Isr.ORGANIZATIONAL_UNIT);
     assertThat(creatorAttr, notNullValue());
     assertThat(creatorAttr.getValue().toString(), is(STREAM_CREATOR));
 


### PR DESCRIPTION
…ational-unit

#### What does this PR do?
The NSIL transformer code maps NSIL_STREAM.creator and NSIL_FILE.creator to contact.creator-name. The NSIL spec aliases this to STANAG 4545 originating station ID (OSTAID) and provides the following description:

> An entity primarily responsible for making the content of the resource. Creator is responsible for the intellectual or creative content of the resource. With raw sensor products a creator is the unit that runs the sensor. With exploited products it is the exploitation station, with an Information Request (IR) it is an IR Management system/service

This PR updates these NSIL fields to map to isr.organizational-unit

#### Who is reviewing it? 
@troymohl 

#### Choose 2 committers to review/merge the PR.
@beyelerb 
@bdeining 

#### How should this be tested?
Verify successful full build.

#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-368](https://codice.atlassian.net/browse/CAL-xxx)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
