### PR TITLE
CAL-351 Update sonar exclusion pattern to improve coverage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,6 +20,7 @@ pipeline {
         POMFIX = 'libs/pom-fix-run'
         LARGE_MVN_OPTS = '-Xmx8192M -Xss128M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC '
         LINUX_MVN_RANDOM = '-Djava.security.egd=file:/dev/./urandom'
+        COVERAGE_EXCLUSIONS = '**/test/**,**/itests/**,**/*Test*,**/sdk/**,**/*.js,**/node_modules/**,**/jaxb/,**/wsdl/,**/nces/sws/**,**/*.adoc,**/*.txt,**/*.xml'
     }
     stages {
         stage('Setup') {
@@ -200,10 +201,10 @@ pipeline {
                                     script {
                                         // If this build is not a pull request, run sonar scan. otherwise run incremental scan
                                         if (env.CHANGE_ID == null) {
-                                            sh 'mvn -q -B -Dfindbugs.skip=true -Dcheckstyle.skip=true org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.host.url=https://sonarqube.com -Dsonar.login=$SONAR_TOKEN  -Dsonar.organization=codice -Dsonar.projectKey=org.codice.alliance -pl !$DOCS,!$ITESTS'
+                                            sh 'mvn -q -B -Dfindbugs.skip=true -Dcheckstyle.skip=true org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.host.url=https://sonarqube.com -Dsonar.login=$SONAR_TOKEN  -Dsonar.organization=codice -Dsonar.projectKey=org.codice.alliance -Dsonar.coverage.exclusions=$COVERAGE_EXCLUSIONS -pl !$DOCS,!$ITESTS'
                                         } else {
                                             echo "Currently Sonar is not run for pull requests"
-                                            // sh 'mvn -q -B -Dfindbugs.skip=true -Dcheckstyle.skip=true org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.github.pullRequest=${CHANGE_ID} -Dsonar.github.oauth=${SONARQUBE_GITHUB_TOKEN} -Dsonar.analysis.mode=preview -Dsonar.host.url=https://sonarqube.com -Dsonar.login=$SONAR_TOKEN  -Dsonar.organization=codice -Dsonar.projectKey=org.codice.alliance -pl !$DOCS,!$ITESTS -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/$CHANGE_TARGET'
+                                            // sh 'mvn -q -B -Dfindbugs.skip=true -Dcheckstyle.skip=true org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.github.pullRequest=${CHANGE_ID} -Dsonar.github.oauth=${SONARQUBE_GITHUB_TOKEN} -Dsonar.analysis.mode=preview -Dsonar.host.url=https://sonarqube.com -Dsonar.login=$SONAR_TOKEN  -Dsonar.organization=codice -Dsonar.projectKey=org.codice.alliance -Dsonar.coverage.exclusions=$COVERAGE_EXCLUSIONS -pl !$DOCS,!$ITESTS -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/$CHANGE_TARGET'
                                         }
                                     }
                                 }


### PR DESCRIPTION
#### What does this PR do?
Updating the sonar coverage exclusion helps improve coverage by avoiding files that should not be analyzed by sonarqube. This includes .adoc .js .xml as well as JAXB and WSDL directories. 

#### Who is reviewing it? 
@oconnormi @vinamartin 

#### Select relevant component teams: 
@codice/build 

#### Choose 2 committers to review/merge the PR. 
@clockard @lessarderic @shaundmorris 

#### How should this be tested? (List steps with links to updated documentation)
This exclusion pattern can be seen in the locally running/succeeding DDF sonar job.

#### Any background context you want to provide?
On DDF, this pattern helped improve the coverage from 48% to 63%.

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
