### PR TITLE
CAL-372 Security Marking parser support for U//FOUO data

### DIFF
--- a/catalog/security/banner-marking/src/main/java/org/codice/alliance/security/banner/marking/BannerMarkings.java
+++ b/catalog/security/banner-marking/src/main/java/org/codice/alliance/security/banner/marking/BannerMarkings.java
@@ -68,6 +68,10 @@ public class BannerMarkings implements Serializable {
     public static ClassificationLevel lookup(String name) {
       return LOOKUP_MAP.get(name);
     }
+
+    public static ClassificationLevel lookupByShortname(String name) {
+      return SHORTNAME_LOOKUP.get(name);
+    }
   }
 
   enum MarkingType {
@@ -84,6 +88,7 @@ public class BannerMarkings implements Serializable {
     FISA("FISA", "FOREIGN INTELLIGENCE SURVEILLANCE ACT"),
     ORCON("ORCON", "ORIGINATOR CONTROLLED"),
     DEA_SENSITIVE("DEA SENSITIVE"),
+    FOUO("FOUO", "FOR OFFICIAL USE ONLY"),
     WAIVED("WAIVED");
 
     private String name;
@@ -107,7 +112,7 @@ public class BannerMarkings implements Serializable {
     }
   }
 
-  enum OtherDissemControl {
+  public enum OtherDissemControl {
     ACCM("ACCM"),
     EXDIS("EXDIS", "EXCLUSIVE DISTRIBUTION"),
     LIMDIS("LIMDIS", "LIMITED DISTRIBUTION"),
@@ -361,7 +366,10 @@ public class BannerMarkings implements Serializable {
       case US:
         classification = ClassificationLevel.lookup(classificationSegment);
         if (classification == null) {
-          throw new MarkingsValidationException("Unknown classification marking", inputMarkings);
+          classification = ClassificationLevel.lookupByShortname(classificationSegment);
+          if (classification == null) {
+            throw new MarkingsValidationException("Unknown classification marking", inputMarkings);
+          }
         }
         break;
       case FGI:

--- a/catalog/security/banner-marking/src/test/groovy/org/codice/alliance/security/banner/marking/BannerMarkingsSpec.groovy
+++ b/catalog/security/banner-marking/src/test/groovy/org/codice/alliance/security/banner/marking/BannerMarkingsSpec.groovy
@@ -78,6 +78,15 @@ class BannerMarkingsSpec extends Specification {
         '//JOINT SECRET CAN DEU USA NATO//TK//RELIDO' | SECRET         | ['CAN', 'DEU', 'USA', 'NATO']
     }
 
+    def 'U//FOUO'() {
+        when:
+        def bannerMarkings = BannerMarkings.parseMarkings("U//FOUO")
+
+        then:
+        bannerMarkings.classification == UNCLASSIFIED
+        bannerMarkings.disseminationControls.contains(FOUO)
+    }
+
     def 'test sci controls only'() {
         when:
         def bannerMarkings = BannerMarkings.parseMarkings(markings)


### PR DESCRIPTION
#### What does this PR do?
Adds support for parsing U//FOUO in the BannerMarkings parser.

#### Who is reviewing it? 
@bdeining 
@glenhein 

#### Choose 2 committers to review/merge the PR.
(please choose ONLY two committers from below, delete the rest)
@coyotesqrl
@stustison

#### How should this be tested?
Full build with tests. 

#### Any background context you want to provide?

#### What are the relevant tickets?
[CAL-372](https://codice.atlassian.net/browse/CAL-372)

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
