### PR TITLE
[0.3.x] CAL-374 Added findbugs dependency at provided scope

### DIFF
--- a/libs/klv/pom.xml
+++ b/libs/klv/pom.xml
@@ -119,6 +119,12 @@
             <version>${project.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>${findbugs.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <karaf.version>4.1.2</karaf.version>
         <commons-lang.version>2.6</commons-lang.version>
         <commons-io.version>2.5</commons-io.version>
+        <findbugs.version>3.0.1</findbugs.version>
         <guava.version>18.0</guava.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>1.5.6</asciidoctor.maven.plugin.version>


### PR DESCRIPTION
#### What does this PR do?
This PR addresses CVE-2010-0538 by adding findbugs dependency at provided scope instead of relying on transient dependencies which will be also removed in DDF for the same reason.

#### Who is reviewing it? 
@tbatie 
@emanns95 

#### Choose 2 committers to review/merge the PR.
@clockard
@coyotesqrl
@figliold

#### How should this be tested?
Run OWASP using `mvn clean install -Powasp -DskipStatic=true -DwebBuildEnv=dev -DskipTests=true` and check report.

#### Any background context you want to provide?
#### What are the relevant tickets?
[CAL-374](https://codice.atlassian.net/browse/CAL-374)
[DDF-3446](https://codice.atlassian.net/browse/DDF-3446)

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
