### PR TITLE
CAL-351 Update Jenkinsfile maven commands to all run in batch-mode

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ pipeline {
                     checkout scm
                 }
                 withMaven(maven: 'M3', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LINUX_MVN_RANDOM}') {
-                    sh 'mvn clean install -DskipStatic=true -DskipTests=true -pl $POMFIX'
+                    sh 'mvn clean install -DskipStatic=true -DskipTests=true -B -pl $POMFIX'
                 }
             }
         }
@@ -59,7 +59,7 @@ pipeline {
                             timeout(time: 1, unit: 'HOURS') {
                                 // TODO: Maven downgraded to work around a linux build issue. Falling back to system java to work around a linux build issue. re-investigate upgrading later
                                 withMaven(maven: 'Maven 3.3.9', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}', options: [artifactsPublisher(disabled: true), dependenciesFingerprintPublisher(disabled: true, includeScopeCompile: false, includeScopeProvided: false, includeScopeRuntime: false, includeSnapshotVersions: false)]) {
-                                    sh 'mvn install -pl !$DOCS -DskipStatic=true -DskipTests=true -T 1C'
+                                    sh 'mvn install -B -pl !$DOCS -DskipStatic=true -DskipTests=true -T 1C'
                                     sh 'mvn clean install -B -T 1C -pl !$ITESTS -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/$CHANGE_TARGET'
                                     sh 'mvn install -B -pl $ITESTS -nsu'
                                 }
@@ -74,7 +74,7 @@ pipeline {
                             }
                             timeout(time: 1, unit: 'HOURS') {
                                 withMaven(maven: 'M35', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS}', options: [artifactsPublisher(disabled: true), dependenciesFingerprintPublisher(disabled: true, includeScopeCompile: false, includeScopeProvided: false, includeScopeRuntime: false, includeSnapshotVersions: false)]) {
-                                    bat 'mvn install -pl !%DOCS% -DskipStatic=true -DskipTests=true -T 1C'
+                                    bat 'mvn install -B -pl !%DOCS% -DskipStatic=true -DskipTests=true -T 1C'
                                     bat 'mvn clean install -B -T 1C -pl !%ITESTS% -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/%CHANGE_TARGET%'
                                     bat 'mvn install -B -pl %ITESTS% -nsu'
                                 }
@@ -183,8 +183,8 @@ pipeline {
                     retry(3) {
                         checkout scm
                     }
-                    sh 'mvn javadoc:aggregate -DskipStatic=true -DskipTests=true'
-                    sh 'mvn deploy -T 1C -DskipStatic=true -DskipTests=true -DretryFailedDeploymentCount=10'
+                    sh 'mvn javadoc:aggregate -B -DskipStatic=true -DskipTests=true'
+                    sh 'mvn deploy -B -T 1C -DskipStatic=true -DskipTests=true -DretryFailedDeploymentCount=10'
                 }
             }
         }
@@ -225,7 +225,7 @@ pipeline {
                                         withCredentials([string(credentialsId: 'alliance-coverity-token', variable: 'COVERITY_TOKEN')]) {
                                             withEnv(["PATH=${tool 'coverity-linux'}/bin:${env.PATH}"]) {
                                                 configFileProvider([configFile(fileId: 'coverity-maven-settings', replaceTokens: true, variable: 'MAVEN_SETTINGS')]) {
-                                                    sh 'cov-build --dir cov-int mvn -DskipTests=true -DskipStatic=true install -pl !$DOCS --settings $MAVEN_SETTINGS'
+                                                    sh 'cov-build --dir cov-int mvn -DskipTests=true -DskipStatic=true install -B -pl !$DOCS --settings $MAVEN_SETTINGS'
                                                     sh 'tar czvf alliance.tgz cov-int'
                                                     sh 'curl --form token=$COVERITY_TOKEN --form email=cmp-security-team@connexta.com --form file=@alliance.tgz --form version="master" --form description="Description: Alliance CI Build" https://scan.coverity.com/builds?project=codice%2Falliance'
                                                 }


### PR DESCRIPTION
#### What does this PR do?
Several maven commands in the Jenkinsfile were not being run in batch-mode. This change updates them all for consistency. This also should reduce log output and size.

#### Who is reviewing it? 
@mackncheesiest @LinkMJB @oconnormi 

#### Select relevant component teams: 
@codice/build 

#### Choose 2 committers to review/merge the PR. 
@clockard @shaundmorris

#### Any background context you want to provide?
Adding this `-B` to the other maven commands greatly reduced log size.

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.