### PR TITLE
CAL-377 Exclude Branding.txt from DDF when building the distro

### DIFF
--- a/distribution/common/src/main/resources/common-bin.xml
+++ b/distribution/common/src/main/resources/common-bin.xml
@@ -29,6 +29,7 @@
                 <!-- Karaf comes with a README in deploy folder which throws warnings in log -->
                 <exclude>deploy/*</exclude>
                 <exclude>Version.txt</exclude>
+                <exclude>Branding.txt</exclude>
                 <!-- All Karaf distributions take out the extra files when being distributed -->
                 <exclude>LICENSE</exclude>
                 <exclude>NOTICE</exclude>
@@ -110,6 +111,16 @@
             <directory>${setup.folder}</directory>
             <includes>
                 <include>Version.txt</include>
+            </includes>
+            <outputDirectory>/</outputDirectory>
+            <fileMode>0644</fileMode>
+        </fileSet>
+
+        <!-- Branding.txt -->
+        <fileSet>
+            <directory>${setup.folder}</directory>
+            <includes>
+                <include>Branding.txt</include>
             </includes>
             <outputDirectory>/</outputDirectory>
             <fileMode>0644</fileMode>


### PR DESCRIPTION
#### **Release PR: [PR 457](https://github.com/codice/alliance/pull/457)**

#### What does this PR do?
It excludes the Branding.txt file from DDF when building the distro.
#### Who is reviewing it? 
@emanns95 
@tbatie 
@Lambeaux 
#### Choose 2 committers to review/merge the PR.
@clockard
@figliold
#### How should this be tested?
Build and unzip the distro. Verify that the Branding.txt file at the root says Alliance.
#### Any background context you want to provide?
#### What are the relevant tickets?
[CAL-377](https://codice.atlassian.net/browse/CAL-377)
[DDF-3447](https://codice.atlassian.net/browse/DDF-3447)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
