### PR TITLE
CAL-373 Removes OWASP suppression for Solr 6.6.1

### DIFF
--- a/dependency-check-maven-config.xml
+++ b/dependency-check-maven-config.xml
@@ -542,14 +542,6 @@
         </notes>
         <cve>CVE-2016-8739</cve>
     </suppress>
-    <!-- Remove this suppression when DDF-3440 is worked -->
-    <suppress>
-        <notes>
-            This suppression is to remove a Solr 6.6.1 CVE. The suggested workaround has be put in
-            place until Solr is upgraded.
-        </notes>
-        <cve>CVE-2017-12629</cve>
-    </suppress>
     <suppress>
         <notes>
             This CVE is related to hash collisions at the Java level. This is mitigated by newer versions of Java (8+).


### PR DESCRIPTION
#### What does this PR do?
Reverts this PR https://github.com/codice/alliance/pull/451 based on the Solr 6.6.2 upgrade (https://github.com/codice/ddf/pull/2698)

#### Who is reviewing it? 
@brjeter @mcalcote 

#### Choose 2 committers to review/merge the PR.
@coyotesqrl
@figliold

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
