### PR TITLE
[0.3.x]CAL-380 Suppressed warning for Xerces OWASP finding (#464)

### DIFF
--- a/dependency-check-maven-config.xml
+++ b/dependency-check-maven-config.xml
@@ -550,4 +550,12 @@
         </notes>
         <cve>CVE-2017-12629</cve>
     </suppress>
+    <suppress>
+        <notes>
+            This CVE is related to hash collisions at the Java level. This is mitigated by newer versions of Java (8+).
+            See http://openjdk.java.net/jeps/180 for more information.
+            xercesImpl-2.11.0.jar
+        </notes>
+        <cve>CVE-2012-0881</cve>
+    </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -351,7 +351,7 @@
                 <plugin>
                     <groupId>com.github.eirslett</groupId>
                     <artifactId>frontend-maven-plugin</artifactId>
-                    <version>1.4.CODICE_1</version>
+                    <version>1.6.CODICE</version>
                     <executions>
                         <execution>
                             <id>install node and yarn</id>


### PR DESCRIPTION
Backport for https://github.com/codice/alliance/pull/464
#### What does this PR do?
Suppresses the Xerces warning since it does not apply to Alliance.
#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)
@emmberk @mcalcote @vinamartin 
#### Choose 2 committers to review/merge the PR.
(please choose ONLY two committers from below, delete the rest)
@coyotesqrl 
@shaundmorris
#### How should this be tested?
#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-380](https://codice.atlassian.net/browse/CAL-380)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
