### PR TITLE
[0.3.x] CAL-382 Convert NITF digraphs to trigraphs

### DIFF
--- a/catalog/imaging/imaging-transformer-nitf/pom.xml
+++ b/catalog/imaging/imaging-transformer-nitf/pom.xml
@@ -113,6 +113,12 @@
             <version>${jpeg2000.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.neovisionaries</groupId>
+            <artifactId>nv-i18n</artifactId>
+            <version>1.21</version>
+        </dependency>
+
         <!--Spock dependencies-->
         <dependency>
             <groupId>ddf.lib</groupId>

--- a/catalog/imaging/imaging-transformer-nitf/pom.xml
+++ b/catalog/imaging/imaging-transformer-nitf/pom.xml
@@ -113,12 +113,6 @@
             <version>${jpeg2000.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>com.neovisionaries</groupId>
-            <artifactId>nv-i18n</artifactId>
-            <version>1.21</version>
-        </dependency>
-
         <!--Spock dependencies-->
         <dependency>
             <groupId>ddf.lib</groupId>

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/SegmentHandler.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/SegmentHandler.java
@@ -14,7 +14,6 @@
 package org.codice.alliance.transformer.nitf.common;
 
 import com.google.common.collect.ImmutableSet;
-import com.neovisionaries.i18n.CountryCode;
 import ddf.catalog.data.Attribute;
 import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
@@ -24,6 +23,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
+import java.util.MissingResourceException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -114,10 +115,14 @@ public class SegmentHandler {
     // check if country code
     if (COUNTRY_CODE_ATTRIBUTES.contains(attributeName)) {
       List<Serializable> alpha3CountryCodes = new ArrayList<>();
-      String[] tokenizedCountryCodes = ((String) value).split(" ");
+      String[] tokenizedCountryCodes = value.toString().split(" ");
 
       for (String countryCode : tokenizedCountryCodes) {
-        alpha3CountryCodes.add(CountryCode.getByCode(countryCode).getAlpha3());
+        try {
+          alpha3CountryCodes.add((new Locale("", countryCode)).getISO3Country());
+        } catch (MissingResourceException mre) {
+          LOGGER.debug("Could not convert {} to ISO-3 country code.", countryCode);
+        }
       }
 
       if (currentAttribute == null) {

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/SegmentHandlerTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/SegmentHandlerTest.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.transformer.nitf.common;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import java.util.List;
+import java.util.function.Function;
+import org.codice.alliance.catalog.core.api.impl.types.SecurityAttributes;
+import org.codice.alliance.catalog.core.api.types.Security;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+public class SegmentHandlerTest {
+
+  @Test
+  public void testCountryCodeConversion() {
+    SegmentHandler handler = new SegmentHandler();
+
+    Metacard mockMetacard = mock(Metacard.class);
+    ArgumentCaptor<Attribute> attrCaptor = ArgumentCaptor.forClass(Attribute.class);
+
+    Function mockAccessor = mock(Function.class);
+    doReturn("us fr cn").when(mockAccessor).apply(anyObject());
+
+    NitfAttribute mockNitfAttr = mock(NitfAttribute.class);
+    doReturn(mockAccessor).when(mockNitfAttr).getAccessorFunction();
+    doReturn(
+            ImmutableSet.of(
+                (new SecurityAttributes()).getAttributeDescriptor(Security.OWNER_PRODUCER)))
+        .when(mockNitfAttr)
+        .getAttributeDescriptors();
+
+    handler.handleSegmentHeader(mockMetacard, null, ImmutableList.of(mockNitfAttr));
+    verify(mockMetacard).setAttribute(attrCaptor.capture());
+
+    List<String> expectedCC = ImmutableList.of("USA", "FRA", "CHN");
+    for (Attribute attr : attrCaptor.getAllValues()) {
+      assertThat(
+          "Not all digraphs were properly converted.",
+          expectedCC.contains(attr.getValue()),
+          is(true));
+    }
+  }
+}


### PR DESCRIPTION
#### What does this PR do?
Converts NITF digraphs to trigraphs when storing on the catalog taxonomy attributes to be more consistent with the rest of the system.

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)
@paouelle 
@vinamartin 
@emmberk 

#### Choose 2 committers to review/merge the PR.
(please choose ONLY two committers from below, delete the rest)
@clockard
@lessarderic

#### How should this be tested?
1. Ingest a NITF with digraphs (two letters) for country codes (like owner producer or releasability)
2. Inspect metacard and see that they have been converted to trigraphs (three letters) for Security.OWNER_PRODUCER and Security.RELEASABILITY

#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-382](https://codice.atlassian.net/browse/CAL-382)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
