### PR TITLE
[0.3.x] CAL-383 Removed hardcoded admin console link on console

### DIFF
--- a/distribution/console-branding/src/main/resources/org/apache/karaf/branding/branding.properties
+++ b/distribution/console-branding/src/main/resources/org/apache/karaf/branding/branding.properties
@@ -22,8 +22,6 @@ welcome = \
 Hit '\u001B[1m<tab>\u001B[0m' for a list of available commands\n\
 and '\u001B[1m[cmd] --help\u001B[0m' for help on a specific command.\n\
 \n\
-Open a browser to https://localhost:8993/admin to access the Admin Console.\n\
-\n\
 Hit '<ctrl-d>' or 'shutdown' to shutdown Codice Alliance.\n
 
 prompt = \u001B[1malliance@local\u001B[0m>


### PR DESCRIPTION
#### What does this PR do?
Removes hardcoded admin console link on console.

#### Who is reviewing it? 
@emanns95
@tbatie
@djblue

#### Choose 2 committers to review/merge the PR.
@clockard
@figliold
@ricklarsen - Documentation

#### How should this be tested?
Unzip distro and check console, it should no longer show `Open a browser to https://localhost:8993/admin to access the Admin Console.`

#### Any background context you want to provide?
#### What are the relevant tickets?
[CAL-383](https://codice.atlassian.net/browse/CAL-383)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
