### PR TITLE
CAL-389 Ensure that inputstream is closed in CatalogOutputAdapter

### DIFF
--- a/catalog/imaging/imaging-transformer-chipping/src/main/java/org/codice/alliance/imaging/chip/transformer/CatalogOutputAdapter.java
+++ b/catalog/imaging/imaging-transformer-chipping/src/main/java/org/codice/alliance/imaging/chip/transformer/CatalogOutputAdapter.java
@@ -130,13 +130,14 @@ public class CatalogOutputAdapter {
   public BufferedImage getImage(ResourceResponse resourceResponse) throws IOException {
     validateArgument(resourceResponse, "resourceResponse");
     validateArgument(resourceResponse.getResource(), "resourceResponse.resource");
-    validateObjectState(
-        resourceResponse.getResource().getInputStream(), "resourceResponse.resource.inputStream");
+    try (InputStream resourceStream = resourceResponse.getResource().getInputStream()) {
+      validateObjectState(resourceStream, "resourceResponse.resource.inputStream");
 
-    Resource resource = resourceResponse.getResource();
-    try (InputStream inputStream = resource.getInputStream();
-        BufferedInputStream bufferedInputStream = new BufferedInputStream(inputStream)) {
-      return ImageIO.read(bufferedInputStream);
+      Resource resource = resourceResponse.getResource();
+      try (InputStream inputStream = resource.getInputStream();
+          BufferedInputStream bufferedInputStream = new BufferedInputStream(inputStream)) {
+        return ImageIO.read(bufferedInputStream);
+      }
     }
   }
 
@@ -562,11 +563,13 @@ public class CatalogOutputAdapter {
   }
 
   private void logImageCoordinatePair(String prefix, ImageCoordinatePair imageCoordinatePair) {
-    LOGGER.debug(
-        "{} - (lon,lat) {}",
-        prefix,
-        String.format(
-            "%.5f,%.5f", imageCoordinatePair.getLongitude(), imageCoordinatePair.getLatitude()));
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug(
+          "{} - (lon,lat) {}",
+          prefix,
+          String.format(
+              "%.5f,%.5f", imageCoordinatePair.getLongitude(), imageCoordinatePair.getLatitude()));
+    }
   }
 
   private void logVectors(String prefix, List<Vector> vectors) {


### PR DESCRIPTION
#### What does this PR do?
Closes an input stream in `CatalogOutputAdapter` and fixed a SonarQube finding

#### Who is reviewing it? 
@brjeter @idperez 

#### Choose 2 committers to review/merge the PR.
@coyotesqrl
@rzwiefel

#### How should this be tested?
Full build

#### What are the relevant tickets?
[CAL-389](https://codice.atlassian.net/browse/CAL-389)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
