### PR TITLE
[0.3.x] CAL-392 Suppress 'Downloading/Downloaded' status lines in logs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -178,10 +178,10 @@ pipeline {
                                 script {
                                     // If this build is not a pull request, run sonar scan. otherwise run incremental scan
                                     if (env.CHANGE_ID == null) {
-                                        sh 'mvn -q -B -Dcheckstyle.skip=true org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN  -Dsonar.organization=codice -Dsonar.projectKey=org.codice.alliance -Dsonar.exclusions=${COVERAGE_EXCLUSIONS} -pl !$DOCS,!$ITESTS $DISABLE_DOWNLOAD_PROGRESS_OPTS'
+                                        sh 'mvn -q -B -Dcheckstyle.skip=true org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN  -Dsonar.organization=codice -Dsonar.projectKey=org.codice:alliance -Dsonar.exclusions=${COVERAGE_EXCLUSIONS} -pl !$DOCS,!$ITESTS $DISABLE_DOWNLOAD_PROGRESS_OPTS'
                                     } else {
                                         echo "Currently Sonar is not run for pull requests"
-                                        // sh 'mvn -q -B -Dcheckstyle.skip=true org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.github.pullRequest=${CHANGE_ID} -Dsonar.github.oauth=${SONARQUBE_GITHUB_TOKEN} -Dsonar.analysis.mode=preview -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN  -Dsonar.organization=codice -Dsonar.projectKey=org.codice.alliance -Dsonar.exclusions=${COVERAGE_EXCLUSIONS} -pl !$DOCS,!$ITESTS -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/$CHANGE_TARGET $DISABLE_DOWNLOAD_PROGRESS_OPTS'
+                                        // sh 'mvn -q -B -Dcheckstyle.skip=true org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.github.pullRequest=${CHANGE_ID} -Dsonar.github.oauth=${SONARQUBE_GITHUB_TOKEN} -Dsonar.analysis.mode=preview -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN  -Dsonar.organization=codice -Dsonar.projectKey=org.codice:alliance -Dsonar.exclusions=${COVERAGE_EXCLUSIONS} -pl !$DOCS,!$ITESTS -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/$CHANGE_TARGET $DISABLE_DOWNLOAD_PROGRESS_OPTS'
                                     }
                                 }
                             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,12 @@
 //"Jenkins Pipeline is a suite of plugins which supports implementing and integrating continuous delivery pipelines into Jenkins. Pipeline provides an extensible set of tools for modeling delivery pipelines "as code" via the Pipeline DSL."
 //More information can be found on the Jenkins Documentation page https://jenkins.io/doc/
 pipeline {
-    agent none
+    agent { label 'linux-large' }
     options {
         buildDiscarder(logRotator(numToKeepStr: '25'))
         disableConcurrentBuilds()
         timestamps()
+        skipDefaultCheckout()
     }
     triggers {
         /*
@@ -19,7 +20,9 @@ pipeline {
         ITESTS = 'distribution/test/itests/test-itests-alliance'
         POMFIX = 'libs/pom-fix-run'
         LARGE_MVN_OPTS = '-Xmx8192M -Xss128M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC '
+        DISABLE_DOWNLOAD_PROGRESS_OPTS = '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn '
         LINUX_MVN_RANDOM = '-Djava.security.egd=file:/dev/./urandom'
+        COVERAGE_EXCLUSIONS = '**/test/**/*,**/itests/**/*,**/*Test*,**/sdk/**/*,**/*.js,**/node_modules/**/*,**/jaxb/**/*,**/wsdl/**/*,**/nces/sws/**/*,**/*.adoc,**/*.txt,**/*.xml'
     }
     stages {
         stage('Setup') {
@@ -29,13 +32,12 @@ pipeline {
         }
         // Use the pomfix tool to validate that bundle dependencies are properly declared
         stage('Validate Poms') {
-            agent { label 'linux-small' }
             steps {
                 retry(3) {
                     checkout scm
                 }
                 withMaven(maven: 'M3', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LINUX_MVN_RANDOM}') {
-                    sh 'mvn clean install -DskipStatic=true -DskipTests=true -pl $POMFIX'
+                    sh 'mvn clean install -DskipStatic=true -DskipTests=true -B -pl $POMFIX $DISABLE_DOWNLOAD_PROGRESS_OPTS'
                 }
             }
         }
@@ -47,121 +49,105 @@ pipeline {
                     expression { env.CHANGE_TARGET != null }
                 }
             }
-            // TODO CAL-296 refactor this stage from scripted syntax to declarative syntax to match the rest of the stages - https://issues.jenkins-ci.org/browse/JENKINS-41334
-            steps {
-                parallel(
-                    linux: {
-                        node('linux-large') {
-                            retry(3) {
-                                checkout scm
-                            }
-                            timeout(time: 1, unit: 'HOURS') {
-                                // TODO: Maven downgraded to work around a linux build issue. Falling back to system java to work around a linux build issue. re-investigate upgrading later
-                                withMaven(maven: 'Maven 3.3.9', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}', options: [artifactsPublisher(disabled: true), dependenciesFingerprintPublisher(disabled: true, includeScopeCompile: false, includeScopeProvided: false, includeScopeRuntime: false, includeSnapshotVersions: false)]) {
-                                    sh 'mvn install -pl !$DOCS -DskipStatic=true -DskipTests=true -T 1C'
-                                    sh 'mvn clean install -B -T 1C -pl !$ITESTS -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/$CHANGE_TARGET'
-                                    sh 'mvn install -B -pl $ITESTS -nsu'
-                                }
-                            }
-                        }
-                    },
-                    windows: {
-                        node('proxmox-windows') {
-                            bat 'git config --system core.longpaths true'
-                            retry(3) {
-                                checkout scm
-                            }
-                            timeout(time: 1, unit: 'HOURS') {
-                                withMaven(maven: 'M35', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS}', options: [artifactsPublisher(disabled: true), dependenciesFingerprintPublisher(disabled: true, includeScopeCompile: false, includeScopeProvided: false, includeScopeRuntime: false, includeSnapshotVersions: false)]) {
-                                    bat 'mvn install -pl !%DOCS% -DskipStatic=true -DskipTests=true -T 1C'
-                                    bat 'mvn clean install -B -T 1C -pl !%ITESTS% -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/%CHANGE_TARGET%'
-                                    bat 'mvn install -B -pl %ITESTS% -nsu'
-                                }
+            parallel {
+                stage ('Linux') {
+                    steps {
+                        timeout(time: 1, unit: 'HOURS') {
+                            // TODO: Maven downgraded to work around a linux build issue. Falling back to system java to work around a linux build issue. re-investigate upgrading later
+                            withMaven(maven: 'Maven 3.3.9', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}', options: [artifactsPublisher(disabled: true), dependenciesFingerprintPublisher(disabled: true, includeScopeCompile: false, includeScopeProvided: false, includeScopeRuntime: false, includeSnapshotVersions: false)]) {
+                                sh 'mvn install -B -pl !$DOCS -DskipStatic=true -DskipTests=true $DISABLE_DOWNLOAD_PROGRESS_OPTS -T 1C'
+                                sh 'mvn clean install -B -T 1C -pl !$ITESTS -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/$CHANGE_TARGET $DISABLE_DOWNLOAD_PROGRESS_OPTS'
+                                sh 'mvn install -B -pl $ITESTS -nsu $DISABLE_DOWNLOAD_PROGRESS_OPTS'
                             }
                         }
                     }
-                )
+                }
+                stage ('Windows') {
+                    agent { label 'server-2016-large' }
+                    steps {
+                        retry(3) {
+                            checkout scm
+                        }
+                        timeout(time: 1, unit: 'HOURS') {
+                            withMaven(maven: 'M35', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS}', options: [artifactsPublisher(disabled: true), dependenciesFingerprintPublisher(disabled: true, includeScopeCompile: false, includeScopeProvided: false, includeScopeRuntime: false, includeSnapshotVersions: false)]) {
+                                bat 'mvn install -B -pl !%DOCS% -DskipStatic=true -DskipTests=true $DISABLE_DOWNLOAD_PROGRESS_OPTS -T 1C'
+                                bat 'mvn clean install -B -T 1C -pl !%ITESTS% -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/%CHANGE_TARGET% %DISABLE_DOWNLOAD_PROGRESS_OPTS%'
+                                bat 'mvn install -B -pl %ITESTS% -nsu %DISABLE_DOWNLOAD_PROGRESS_OPTS%'
+                            }
+                        }
+                    }
+                }
             }
         }
         // The full build will be run against all regular branches
         stage('Full Build') {
             when { expression { env.CHANGE_ID == null } }
-            // TODO CAL-296 refactor this stage from scripted syntax to declarative syntax to match the rest of the stages - https://issues.jenkins-ci.org/browse/JENKINS-41334
-            steps{
-                parallel(
-                    linux: {
-                        node('linux-large') {
-                            retry(3) {
-                                checkout scm
-                            }
-                            timeout(time: 1, unit: 'HOURS') {
-                                // TODO: Maven downgraded to work around a linux build issue. Falling back to system java to work around a linux build issue. re-investigate upgrading later
-                                withMaven(maven: 'Maven 3.3.9', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}') {
-                                    sh 'mvn clean install -B -T 1C -pl !$ITESTS'
-                                    sh 'mvn install -B -pl $ITESTS -nsu'
-                                }
+            parallel {
+                stage ('Linux') {
+                    steps {
+                        timeout(time: 1, unit: 'HOURS') {
+                            // TODO: Maven downgraded to work around a linux build issue. Falling back to system java to work around a linux build issue. re-investigate upgrading later
+                            withMaven(maven: 'Maven 3.3.9', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}') {
+                                sh 'mvn clean install -B -T 1C -pl !$ITESTS $DISABLE_DOWNLOAD_PROGRESS_OPTS'
+                                sh 'mvn install -B -pl $ITESTS -nsu $DISABLE_DOWNLOAD_PROGRESS_OPTS'
                             }
                         }
-                    },
-                    windows: {
-                        node('proxmox-windows') {
-                            bat 'git config --system core.longpaths true'
-                            retry(3) {
-                                checkout scm
+                    }
+                }
+                stage ('Windows') {
+                    agent { label 'server-2016-large' }
+                    steps {
+                        retry(3) {
+                            checkout scm
+                        }
+                        timeout(time: 1, unit: 'HOURS') {
+                            withMaven(maven: 'M35', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS}') {
+                                bat 'mvn clean install -B -T 1C -pl !%ITESTS% %DISABLE_DOWNLOAD_PROGRESS_OPTS%'
+                                bat 'mvn install -B -pl %ITESTS% -nsu %DISABLE_DOWNLOAD_PROGRESS_OPTS%'
                             }
-                            timeout(time: 1, unit: 'HOURS') {
-                                withMaven(maven: 'M35', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS}') {
-                                    bat 'mvn clean install -B -T 1C -pl !%ITESTS%'
-                                    bat 'mvn install -B -pl %ITESTS% -nsu'
+                        }
+                    }
+                }
+            }
+        }
+        stage('Security Analysis') {
+            parallel {
+                stage ('Owasp') {
+                    steps {
+                        withMaven(maven: 'M35', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}') {
+                            script {
+                                // If this build is not a pull request, run full owasp scan. Otherwise run incremental scan
+                                if (env.CHANGE_ID == null) {
+                                    sh 'mvn install -q -B -Powasp -DskipTests=true -DskipStatic=true -pl !$DOCS $DISABLE_DOWNLOAD_PROGRESS_OPTS'
+                                } else {
+                                    sh 'mvn install -q -B -Powasp -DskipTests=true -DskipStatic=true -pl !$DOCS -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/$CHANGE_TARGET $DISABLE_DOWNLOAD_PROGRESS_OPTS'
                                 }
                             }
                         }
                     }
-                )
-            }
-        }
-        stage('Security Analysis') {
-            steps {
-                parallel(
-                    owasp: {
-                        node('linux-large') {
-                            retry(3) {
-                                checkout scm
-                            }
-                            withMaven(maven: 'M35', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}') {
-                                script {
-                                    // If this build is not a pull request, run full owasp scan. Otherwise run incremntal scan
-                                    if (env.CHANGE_ID == null) {
-                                        sh 'mvn install -q -B -Powasp -DskipTests=true -DskipStatic=true -pl !$DOCS'
-                                    } else {
-                                        sh 'mvn install -q -B -Powasp -DskipTests=true -DskipStatic=true -pl !$DOCS -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/$CHANGE_TARGET'
-                                    }
-                                }
-                            }
+                }
+                stage ('NodeJsSecurity') {
+                    agent { label 'linux-small' }
+                    steps {
+                        retry(3) {
+                            checkout scm
                         }
-                    },
-                    nodeJsSecurity: {
-                        node('linux-small') {
-                            retry(3) {
-                                checkout scm
-                            }
-                            script {
-                                def packageFiles = findFiles(glob: '**/package.json')
-                                for (int i = 0; i < packageFiles.size(); i++) {
-                                    dir(packageFiles[i].path.split('package.json')[0]) {
-                                        def packageFile = readJSON file: 'package.json'
-                                        if (packageFile.scripts =~ /.*webpack.*/ || packageFile.containsKey("browserify")) {
-                                            nodejs(configId: 'npmrc-default', nodeJSInstallationName: 'nodejs') {
-                                                echo "Scanning ${packageFiles[i].path}"
-                                                sh 'nsp check'
-                                            }
+                        script {
+                            def packageFiles = findFiles(glob: '**/package.json')
+                            for (int i = 0; i < packageFiles.size(); i++) {
+                                dir(packageFiles[i].path.split('package.json')[0]) {
+                                    def packageFile = readJSON file: 'package.json'
+                                    if (packageFile.scripts =~ /.*webpack.*/ || packageFile.containsKey("browserify")) {
+                                        nodejs(configId: 'npmrc-default', nodeJSInstallationName: 'nodejs') {
+                                            echo "Scanning ${packageFiles[i].path}"
+                                            sh 'nsp check'
                                         }
                                     }
                                 }
                             }
                         }
                     }
-                )
+                }
             }
         }
         /*
@@ -169,7 +155,6 @@ pipeline {
           It will also only deploy in the presence of an environment variable JENKINS_ENV = 'prod'. This can be passed in globally from the jenkins master node settings.
         */
         stage('Deploy') {
-            agent { label 'linux-small' }
             when {
               allOf {
                 expression { env.CHANGE_ID == null }
@@ -179,78 +164,70 @@ pipeline {
             }
             steps {
                 withMaven(maven: 'M3', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LINUX_MVN_RANDOM}') {
-                    retry(3) {
-                        checkout scm
-                    }
-                    sh 'mvn javadoc:aggregate -DskipStatic=true -DskipTests=true'
-                    sh 'mvn deploy -T 1C -DskipStatic=true -DskipTests=true -DretryFailedDeploymentCount=10'
+                    sh 'mvn javadoc:aggregate -B -DskipStatic=true -DskipTests=true $DISABLE_DOWNLOAD_PROGRESS_OPTS'
+                    sh 'mvn deploy -B -T 1C -DskipStatic=true -DskipTests=true -DretryFailedDeploymentCount=10 $DISABLE_DOWNLOAD_PROGRESS_OPTS'
                 }
             }
         }
         stage('Quality Analysis') {
-            steps {
-                parallel(
-                    sonarqube: {
-                        node('linux-large') {
-                            retry(3) {
-                        checkout scm
-                            }
-                            withMaven(maven: 'M35', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}') {
-                                withCredentials([string(credentialsId: 'SonarQubeGithubToken', variable: 'SONARQUBE_GITHUB_TOKEN'), string(credentialsId: 'sonarqube-token', variable: 'SONAR_TOKEN')]) {
-                                    script {
-                                        // If this build is not a pull request, run sonar scan. otherwise run incremental scan
-                                        if (env.CHANGE_ID == null) {
-                                            sh 'mvn -q -B -Dfindbugs.skip=true -Dcheckstyle.skip=true org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.host.url=https://sonarqube.com -Dsonar.login=$SONAR_TOKEN  -Dsonar.organization=codice -Dsonar.projectKey=org.codice.alliance -pl !$DOCS,!$ITESTS'
-                                        } else {
-                                            echo "Currently Sonar is not run for pull requests"
-                                            // sh 'mvn -q -B -Dfindbugs.skip=true -Dcheckstyle.skip=true org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.github.pullRequest=${CHANGE_ID} -Dsonar.github.oauth=${SONARQUBE_GITHUB_TOKEN} -Dsonar.analysis.mode=preview -Dsonar.host.url=https://sonarqube.com -Dsonar.login=$SONAR_TOKEN  -Dsonar.organization=codice -Dsonar.projectKey=org.codice.alliance -pl !$DOCS,!$ITESTS -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/$CHANGE_TARGET'
-                                        }
+            parallel {
+                stage ('SonarCloud') {
+                    steps {
+                        withMaven(maven: 'M35', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}') {
+                            withCredentials([string(credentialsId: 'SonarQubeGithubToken', variable: 'SONARQUBE_GITHUB_TOKEN'), string(credentialsId: 'sonarqube-token', variable: 'SONAR_TOKEN')]) {
+                                script {
+                                    // If this build is not a pull request, run sonar scan. otherwise run incremental scan
+                                    if (env.CHANGE_ID == null) {
+                                        sh 'mvn -q -B -Dcheckstyle.skip=true org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN  -Dsonar.organization=codice -Dsonar.projectKey=org.codice.alliance -Dsonar.exclusions=${COVERAGE_EXCLUSIONS} -pl !$DOCS,!$ITESTS $DISABLE_DOWNLOAD_PROGRESS_OPTS'
+                                    } else {
+                                        echo "Currently Sonar is not run for pull requests"
+                                        // sh 'mvn -q -B -Dcheckstyle.skip=true org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.github.pullRequest=${CHANGE_ID} -Dsonar.github.oauth=${SONARQUBE_GITHUB_TOKEN} -Dsonar.analysis.mode=preview -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN  -Dsonar.organization=codice -Dsonar.projectKey=org.codice.alliance -Dsonar.exclusions=${COVERAGE_EXCLUSIONS} -pl !$DOCS,!$ITESTS -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/$CHANGE_TARGET $DISABLE_DOWNLOAD_PROGRESS_OPTS'
                                     }
                                 }
                             }
                         }
-                    },
-                    // Coverity will be skipped on all PR builds
-                    coverity: {
-                        node('linux-medium') {
-                            script {
-                                if (env.BRANCH_NAME != 'master') {
-                                    echo "Coverity is only run on master"
-                                } else {
-                                    retry(3) {
-                                        checkout scm
-                                    }
-                                    withMaven(maven: 'M35', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LINUX_MVN_RANDOM}') {
-                                        withCredentials([string(credentialsId: 'alliance-coverity-token', variable: 'COVERITY_TOKEN')]) {
-                                            withEnv(["PATH=${tool 'coverity-linux'}/bin:${env.PATH}"]) {
-                                                configFileProvider([configFile(fileId: 'coverity-maven-settings', replaceTokens: true, variable: 'MAVEN_SETTINGS')]) {
-                                                    sh 'cov-build --dir cov-int mvn -DskipTests=true -DskipStatic=true install -pl !$DOCS --settings $MAVEN_SETTINGS'
-                                                    sh 'tar czvf alliance.tgz cov-int'
-                                                    sh 'curl --form token=$COVERITY_TOKEN --form email=cmp-security-team@connexta.com --form file=@alliance.tgz --form version="master" --form description="Description: Alliance CI Build" https://scan.coverity.com/builds?project=codice%2Falliance'
-                                                }
+                    }
+                }
+                // Coverity will be skipped on all PR builds
+                stage ('Coverity') {
+                    agent { label 'linux-medium' }
+                    steps {
+                        retry(3) {
+                            checkout scm
+                        }
+                        script {
+                            if (env.BRANCH_NAME != 'master') {
+                                echo "Coverity is only run on master"
+                            } else {
+                                withMaven(maven: 'M35', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LINUX_MVN_RANDOM}') {
+                                    withCredentials([string(credentialsId: 'alliance-coverity-token', variable: 'COVERITY_TOKEN')]) {
+                                        withEnv(["PATH=${tool 'coverity-linux'}/bin:${env.PATH}"]) {
+                                            configFileProvider([configFile(fileId: 'coverity-maven-settings', replaceTokens: true, variable: 'MAVEN_SETTINGS')]) {
+                                                sh 'cov-build --dir cov-int mvn -DskipTests=true -DskipStatic=true install -B -pl !$DOCS $DISABLE_DOWNLOAD_PROGRESS_OPTS --settings $MAVEN_SETTINGS'
+                                                sh 'tar czvf alliance.tgz cov-int'
+                                                sh 'curl --form token=$COVERITY_TOKEN --form email=cmp-security-team@connexta.com --form file=@alliance.tgz --form version="master" --form description="Description: Alliance CI Build" https://scan.coverity.com/builds?project=codice%2Falliance'
                                             }
                                         }
                                     }
                                 }
                             }
                         }
-                    },
-                    codecov: {
-                        node('linux-large') {
-                            script {
-                                retry(3) {
-                                    checkout scm
-                                }
-                                withMaven(maven: 'M35', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}') {
-                                    withCredentials([string(credentialsId: 'DDF_CodeCov', variable: 'CODECOV_TOKEN')]) {
-                                        sh 'mvn clean install -B -T 1C -pl !$ITESTS'
-                                        sh 'curl -s https://codecov.io/bash | bash -s - -t ${CODECOV_TOKEN}'
-                                    }
-                                }
+                    }
+                }
+                stage ('Codecov') {
+                    agent { label 'linux-small' }
+                    steps {
+                        retry(3) {
+                            checkout scm
+                        }
+                        withMaven(maven: 'M35', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}') {
+                            withCredentials([string(credentialsId: 'Alliance_CodeCov', variable: 'CODECOV_TOKEN')]) {
+                                sh 'mvn clean install -B -T 1C -pl !$ITESTS $DISABLE_DOWNLOAD_PROGRESS_OPTS'
+                                sh 'curl -s https://codecov.io/bash | bash -s - -t ${CODECOV_TOKEN}'
                             }
                         }
                     }
-                )
+                }
             }
         }
     }


### PR DESCRIPTION
#### What does this PR do?
Suppresses lines of the form 
```
18:43:23 [INFO] Downloading: http://NEXUS/PATH/TO/ARTIFACT
18:43:23 [INFO] Downloaded: http://NEXUS/PATH/TO/ARTIFACT (27 KB at 985.4 KB/sec)
```
from the Jenkins Pipeline build logs

#### Who is reviewing it? 
@vinamartin @blen-desta @oconnormi @mcalcote @LinkMJB 

#### Choose 2 committers to review/merge the PR. 
(please choose ONLY two committers from below, delete the rest)
@bdeining
@clockard

#### How should this be tested? (List steps with links to updated documentation)
It has been verified both on a downstream project and in [CAL master](https://github.com/codice/alliance/commit/4f9e0c933d3dc541d88b838e567b521d7d878f72) that only the desired logs are suppressed.

#### Any background context you want to provide?
As a bonus, this also brings the 0.3.x pipeline up to date with master with regards to #477

#### What are the relevant tickets?
[CAL-392](https://codice.atlassian.net/browse/CAL-392)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
