### PR TITLE
[0.3.x]CAL-390 Add validation for KLV processing for dissemination and SCI Controls

### DIFF
--- a/libs/klv/src/main/java/org/codice/alliance/libs/klv/AlphanumericDistinctKlvProcessor.java
+++ b/libs/klv/src/main/java/org/codice/alliance/libs/klv/AlphanumericDistinctKlvProcessor.java
@@ -13,15 +13,16 @@
  */
 package org.codice.alliance.libs.klv;
 
-import org.codice.alliance.libs.stanag4609.Stanag4609TransportStreamParser;
+import java.io.Serializable;
 
-public class SecurityCaveatsKlvProcessor extends AlphanumericDistinctKlvProcessor {
-  public SecurityCaveatsKlvProcessor() {
-    super(AttributeNameConstants.CAVEATS, Stanag4609TransportStreamParser.CAVEATS);
+public class AlphanumericDistinctKlvProcessor extends DistinctKlvProcessor {
+
+  public AlphanumericDistinctKlvProcessor(String attributeName, String stanagFieldName) {
+    super(attributeName, stanagFieldName);
   }
 
   @Override
-  public String toString() {
-    return "SecurityCaveatsKlvProcessor{}";
+  protected boolean isValidAttributeValue(Serializable value) {
+    return Utilities.isNotBlankString(value) && Utilities.isAlphanumericString(value);
   }
 }

--- a/libs/klv/src/main/java/org/codice/alliance/libs/klv/DistinctKlvProcessor.java
+++ b/libs/klv/src/main/java/org/codice/alliance/libs/klv/DistinctKlvProcessor.java
@@ -41,7 +41,7 @@ public class DistinctKlvProcessor extends SingleFieldKlvProcessor {
         attribute
             .getValues()
             .stream()
-            .filter(Utilities::isNotEmptyString)
+            .filter(this::isValidAttributeValue)
             .distinct()
             .collect(Collectors.toList());
 
@@ -53,5 +53,9 @@ public class DistinctKlvProcessor extends SingleFieldKlvProcessor {
   @Override
   public void accept(Visitor visitor) {
     visitor.visit(this);
+  }
+
+  protected boolean isValidAttributeValue(Serializable value) {
+    return Utilities.isNotBlankString(value);
   }
 }

--- a/libs/klv/src/main/java/org/codice/alliance/libs/klv/DistinctSingleKlvProcessor.java
+++ b/libs/klv/src/main/java/org/codice/alliance/libs/klv/DistinctSingleKlvProcessor.java
@@ -38,7 +38,7 @@ public class DistinctSingleKlvProcessor extends SingleFieldKlvProcessor {
     attribute
         .getValues()
         .stream()
-        .filter(Utilities::isNotEmptyString)
+        .filter(Utilities::isNotBlankString)
         .findFirst()
         .ifPresent(
             serializable -> {

--- a/libs/klv/src/main/java/org/codice/alliance/libs/klv/SecurityInformationKlvProcessor.java
+++ b/libs/klv/src/main/java/org/codice/alliance/libs/klv/SecurityInformationKlvProcessor.java
@@ -15,7 +15,7 @@ package org.codice.alliance.libs.klv;
 
 import org.codice.alliance.libs.stanag4609.Stanag4609TransportStreamParser;
 
-public class SecurityInformationKlvProcessor extends DistinctKlvProcessor {
+public class SecurityInformationKlvProcessor extends AlphanumericDistinctKlvProcessor {
   public SecurityInformationKlvProcessor() {
     super(
         AttributeNameConstants.SECURITY_SCI_SHI_INFORMATION,

--- a/libs/klv/src/main/java/org/codice/alliance/libs/klv/UnionKlvProcessor.java
+++ b/libs/klv/src/main/java/org/codice/alliance/libs/klv/UnionKlvProcessor.java
@@ -42,7 +42,7 @@ public class UnionKlvProcessor extends AbstractMultiKlvProcessor {
             .stream()
             .filter(a -> a.getValues() != null)
             .flatMap(a -> a.getValues().stream())
-            .filter(Utilities::isNotEmptyString)
+            .filter(Utilities::isNotBlankString)
             .distinct()
             .collect(Collectors.toList());
     if (!serializables.isEmpty()) {

--- a/libs/klv/src/main/java/org/codice/alliance/libs/klv/Utilities.java
+++ b/libs/klv/src/main/java/org/codice/alliance/libs/klv/Utilities.java
@@ -28,12 +28,16 @@ import org.slf4j.LoggerFactory;
 public class Utilities {
   private static final Logger LOGGER = LoggerFactory.getLogger(Utilities.class);
 
-  public static boolean isEmptyString(Serializable serializable) {
-    return serializable instanceof String && StringUtils.isEmpty((String) serializable);
+  public static boolean isBlankString(Serializable serializable) {
+    return serializable instanceof String && StringUtils.isBlank((String) serializable);
   }
 
-  public static boolean isNotEmptyString(Serializable serializable) {
-    return !isEmptyString(serializable);
+  public static boolean isNotBlankString(Serializable serializable) {
+    return !isBlankString(serializable);
+  }
+
+  public static boolean isAlphanumericString(Serializable serializable) {
+    return serializable instanceof String && StringUtils.isAlphanumeric((String) serializable);
   }
 
   static void safelySetAttribute(Metacard metacard, Attribute attribute) {

--- a/libs/klv/src/test/java/org/codice/alliance/libs/klv/AlphanumericDistinctKlvProcessorTest.java
+++ b/libs/klv/src/test/java/org/codice/alliance/libs/klv/AlphanumericDistinctKlvProcessorTest.java
@@ -19,7 +19,6 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
@@ -30,50 +29,42 @@ import java.io.Serializable;
 import java.util.List;
 import org.junit.Test;
 
-public class DistinctKlvProcessorTest {
-
+public class AlphanumericDistinctKlvProcessorTest {
   public static final String ATTRIBUTE_NAME = "title";
 
   @Test
-  public void doProcessWithActualValue() {
-    Metacard metacard = setupAndExecuteDoProcess(ImmutableList.of("test-value"));
+  public void doProcessWithAlphanumericValue() {
+    Metacard metacard = setupAndExecuteDoProcess(ImmutableList.of("testvalue"));
 
     assertThat(metacard.getAttribute(ATTRIBUTE_NAME), is(not(nullValue())));
-    assertThat(metacard.getAttribute(ATTRIBUTE_NAME).getValue().toString(), equalTo("test-value"));
+    assertThat(metacard.getAttribute(ATTRIBUTE_NAME).getValue().toString(), equalTo("testvalue"));
   }
 
   @Test
-  public void doProcessWithBlankValues() {
-    Metacard metacard = setupAndExecuteDoProcess(ImmutableList.of("", " "));
+  public void doProcessWithNonalphanumericValues() {
+    Metacard metacard = setupAndExecuteDoProcess(ImmutableList.of("a-fasd", "//"));
 
     assertThat(metacard.getAttribute(ATTRIBUTE_NAME), is(nullValue()));
   }
 
   @Test
-  public void doProcessWithBlankValuesAndActualValue() {
-    Metacard metacard = setupAndExecuteDoProcess(ImmutableList.of("test-value", " "));
+  public void doProcessWithCombination() {
+    Metacard metacard = setupAndExecuteDoProcess(ImmutableList.of("testvalue", "//"));
 
     assertThat(metacard.getAttribute(ATTRIBUTE_NAME), is(not(nullValue())));
-    assertThat(metacard.getAttribute(ATTRIBUTE_NAME).getValue().toString(), equalTo("test-value"));
-  }
-
-  @Test
-  public void accept() {
-    DistinctKlvProcessor distinctKlvProcessor = new DistinctKlvProcessor("a", "b");
-    KlvProcessor.Visitor visitor = mock(KlvProcessor.Visitor.class);
-    distinctKlvProcessor.accept(visitor);
-    verify(visitor).visit(distinctKlvProcessor);
+    assertThat(metacard.getAttribute(ATTRIBUTE_NAME).getValue().toString(), equalTo("testvalue"));
   }
 
   private Metacard setupAndExecuteDoProcess(List<Serializable> values) {
-    DistinctKlvProcessor distinctKlvProcessor = new DistinctKlvProcessor(ATTRIBUTE_NAME, "b");
+    AlphanumericDistinctKlvProcessor alphanumericDistinctKlvProcessor =
+        new AlphanumericDistinctKlvProcessor(ATTRIBUTE_NAME, "b");
 
     Attribute mockAttribute = mock(Attribute.class);
     when(mockAttribute.getValues()).thenReturn(values);
 
     Metacard metacard = new MetacardImpl();
 
-    distinctKlvProcessor.doProcess(mockAttribute, metacard);
+    alphanumericDistinctKlvProcessor.doProcess(mockAttribute, metacard);
 
     return metacard;
   }

--- a/libs/klv/src/test/java/org/codice/alliance/libs/klv/DistinctKlvProcessorTest.java
+++ b/libs/klv/src/test/java/org/codice/alliance/libs/klv/DistinctKlvProcessorTest.java
@@ -50,11 +50,25 @@ public class DistinctKlvProcessorTest {
   }
 
   @Test
-  public void doProcessWithBlankValuesAndActualValue() {
+  public void doProcessWithBlankValueAndSingleActualValue() {
     Metacard metacard = setupAndExecuteDoProcess(ImmutableList.of("test-value", " "));
 
     assertThat(metacard.getAttribute(ATTRIBUTE_NAME), is(not(nullValue())));
     assertThat(metacard.getAttribute(ATTRIBUTE_NAME).getValue().toString(), equalTo("test-value"));
+  }
+
+  @Test
+  public void doProcessWithBlankValueAndMultipleActualValues() {
+    Metacard metacard =
+        setupAndExecuteDoProcess(ImmutableList.of("test-value1", "test-value2", " "));
+
+    assertThat(metacard.getAttribute(ATTRIBUTE_NAME), is(not(nullValue())));
+
+    List<Serializable> attValues = metacard.getAttribute(ATTRIBUTE_NAME).getValues();
+
+    assertThat(attValues.size(), equalTo(2));
+    assertThat(attValues.contains("test-value1"), is(true));
+    assertThat(attValues.contains("test-value2"), is(true));
   }
 
   @Test

--- a/libs/klv/src/test/java/org/codice/alliance/libs/klv/UtilitiesTest.java
+++ b/libs/klv/src/test/java/org/codice/alliance/libs/klv/UtilitiesTest.java
@@ -92,6 +92,12 @@ public class UtilitiesTest {
   }
 
   @Test
+  public void testIsEmptryStringUsingBlankAttribute() throws Exception {
+    assertThat(Utilities.isBlankString(" "), is(true));
+    assertThat(Utilities.isNotBlankString(" "), is(false));
+  }
+
+  @Test
   public void testNullDescriptorDoesNotSetAttribute() throws Exception {
     AttributeImpl attribute = new AttributeImpl(ATTRIBUTE_KEY_POC, EXPECTED_POC);
     Metacard mockedMetacard = setupMetacardWithNullDescriptor();

--- a/libs/klv/src/test/java/org/codice/alliance/libs/klv/UtilitiesTest.java
+++ b/libs/klv/src/test/java/org/codice/alliance/libs/klv/UtilitiesTest.java
@@ -92,7 +92,7 @@ public class UtilitiesTest {
   }
 
   @Test
-  public void testIsEmptryStringUsingBlankAttribute() throws Exception {
+  public void testIsBlankString() throws Exception {
     assertThat(Utilities.isBlankString(" "), is(true));
     assertThat(Utilities.isNotBlankString(" "), is(false));
   }


### PR DESCRIPTION
#### What does this PR do?
- Filters out blank values for metacard attributes being set from KLV data
- Filters out non-alphanumeric values for dissemination and SCI Controls from KLV data

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)
@glenhein @blen-desta 
#### Choose 2 committers to review/merge the PR.
(please choose ONLY two committers from below, delete the rest)

@bdeining 
@coyotesqrl 
#### How should this be tested?
- Full build
- Install Alliance then start the `video-app`
- Test ingesting video files of `mpegts` format with invalid klv values
- Verify they can be ingested and the invalid values are not set on the metacard
#### Any background context you want to provide?
Various `mpegts` files were failing to ingest
#### What are the relevant tickets?

[CAL-390](https://codice.atlassian.net/browse/CAL-390)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
