### PR TITLE
CAL-397 Removing commons-beanutils from the project

### DIFF
--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -51,11 +51,6 @@
                 <version>${commons-lang3.version}</version>
             </dependency>
             <dependency>
-                <groupId>commons-beanutils</groupId>
-                <artifactId>commons-beanutils</artifactId>
-                <version>${commons-beanutils.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>javax.mail</groupId>
                 <artifactId>mail</artifactId>
                 <version>${javax-mail.version}</version>

--- a/dependency-check-maven-config.xml
+++ b/dependency-check-maven-config.xml
@@ -552,4 +552,13 @@
         </notes>
         <cve>CVE-2012-0881</cve>
     </suppress>
+
+    <suppress>
+        <notes>
+            This CVE has been addressed by upgrading commons-beanutils to version 1.9.3 in DDF. OWASP will
+            continue to report the vulnerability since OWASP sees the DDF version instead of the actual version.
+            security-pdp-authzrealm-2.11.4-SNAPSHOT.jar (cpe:/a:apache:commons_beanutils:2.11.4, cpe:/a:apache:commons_collections:2.11.4, ddf.security.pdp:security-pdp-authzrealm:2.11.4-SNAPSHOT)
+        </notes>
+        <cve>CVE-2017-15708</cve>
+    </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,6 @@
         <joda-time.version>2.2</joda-time.version>
         <jts.version>1.12</jts.version>
         <commons-lang3.version>3.4</commons-lang3.version>
-        <commons-beanutils.version>1.9.2</commons-beanutils.version>
         <slf4j.version>1.7.14</slf4j.version>
         <awaitility.version>3.0.0</awaitility.version>
         <slf4j.version>1.7.12</slf4j.version>


### PR DESCRIPTION
Forward-port for https://github.com/codice/alliance/pull/501
#### What does this PR do?
- Removes beanutils from the project since it's not used and the maven property for the version points to an old version **causing the build to fail** on an OWASP error.
- Also suppressing this CVE because OWASP still fails because it looks at the DDF version to determine the vulnerability.
#### Who is reviewing it? 
@mackncheesiest 
#### Choose 2 committers to review/merge the PR.
(please choose ONLY two committers from below, delete the rest)

@bdeining 
@clockard 
#### How should this be tested?
#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-397](https://codice.atlassian.net/browse/CAL-397)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

  
  