### PR TITLE
CAL-398 Update node version to comply with yarn

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,8 @@
         <jcodec.version>0.2.0_1</jcodec.version>
         <mpegts-streamer.version>0.1.0_2</mpegts-streamer.version>
         <commons-collections4.version>4.1</commons-collections4.version>
-        <node.version>v7.4.0</node.version>
+        <!-- Properties for the frontend-maven-plugin -->
+        <node.version>v8.0.0</node.version>
         <yarn.version>v1.2.1</yarn.version>
         <netty.version>4.1.5.Final</netty.version>
         <!--Documentation Replacements-->


### PR DESCRIPTION
#### What does this PR do?
Upgrade the node version to comply with yarn

#### Who is reviewing it? 
@LinkMJB @vinamartin 

#### Choose 2 committers to review/merge the PR. 
@andrewkfiedler
@clockard 

#### Any background context you want to provide?
This upgrade is to get rid of the errors we get from yarn:
`[ERROR] warning You are using Node "7.1.0" which is not supported and may encounter bugs or unexpected behavior. Yarn supports the following semver range: "^4.8.0 || ^5.7.0 || ^6.2.2 || ^8.0.0"`

[CAL-398](https://codice.atlassian.net/browse/CAL-398)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
