### PR TITLE
CAL-406 Updated Chipping.js to allow bounding selection from all directions

### DIFF
--- a/catalog/imaging/imaging-actionprovider-chip/src/main/webapp/js/chipping.js
+++ b/catalog/imaging/imaging-actionprovider-chip/src/main/webapp/js/chipping.js
@@ -85,6 +85,15 @@ function setOnClickListeners() {
         var w = rect.w;
         var h = rect.h;
 
+        if(w < 0){
+            x += w;
+            w *= -1;
+        }
+        if(h < 0){
+            y += h;
+            h *= -1;
+        }
+
         var chipUrl = "/services/catalog/sources/" + source + "/" + id + "?transform=jpeg-chip&qualifier=overview&x=" + x + "&y=" + y + "&w=" + w + "&h=" + h;
 
         $('.chip-jpeg-image').attr('href',chipUrl);
@@ -95,6 +104,15 @@ function setOnClickListeners() {
         var y = rect.startY
         var w = rect.w;
         var h = rect.h;
+
+        if(w < 0){
+            x += w;
+            w *= -1;
+        }
+        if(h < 0){
+            y += h;
+            h *= -1;
+        }
 
         var chipUrl = "/services/catalog/sources/" + source + "/" + id + "?transform=nitf-chip&qualifier=overview&x=" + x + "&y=" + y + "&w=" + w + "&h=" + h;
 


### PR DESCRIPTION
**What does this PR do?**

This PR fixes an issue with the chipping function that prevents the user from selecting the area of an image unless the first coordinate specified is the top-left one. 

**Who is reviewing it?** 

@emmberk 
@peterhuffer 

**Choose 2 committers to review/merge the PR.**

@bdeining 
@clockard

**How should this be tested?**

Ingest a valid NITF file. Navigate to the file inspector in Intrigue. Select Chip Image under the Actions tab and create a bounding box by dragging from all possible directions. Confirm that the generated URL/JPEG/NITF file are correct. 

**What are the relevant tickets?**

[CAL-406](https://codice.atlassian.net/browse/CAL-406)
