### PR TITLE
CAL-291 fixed formatting for sample Alliance urls in docs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,9 @@
         <cal-branding>Alliance</cal-branding>
         <admin-console>Admin Console</admin-console>
         <command-console>Command Console</command-console>
-        <public_url>\http://{FQDN}:{PORT}</public_url>
-        <secure_url>\https://{FQDN}:{PORT}</secure_url>
+        <!--default url substitutions: preface with a \ to disable automatic hyperlinking-->
+        <public_url>http://{FQDN}:{PORT}</public_url>
+        <secure_url>https://{FQDN}:{PORT}</secure_url>
         <home_directory>&lt;ALLIANCE_HOME&gt;</home_directory>
         <!--Needed for documentation formatting-->
         <at-symbol>@</at-symbol>


### PR DESCRIPTION
**Port to `master` of PR https://github.com/codice/alliance/pull/532**

#### What does this PR do?

Aligns with changes to displaying default URLs in documentation. See also PR https://github.com/codice/ddf/pull/2955

#### Who is reviewing it? 
@mcalcote @vinamartin @ahoffer @garrettfreibott 

#### Choose 2 committers to review/merge the PR.
@clockard
@coyotesqrl
@lessarderic
@ricklarsen - Documentation
@rzwiefel
@shaundmorris

#### What are the relevant tickets?

[CAL-291](https://codice.atlassian.net/browse/CAL-291)
#### Screenshots (if appropriate)
#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
