### PR TITLE
CAL-424 Update banner marking extractors to use common attribute descriptors

### DIFF
--- a/catalog/core/catalog-core-api-impl/src/main/java/org/codice/alliance/catalog/core/api/impl/types/Dod520001Attributes.java
+++ b/catalog/core/catalog-core-api-impl/src/main/java/org/codice/alliance/catalog/core/api/impl/types/Dod520001Attributes.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.catalog.core.api.impl.types;
+
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.impl.AttributeDescriptorImpl;
+import ddf.catalog.data.impl.BasicTypes;
+import java.util.HashSet;
+import java.util.Set;
+import org.codice.alliance.catalog.core.api.types.Dod520001;
+
+/**
+ * <b> This code is experimental. While this is functional and tested, it may change or be removed
+ * in a future version of the library. </b>
+ */
+public class Dod520001Attributes implements Dod520001, MetacardType {
+  private static final Set<AttributeDescriptor> DESCRIPTORS = new HashSet<>();
+
+  private static final String NAME = "dod520001";
+
+  static {
+    DESCRIPTORS.add(
+        new AttributeDescriptorImpl(
+            Dod520001.SECURITY_DOD5200_AEA,
+            true /* indexed */,
+            true /* stored */,
+            false /* tokenized */,
+            true /* multivalued */,
+            BasicTypes.STRING_TYPE));
+    DESCRIPTORS.add(
+        new AttributeDescriptorImpl(
+            Dod520001.SECURITY_DOD5200_DODUCNI,
+            true /* indexed */,
+            true /* stored */,
+            false /* tokenized */,
+            true /* multivalued */,
+            BasicTypes.STRING_TYPE));
+    DESCRIPTORS.add(
+        new AttributeDescriptorImpl(
+            Dod520001.SECURITY_DOD5200_DOEUCNI,
+            true /* indexed */,
+            true /* stored */,
+            false /* tokenized */,
+            true /* multivalued */,
+            BasicTypes.STRING_TYPE));
+    DESCRIPTORS.add(
+        new AttributeDescriptorImpl(
+            Dod520001.SECURITY_DOD5200_FGI,
+            true /* indexed */,
+            true /* stored */,
+            false /* tokenized */,
+            true /* multivalued */,
+            BasicTypes.STRING_TYPE));
+    DESCRIPTORS.add(
+        new AttributeDescriptorImpl(
+            Dod520001.SECURITY_DOD5200_OTHER_DISSEM,
+            true /* indexed */,
+            true /* stored */,
+            false /* tokenized */,
+            true /* multivalued */,
+            BasicTypes.STRING_TYPE));
+    DESCRIPTORS.add(
+        new AttributeDescriptorImpl(
+            Dod520001.SECURITY_DOD5200_SAP,
+            true /* indexed */,
+            true /* stored */,
+            false /* tokenized */,
+            true /* multivalued */,
+            BasicTypes.STRING_TYPE));
+  }
+
+  @Override
+  public Set<AttributeDescriptor> getAttributeDescriptors() {
+    return DESCRIPTORS;
+  }
+
+  @Override
+  public AttributeDescriptor getAttributeDescriptor(String name) {
+    return DESCRIPTORS
+        .stream()
+        .filter(attr -> attr.getName().equals(name))
+        .findFirst()
+        .orElse(null);
+  }
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+}

--- a/catalog/core/catalog-core-api-impl/src/test/java/org/codice/alliance/catalog/core/api/impl/types/MetacardTypeAttributeTest.java
+++ b/catalog/core/catalog-core-api-impl/src/test/java/org/codice/alliance/catalog/core/api/impl/types/MetacardTypeAttributeTest.java
@@ -27,6 +27,7 @@ import ddf.catalog.data.types.Media;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import org.codice.alliance.catalog.core.api.types.Dod520001;
 import org.codice.alliance.catalog.core.api.types.Isr;
 import org.codice.alliance.catalog.core.api.types.Security;
 import org.junit.Test;
@@ -40,6 +41,8 @@ public class MetacardTypeAttributeTest {
   private static final CoreAttributes CORE_ATTRIBUTES = new CoreAttributes();
 
   private static final SecurityAttributes SECURITY_ATTRIBUTES = new SecurityAttributes();
+
+  private static final Dod520001Attributes DOD_520001_ATTRIBUTES = new Dod520001Attributes();
 
   @Test
   public void testIsrMetacardType() {
@@ -66,15 +69,29 @@ public class MetacardTypeAttributeTest {
   }
 
   @Test
+  public void testDod520001MetacardType() {
+    List<MetacardType> metacardTypeList = new ArrayList<>();
+    metacardTypeList.add(DOD_520001_ATTRIBUTES);
+    MetacardType metacardType = new MetacardTypeImpl(TEST_NAME, metacardTypeList);
+    assertMetacardAttributes(metacardType, DOD_520001_ATTRIBUTES.getAttributeDescriptors());
+    assertThat(DOD_520001_ATTRIBUTES.getName(), is("dod520001"));
+    assertThat(
+        DOD_520001_ATTRIBUTES.getAttributeDescriptor(Dod520001.SECURITY_DOD5200_AEA),
+        notNullValue());
+  }
+
+  @Test
   public void testAllTypes() {
     List<MetacardType> metacardTypeList = new ArrayList<>();
     metacardTypeList.add(ISR_ATTRIBUTES);
     metacardTypeList.add(SECURITY_ATTRIBUTES);
+    metacardTypeList.add(DOD_520001_ATTRIBUTES);
 
     MetacardType metacardType = new MetacardTypeImpl(TEST_NAME, metacardTypeList);
     assertMetacardAttributes(metacardType, CORE_ATTRIBUTES.getAttributeDescriptors());
     assertMetacardAttributes(metacardType, ISR_ATTRIBUTES.getAttributeDescriptors());
     assertMetacardAttributes(metacardType, SECURITY_ATTRIBUTES.getAttributeDescriptors());
+    assertMetacardAttributes(metacardType, DOD_520001_ATTRIBUTES.getAttributeDescriptors());
   }
 
   private void assertMetacardAttributes(

--- a/catalog/core/catalog-core-api/src/main/java/org/codice/alliance/catalog/core/api/types/Dod520001.java
+++ b/catalog/core/catalog-core-api/src/main/java/org/codice/alliance/catalog/core/api/types/Dod520001.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.catalog.core.api.types;
+
+/**
+ * <b> This code is experimental. While this interface is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ */
+public interface Dod520001 {
+  String SECURITY_DOD5200_SAP = "security.dod5200.sap";
+  String SECURITY_DOD5200_AEA = "security.dod5200.aea";
+  String SECURITY_DOD5200_DODUCNI = "security.dod5200.doducni";
+  String SECURITY_DOD5200_DOEUCNI = "security.dod5200.doeucni";
+  String SECURITY_DOD5200_FGI = "security.dod5200.fgi";
+  String SECURITY_DOD5200_OTHER_DISSEM = "security.dod5200.otherDissem";
+}

--- a/catalog/security/banner-marking/pom.xml
+++ b/catalog/security/banner-marking/pom.xml
@@ -56,6 +56,11 @@
             <artifactId>catalog-core-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.codice.alliance.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -69,9 +74,13 @@
                         </Export-Package>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Embed-Dependency>
-                            catalog-core-api-impl,
+                            catalog-core-api-impl;groupId=org.codice.alliance.catalog.core;version=${project.version},
                             platform-util
                         </Embed-Dependency>
+                        <Private-Package>
+                            org.codice.alliance.security.banner.marking.*,
+                            ddf.catalog.data.impl.*
+                        </Private-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/catalog/security/banner-marking/src/main/java/org/codice/alliance/security/banner/marking/BannerCommonMarkingExtractor.java
+++ b/catalog/security/banner-marking/src/main/java/org/codice/alliance/security/banner/marking/BannerCommonMarkingExtractor.java
@@ -17,16 +17,19 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import ddf.catalog.Constants;
 import ddf.catalog.data.Attribute;
+import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.AttributeImpl;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.codice.alliance.catalog.core.api.impl.types.SecurityAttributes;
 import org.codice.alliance.catalog.core.api.types.Security;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +37,9 @@ import org.slf4j.LoggerFactory;
 public class BannerCommonMarkingExtractor extends MarkingExtractor {
 
   private static final Logger INGEST_LOGGER = LoggerFactory.getLogger(Constants.INGEST_LOGGER_NAME);
+
+  private Set<AttributeDescriptor> attributeDescriptors =
+      new SecurityAttributes().getAttributeDescriptors();
 
   static final String SECURITY_CONFLICT_MESSAGE =
       "Extracted security attribute %s from the banner markings"
@@ -55,6 +61,11 @@ public class BannerCommonMarkingExtractor extends MarkingExtractor {
 
   public BannerCommonMarkingExtractor() {
     setAttProcessors(securityMap);
+  }
+
+  @Override
+  public Set<AttributeDescriptor> getMetacardAttributes() {
+    return attributeDescriptors;
   }
 
   private void checkSecurityAttribute(String name, Serializable oldVal, Serializable newVal) {

--- a/catalog/security/banner-marking/src/main/java/org/codice/alliance/security/banner/marking/Dod520001MarkingExtractor.java
+++ b/catalog/security/banner-marking/src/main/java/org/codice/alliance/security/banner/marking/Dod520001MarkingExtractor.java
@@ -15,14 +15,18 @@ package org.codice.alliance.security.banner.marking;
 
 import com.google.common.collect.ImmutableList;
 import ddf.catalog.data.Attribute;
+import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.AttributeImpl;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import org.apache.commons.collections.CollectionUtils;
+import org.codice.alliance.catalog.core.api.impl.types.Dod520001Attributes;
+import org.codice.alliance.catalog.core.api.types.Dod520001;
 
 /**
  * Processes US Markings in conformance with DoD Guildlines for banner markings.
@@ -35,75 +39,73 @@ import org.apache.commons.collections.CollectionUtils;
  */
 public class Dod520001MarkingExtractor extends MarkingExtractor {
 
-  public static final String SECURITY_DOD5200_SAP = "security.dod5200.sap";
-
-  public static final String SECURITY_DOD5200_AEA = "security.dod5200.aea";
-
-  public static final String SECURITY_DOD5200_DODUCNI = "security.dod5200.doducni";
-
-  public static final String SECURITY_DOD5200_DOEUCNI = "security.dod5200.doeucni";
-
-  public static final String SECURITY_DOD5200_FGI = "security.dod5200.fgi";
-
-  public static final String SECURITY_DOD5200_OTHER_DISSEM = "security.dod5200.otherDissem";
-
   private static final String ACCM_PREFIX = "ACCM-";
 
   private static final String FGI_PREFIX = "FGI ";
 
+  private Set<AttributeDescriptor> attributeDescriptors =
+      new Dod520001Attributes().getAttributeDescriptors();
+
   public Dod520001MarkingExtractor() {
     Map<String, BiFunction<Metacard, BannerMarkings, Attribute>> tempMap = new HashMap<>();
 
-    tempMap.put(SECURITY_DOD5200_SAP, this::processSap);
-    tempMap.put(SECURITY_DOD5200_AEA, this::processAea);
-    tempMap.put(SECURITY_DOD5200_DODUCNI, this::processDodUcni);
-    tempMap.put(SECURITY_DOD5200_DOEUCNI, this::processDoeUcni);
-    tempMap.put(SECURITY_DOD5200_FGI, this::processFgi);
-    tempMap.put(SECURITY_DOD5200_OTHER_DISSEM, this::processOtherDissem);
+    tempMap.put(Dod520001.SECURITY_DOD5200_SAP, this::processSap);
+    tempMap.put(Dod520001.SECURITY_DOD5200_AEA, this::processAea);
+    tempMap.put(Dod520001.SECURITY_DOD5200_DODUCNI, this::processDodUcni);
+    tempMap.put(Dod520001.SECURITY_DOD5200_DOEUCNI, this::processDoeUcni);
+    tempMap.put(Dod520001.SECURITY_DOD5200_FGI, this::processFgi);
+    tempMap.put(Dod520001.SECURITY_DOD5200_OTHER_DISSEM, this::processOtherDissem);
 
     setAttProcessors(tempMap);
   }
 
+  @Override
+  public Set<AttributeDescriptor> getMetacardAttributes() {
+    return attributeDescriptors;
+  }
+
   Attribute processSap(Metacard metacard, BannerMarkings bannerMarkings) {
-    Attribute currAttr = metacard.getAttribute(SECURITY_DOD5200_SAP);
+    Attribute currAttr = metacard.getAttribute(Dod520001.SECURITY_DOD5200_SAP);
     SapControl sapControl = bannerMarkings.getSapControl();
     if (sapControl == null) {
       return currAttr;
     }
 
-    return new AttributeImpl(SECURITY_DOD5200_SAP, ImmutableList.<String>of(sapControl.toString()));
+    return new AttributeImpl(
+        Dod520001.SECURITY_DOD5200_SAP, ImmutableList.<String>of(sapControl.toString()));
   }
 
   Attribute processAea(Metacard metacard, BannerMarkings bannerMarkings) {
-    Attribute currAttr = metacard.getAttribute(SECURITY_DOD5200_AEA);
+    Attribute currAttr = metacard.getAttribute(Dod520001.SECURITY_DOD5200_AEA);
     AeaMarking aeaMarking = bannerMarkings.getAeaMarking();
     if (aeaMarking == null) {
       return currAttr;
     }
 
-    return new AttributeImpl(SECURITY_DOD5200_AEA, ImmutableList.<String>of(aeaMarking.toString()));
+    return new AttributeImpl(
+        Dod520001.SECURITY_DOD5200_AEA, ImmutableList.<String>of(aeaMarking.toString()));
   }
 
   Attribute processDodUcni(Metacard metacard, BannerMarkings bannerMarkings) {
     if (bannerMarkings.getDodUcni()) {
       return new AttributeImpl(
-          SECURITY_DOD5200_DODUCNI,
+          Dod520001.SECURITY_DOD5200_DODUCNI,
           ImmutableList.<String>of("DOD UNCLASSIFIED CONTROLLED NUCLEAR INFORMATION"));
     }
-    return metacard.getAttribute(SECURITY_DOD5200_DODUCNI);
+    return metacard.getAttribute(Dod520001.SECURITY_DOD5200_DODUCNI);
   }
 
   Attribute processDoeUcni(Metacard metacard, BannerMarkings bannerMarkings) {
     if (bannerMarkings.getDoeUcni()) {
       return new AttributeImpl(
-          SECURITY_DOD5200_DOEUCNI,
+          Dod520001.SECURITY_DOD5200_DOEUCNI,
           ImmutableList.<String>of("DOE UNCLASSIFIED CONTROLLED NUCLEAR INFORMATION"));
     }
-    return metacard.getAttribute(SECURITY_DOD5200_DOEUCNI);
+    return metacard.getAttribute(Dod520001.SECURITY_DOD5200_DOEUCNI);
   }
 
   Attribute processFgi(Metacard metacard, BannerMarkings bannerMarkings) {
-    Attribute currAttr = metacard.getAttribute(SECURITY_DOD5200_FGI);
+    Attribute currAttr = metacard.getAttribute(Dod520001.SECURITY_DOD5200_FGI);
     List<String> fgiCountryCodes = bannerMarkings.getUsFgiCountryCodes();
 
     // There is a distinction between a null set of FGI country codes and an empty set of
@@ -114,7 +116,7 @@ public class Dod520001MarkingExtractor extends MarkingExtractor {
     }
 
     String fgi = fgiCountryCodes.stream().collect(Collectors.joining(" ", FGI_PREFIX, "")).trim();
-    return new AttributeImpl(SECURITY_DOD5200_FGI, ImmutableList.<String>of(fgi));
+    return new AttributeImpl(Dod520001.SECURITY_DOD5200_FGI, ImmutableList.<String>of(fgi));
   }
 
   Attribute processOtherDissem(Metacard metacard, BannerMarkings bannerMarkings) {
@@ -133,13 +135,13 @@ public class Dod520001MarkingExtractor extends MarkingExtractor {
               .collect(Collectors.toList()));
     }
 
-    Attribute currAttr = metacard.getAttribute(SECURITY_DOD5200_OTHER_DISSEM);
+    Attribute currAttr = metacard.getAttribute(Dod520001.SECURITY_DOD5200_OTHER_DISSEM);
     if (currAttr != null) {
       return new AttributeImpl(
-          SECURITY_DOD5200_OTHER_DISSEM, dedupedList(otherDissem, currAttr.getValues()));
+          Dod520001.SECURITY_DOD5200_OTHER_DISSEM, dedupedList(otherDissem, currAttr.getValues()));
     } else {
       return new AttributeImpl(
-          SECURITY_DOD5200_OTHER_DISSEM, ImmutableList.<String>copyOf(otherDissem));
+          Dod520001.SECURITY_DOD5200_OTHER_DISSEM, ImmutableList.<String>copyOf(otherDissem));
     }
   }
 }

--- a/catalog/security/banner-marking/src/main/java/org/codice/alliance/security/banner/marking/MarkingExtractor.java
+++ b/catalog/security/banner-marking/src/main/java/org/codice/alliance/security/banner/marking/MarkingExtractor.java
@@ -18,13 +18,9 @@ import static org.codice.alliance.security.banner.marking.ClassificationLevel.TO
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import ddf.catalog.content.operation.ContentMetadataExtractor;
 import ddf.catalog.data.Attribute;
-import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
-import ddf.catalog.data.impl.AttributeDescriptorImpl;
-import ddf.catalog.data.impl.BasicTypes;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -36,9 +32,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.BiFunction;
-import java.util.stream.Collectors;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,8 +41,6 @@ public abstract class MarkingExtractor implements ContentMetadataExtractor {
   private static final Logger LOGGER = LoggerFactory.getLogger(MarkingExtractor.class);
 
   private Map<String, BiFunction<Metacard, BannerMarkings, Attribute>> attProcessors;
-
-  private Set<AttributeDescriptor> attributeDescriptors;
 
   @Override
   public void process(String input, Metacard metacard) {
@@ -80,11 +72,6 @@ public abstract class MarkingExtractor implements ContentMetadataExtractor {
     for (BiFunction<Metacard, BannerMarkings, Attribute> attFunc : attProcessors.values()) {
       metacard.setAttribute(attFunc.apply(metacard, bannerMarkings));
     }
-  }
-
-  @Override
-  public Set<AttributeDescriptor> getMetacardAttributes() {
-    return attributeDescriptors;
   }
 
   public String translateClassification(
@@ -122,17 +109,6 @@ public abstract class MarkingExtractor implements ContentMetadataExtractor {
   protected void setAttProcessors(
       Map<String, BiFunction<Metacard, BannerMarkings, Attribute>> attProcessors) {
     this.attProcessors = ImmutableMap.copyOf(attProcessors);
-
-    attributeDescriptors =
-        ImmutableSet.copyOf(
-            attProcessors
-                .keySet()
-                .stream()
-                .map(
-                    s ->
-                        new AttributeDescriptorImpl(
-                            s, false, true, false, true, BasicTypes.STRING_TYPE))
-                .collect(Collectors.toSet()));
   }
 
   protected List<Serializable> dedupedList(

--- a/catalog/security/banner-marking/src/test/groovy/org/codice/alliance/security/banner/marking/BannerCommonMarkingExtractorSpec.groovy
+++ b/catalog/security/banner-marking/src/test/groovy/org/codice/alliance/security/banner/marking/BannerCommonMarkingExtractorSpec.groovy
@@ -60,7 +60,6 @@ class BannerCommonMarkingExtractorSpec extends Specification {
                               Security.CLASSIFICATION_SYSTEM]
 
         then:
-        attributes.size() == attributeNames.size()
         attributes*.name.containsAll(attributeNames)
     }
 

--- a/distribution/sdk/sample-content-metadata-extractor/pom.xml
+++ b/distribution/sdk/sample-content-metadata-extractor/pom.xml
@@ -44,6 +44,11 @@
             <artifactId>platform-util</artifactId>
             <version>${ddf.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.codice.alliance.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -59,10 +64,13 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Export-Package/>
                         <Embed-Dependency>
-                            catalog-core-api-impl,
-                            platform-util,
+                            catalog-core-api-impl;groupId=org.codice.alliance.catalog.core;version=${project.version},
                             banner-marking
+                            platform-util
                         </Embed-Dependency>
+                        <Private-Package>
+                            ddf.catalog.data.impl.*
+                        </Private-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/distribution/sdk/sample-content-metadata-extractor/src/main/java/org/codice/alliance/sdk/extraction/SampleContentMetadataExtractor.java
+++ b/distribution/sdk/sample-content-metadata-extractor/src/main/java/org/codice/alliance/sdk/extraction/SampleContentMetadataExtractor.java
@@ -13,9 +13,12 @@
  */
 package org.codice.alliance.sdk.extraction;
 
+import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.AttributeImpl;
 import java.io.InputStream;
+import java.util.Set;
+import org.codice.alliance.catalog.core.api.impl.types.SecurityAttributes;
 import org.codice.alliance.catalog.core.api.types.Security;
 import org.codice.alliance.security.banner.marking.MarkingExtractor;
 
@@ -25,5 +28,10 @@ public class SampleContentMetadataExtractor extends MarkingExtractor {
   public void process(InputStream input, Metacard metacard) {
     metacard.setAttribute(new AttributeImpl(Security.CLASSIFICATION, "S"));
     metacard.setAttribute(new AttributeImpl(Security.OWNER_PRODUCER, "GBR"));
+  }
+
+  @Override
+  public Set<AttributeDescriptor> getMetacardAttributes() {
+    return new SecurityAttributes().getAttributeDescriptors();
   }
 }

--- a/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/BannerMarkingsTest.java
+++ b/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/BannerMarkingsTest.java
@@ -32,8 +32,8 @@ import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Optional;
+import org.codice.alliance.catalog.core.api.types.Dod520001;
 import org.codice.alliance.catalog.core.api.types.Security;
-import org.codice.alliance.security.banner.marking.Dod520001MarkingExtractor;
 import org.codice.alliance.test.itests.common.AbstractAllianceIntegrationTest;
 import org.codice.ddf.test.common.annotations.BeforeExam;
 import org.junit.After;
@@ -131,7 +131,7 @@ public class BannerMarkingsTest extends AbstractAllianceIntegrationTest {
     assertThat(attributes.size(), is(1));
     assertThat(attributes, containsInAnyOrder("ORCON"));
 
-    attribute = getAttribute(metacard, Dod520001MarkingExtractor.SECURITY_DOD5200_OTHER_DISSEM);
+    attribute = getAttribute(metacard, Dod520001.SECURITY_DOD5200_OTHER_DISSEM);
     attributes = attribute.getValues();
     assertThat(attributes.size(), is(1));
     assertThat(attributes, containsInAnyOrder("LIMDIS"));


### PR DESCRIPTION
#### What does this PR do?
Use the attribute descriptors already defined for attributes instead of redefining them. This ensures they are consistent.
#### Who is reviewing it? 
@emmberk @peterhuffer @kcover 
#### Choose 2 committers to review/merge the PR.
@coyotesqrl
@figliold

#### How should this be tested?
Install and setup security defaults. You can use this profile 
```json
{
  "TestUnclass": {
    "guestClaims": {
      "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier": "guest",
      "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role": "guest"
    },
    "systemClaims": {
      "ownerProducer" : "USA",
      "releasableTo": "USA",
      "classification": "U"
    },
    "configs": []
  }
}
```
Ingest a text file with banner markings. (first line is something like `TOP SECRET`)
Export the metacard xml and verify that the security markings are not duplicated.
#### What are the relevant tickets?

[CAL-424](https://codice.atlassian.net/browse/CAL-424)
