### PR TITLE
CAL-291 added release notes URL to documentation

### DIFF
--- a/distribution/docs/src/main/resources/content/config.adoc
+++ b/distribution/docs/src/main/resources/content/config.adoc
@@ -17,6 +17,7 @@ Version: ${project.version}. Copyright (c) Codice Foundation
 :adoc-include: ${project.build.directory}/doc-contents/_ddf/docs-${ddf.version}
 :adoc-include-cal: ${project.build.directory}/doc-contents/_contents
 :download-url: https://github.com/codice/alliance/releases
+:release-notes-url: https://codice.atlassian.net/wiki/spaces/CAL/pages/71276940/Release+Notes
 :last-update-label: Copyright (c) Codice Foundation. +
 This work is licensed under a Creative Commons Attribution 4.0 International License (http://creativecommons.org/licenses/by/4.0). +
 This page last updated:


### PR DESCRIPTION
#### What does this PR do?

Adds `release-notes-url` property to docs config file to point to Alliance release notes page.

#### Who is reviewing it? 
@mcalcote @vinamartin @ahoffer @garrettfreibott 

#### Choose 2 committers to review/merge the PR.

@clockard
@lessarderic
@ricklarsen - Documentation
@shaundmorris

#### How should this be tested?

text replacement renders working link

#### Any background context you want to provide?


#### What are the relevant tickets?

[CAL-291](https://codice.atlassian.net/browse/CAL-291)

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
