### PR TITLE
CAL-428 Update how DefaultSecurityAttributeValuesPlugin is configured

### DIFF
--- a/catalog/plugin/catalog-plugin-defaultsecurityattributevalues/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/plugin/catalog-plugin-defaultsecurityattributevalues/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -26,17 +26,17 @@
           class="org.codice.alliance.catalog.plugin.defaultsecurity.DefaultSecurityAttributeValuesPlugin">
         <cm:managed-properties
                 persistent-id="org.codice.alliance.catalog.plugin.defaultsecurity.DefaultSecurityAttributeValuesPlugin"
-                update-strategy="component-managed" update-method="update"/>
+                update-strategy="container-managed"/>
         <argument ref="securityAttributes"/>
         <argument ref="systemHighAttributes"/>
         <argument>
             <map>
-                <entry key="classification" value="classification"/>
-                <entry key="releasability" value="releasableTo"/>
-                <entry key="codewords" value="sciControls"/>
-                <entry key="disseminationControls" value="disseminationControls"/>
-                <entry key="otherDisseminationControls" value="otherDisseminationControls"/>
-                <entry key="ownerProducer" value="ownerProducer"/>
+                <entry key="security.classification" value="classification"/>
+                <entry key="security.releasability" value="releasableTo"/>
+                <entry key="security.codewords" value="sciControls"/>
+                <entry key="security.dissemination-controls" value="disseminationControls"/>
+                <entry key="security.other-dissemination-controls" value="otherDisseminationControls"/>
+                <entry key="security.owner-producer" value="ownerProducer"/>
             </map>
         </argument>
     </bean>

--- a/catalog/plugin/catalog-plugin-defaultsecurityattributevalues/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/plugin/catalog-plugin-defaultsecurityattributevalues/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -15,44 +15,12 @@
 <metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
 
 	<OCD  name="Default Security Attribute Values Plugin" id="org.codice.alliance.catalog.plugin.defaultsecurity.DefaultSecurityAttributeValuesPlugin" description="Mapping of System High attributes to use in case metacards are ingested without any security marking.">
-		<AD name="Classification" id="classification"
-			required="true"
+		<AD name="Attribute Mappings" id="attributeMappings"
 			type="String"
-			default="classification"
-			description="Mappings of system attributes to Classification metacard marking.">
+			cardinality="100"
+			default="security.classification=classification,security.releasability=releasableTo,security.codewords=sciControls,security.dissemination-controls=disseminationControls,security.other-dissemination-controls=otherDisseminationControls,security.owner-producer=ownerProducer"
+			description="Mappings of metacard attributes to system attributes. Format is 'metacardAttribute=systemAttribute`">
 		</AD>
-		<AD name="Releasabilty" id="releasability"
-			required="true"
-			type="String"
-			default="releasableTo"
-			description="Mappings of system attributes to Releasabilty metacard marking.">
-		</AD>
-		<AD name="Codewords" id="codewords"
-			required="true"
-			type="String" 
-			default="sciControls"
-			description="Mappings of system attributes to Codewords metacard marking.">
-		</AD>
-		<AD name="Dissemination Controls" id="disseminationControls"
-			required="true"
-			type="String" 
-			default="disseminationControls"
-			description="Mappings of system attributes to Dissemination Controls metacard marking.">
-		</AD>
-
-		<AD name="Other Dissemination Controls" id="otherDisseminationControls"
-			required="true"
-			type="String" 
-			default="otherDisseminationControls"
-			description="Mappings of system attributes to Other Dissemination Controls metacard marking.">
-		</AD>
-		<AD name="Owner Producer" id="ownerProducer"
-			required="true"
-			type="String" 
-			default="ownerProducer"
-			description="Mappings of system attributes to Owner Producer metacard marking.">
-		</AD>
-
 	</OCD>
 
 	<Designate pid="org.codice.alliance.catalog.plugin.defaultsecurity.DefaultSecurityAttributeValuesPlugin">

--- a/distribution/docs/src/main/resources/content/_tables/DefaultAttributeValuesPlugin.adoc
+++ b/distribution/docs/src/main/resources/content/_tables/DefaultAttributeValuesPlugin.adoc
@@ -15,46 +15,11 @@
 |Default Value
 |Required
 
-|Classification
-|classification
+|Attribute Mappings
+|attributeMappings
 |String
-|Mappings of system attributes to Classification metacard marking.
-|classification
-|true
-
-|Releasabilty
-|releasability
-|String
-|Mappings of system attributes to Releasabilty metacard marking.
-|releasableTo
-|true
-
-|Codewords
-|codewords
-|String
-|Mappings of system attributes to Codewords metacard marking.
-|sciControls
-|true
-
-|Dissemination Controls
-|disseminationControls
-|String
-|Mappings of system attributes to Dissemination Controls metacard marking.
-|disseminationControls
-|true
-
-|Other Dissemination Controls
-|otherDisseminationControls
-|String
-|Mappings of system attributes to Other Dissemination Controls metacard marking.
-|otherDisseminationControls
-|true
-
-|Owner Producer
-|ownerProducer
-|String
-|Mappings of system attributes to Owner Producer metacard marking.
-|ownerProducer
+|Mapping of System High attributes to use in case metacards are ingested without any security marking.
+|security.classification=classification,security.releasability=releasableTo,security.codewords=sciControls,security.dissemination-controls=disseminationControls,security.other-dissemination-controls=otherDisseminationControls,security.owner-producer=ownerProducer
 |true
 
 |===


### PR DESCRIPTION
#### What does this PR do?
Update how DefaultSecurityAttributeValuesPlugin is configured.
Should the SecurityAttributes usage/checks be replaced with AttributeRegistry lookup of the configured terms?
#### Who is reviewing it? 
@emmberk @ryeats @peterhuffer @kcover 
#### Choose 2 committers to review/merge the PR.

@bdeining
@coyotesqrl

#### How should this be tested?
Unzip the alliance distro and put the following in a file called profiles.json in <installhome>/etc/ws-security/
```json
{
  "TestUnclass": {
    "guestClaims": {
      "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier": "guest",
      "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role": "guest"
    },
    "systemClaims": {
      "ownerProducer" : "USA",
      "releasableTo": "USA",
      "classification": "U"
    },
    "configs": []
  }
}
```
Install Alliance and select the TestUnclass profile on the claims installer page.
Ingest a text or jpg file and verify that it has the three system claims in its security attributes.
Go to the DefaultSecurityAttributeValuesPlugin configuration and remove the entry for `security.ownerProducer`
Ingest another text or jpg file and verify that it has two system claims and not the ownerProducer


#### What are the relevant tickets?

[CAL-428](https://codice.atlassian.net/browse/CAL-428)
