### PR TITLE
CAL-431 Add ResourceRequestByDerivedUri

### DIFF
--- a/catalog/imaging/imaging-transformer-chipping/src/main/java/org/codice/alliance/imaging/chip/transformer/CatalogInputAdapter.java
+++ b/catalog/imaging/imaging-transformer-chipping/src/main/java/org/codice/alliance/imaging/chip/transformer/CatalogInputAdapter.java
@@ -18,8 +18,8 @@ import static org.apache.commons.lang3.Validate.notNull;
 import ddf.catalog.data.Attribute;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.operation.ResourceRequest;
+import ddf.catalog.operation.impl.ResourceRequestByDerivedUri;
 import ddf.catalog.operation.impl.ResourceRequestById;
-import ddf.catalog.operation.impl.ResourceRequestByProductUri;
 import java.io.Serializable;
 import java.net.URI;
 import java.util.List;
@@ -60,7 +60,7 @@ public class CatalogInputAdapter {
 
       URI qualifiedUri = findDerivedResourceUri(values, qualifier);
 
-      return new ResourceRequestByProductUri(qualifiedUri);
+      return new ResourceRequestByDerivedUri(qualifiedUri);
     }
 
     throw new IllegalStateException(


### PR DESCRIPTION
#### What does this PR do?

Changes one line in CatalogInputAdapter to utilize the new ResourceRequestByDerivedUri class in DDF.

#### Who is reviewing it? 

@peterhuffer @emmberk @oconnormi 

#### Choose 2 committers to review/merge the PR.

@clockard
@pklinef

#### How should this be tested?

Verify various types of products ingest and download properly, especially Nitf overviews and originals.

#### What are the relevant tickets?

[CAL-431](https://codice.atlassian.net/browse/CAL-431)
[DDF-3712](https://codice.atlassian.net/browse/DDF-3712)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
