### PR TITLE
CAL-434 Upgrade jruby version for doc build for RHEL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <asciidoctorj.pdf.version>1.5.0-alpha.16</asciidoctorj.pdf.version>
         <asciidoctor.source.highlighter>coderay</asciidoctor.source.highlighter>
         <jbake.maven.plugin.version>0.0.9</jbake.maven.plugin.version>
-        <jruby.version>1.7.26</jruby.version>
+        <jruby.version>9.0.4.0</jruby.version>
         <httpcore.version>4.4.5</httpcore.version>
         <httpclient.version>4.5.2</httpclient.version>
         <!-- output directory for reports -->


### PR DESCRIPTION
#### What does this PR do?
Allow RHEL Jenkins using Maven 3.5.0 to successfully build DDF. But we will need to verify that it doesn't break in other environment (especially Windows since I don't have Windows)

#### Who is reviewing it? 
@jlcsmith @AzGoalie @ricklarsen

(please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)
#### Choose 2 committers to review/merge the PR.
(please choose ONLY two committers from below, delete the rest)
@millerw8
@ricklarsen - Documentation

#### How should this be tested?
Verified that it build in Windows / Mac / Linux

#### Any background context you want to provide?
It failed in RHEL when the version is at 1.7.26
Source of reference: asciidoctor/asciidoctorj#586

#### What are the relevant tickets?

[CAL-434](https://codice.atlassian.net/browse/CAL-434)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
