### PR TITLE
CAL-435 Moved PDF generation to the release profile

### DIFF
--- a/distribution/docs/pom.xml
+++ b/distribution/docs/pom.xml
@@ -46,6 +46,65 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <profiles>
+        <profile>
+            <id>release</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>1.5</version>
+                        <executions>
+                            <execution>
+                                <id>attach-omnibus</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>attach-artifact</goal>
+                                </goals>
+                                <configuration>
+                                    <artifacts>
+                                        <artifact>
+                                            <file>${project.build.directory}/docs/pdf/documentation.pdf</file>
+                                            <type>pdf</type>
+                                            <classifier>documentation</classifier>
+                                        </artifact>
+                                    </artifacts>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctor-maven-plugin</artifactId>
+                        <version>${asciidoctor.maven.plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>output-pdf</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>process-asciidoc</goal>
+                                </goals>
+                                <configuration>
+                                    <backend>pdf</backend>
+                                    <outputDirectory>${project.build.directory}/docs/pdf</outputDirectory>
+                                    <attributes>
+                                        <pagenums/>
+                                        <toc/>
+                                        <idprefix>_</idprefix>
+                                        <idseparator>_</idseparator>
+                                    </attributes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
     <build>
         <plugins>
             <plugin>
@@ -324,23 +383,6 @@
                             <outputDirectory>${project.build.directory}/docs/html</outputDirectory>
                         </configuration>
                     </execution>
-                    <execution>
-                        <id>output-pdf</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>process-asciidoc</goal>
-                        </goals>
-                        <configuration>
-                            <backend>pdf</backend>
-                            <outputDirectory>${project.build.directory}/docs/pdf</outputDirectory>
-                            <attributes>
-                                <pagenums/>
-                                <toc/>
-                                <idprefix>_</idprefix>
-                                <idseparator>_</idseparator>
-                            </attributes>
-                        </configuration>
-                    </execution>
                 </executions>
                 <configuration>
                     <sourceDirectory>${project.build.directory}/asciidoctor-ready</sourceDirectory>
@@ -409,11 +451,6 @@
                                 <artifact>
                                     <file>${project.build.directory}/docs/html/documentation.html</file>
                                     <type>html</type>
-                                    <classifier>documentation</classifier>
-                                </artifact>
-                                <artifact>
-                                    <file>${project.build.directory}/docs/pdf/documentation.pdf</file>
-                                    <type>pdf</type>
                                     <classifier>documentation</classifier>
                                 </artifact>
                             </artifacts>


### PR DESCRIPTION
#### What does this PR do?
Ensure that PDF generation only occurs when using the release profile. HTML docs will still be generated when building the docs module.

#### Who is reviewing it?
@ahoffer @austinsteffes @sblackmore

#### Select relevant component teams:
@codice/docs

#### Choose 2 committers to review/merge the PR.
@clockard @ricklarsen @rzwiefel

#### How should this be tested? (List steps with links to updated documentation)
`mvn clean install` in \distribution\docs to confirm HTML docs are still generated
`mvn clean install -P release` in \distribution\docs to confirm both HTML and PDF docs are generated

#### Any background context you want to provide?
This change reduced the standard build of the docs module by several minutes on my machine.

#### What are the relevant tickets?
[CAL-435](https://codice.atlassian.net/browse/CAL-435)
