### PR TITLE
CAL-426 Adds UI as a distribution boot feature

### DIFF
--- a/distribution/alliance/pom.xml
+++ b/distribution/alliance/pom.xml
@@ -45,6 +45,13 @@
             <classifier>features</classifier>
             <type>xml</type>
         </dependency>
+        <dependency>
+            <groupId>org.codice.ddf</groupId>
+            <artifactId>ui</artifactId>
+            <version>${ddf.version}</version>
+            <classifier>features</classifier>
+            <type>xml</type>
+        </dependency>
 
         <!-- Alliance Apps -->
         <dependency>
@@ -167,6 +174,10 @@
                                 <descriptor>
                                     mvn:ddf.features/apps/${ddf.version}/xml/features
                                 </descriptor>
+                                <descriptor>
+                                    mvn:org.codice.ddf/ui/${ddf.version}/xml/features
+                                </descriptor>
+
                                 <!-- Alliance Apps -->
                                 <descriptor>
                                     mvn:org.codice.alliance.nsili/nsili-app/${project.version}/xml/features

--- a/distribution/alliance/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
+++ b/distribution/alliance/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
@@ -54,6 +54,7 @@ featuresRepositories= \
 # TODO DDF-3072 Investigate improvements of this configuration.
 featuresBoot= \
  (ddf-boot-features, \
+ ui, \
  admin-modules-installer, \
  alliance-branding)
 


### PR DESCRIPTION
#### What does this PR do?

Once https://github.com/codice/ddf/pull/3230 gets into DDF, Alliance will be broken. This PR re-adds the ui as a distribution level boot feature to fix the problem.

#### Who is reviewing it? 

@mackncheesiest 
@tbatie 

#### Choose 2 committers to review/merge the PR.

@bdeining
@pklinef

#### How should this be tested?

- build https://github.com/codice/ddf/pull/3230
- build Alliance
- ensure ui comes up and works correctly

#### What are the relevant tickets?

[CAL-426](https://codice.atlassian.net/browse/CAL-426)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
