### PR TITLE
CAL-438 [0.3.x] Update Alliance to support separate external/internal urls

### DIFF
--- a/catalog/imaging/imaging-actionprovider-chip/src/main/java/org/codice/alliance/imaging/chip/actionprovider/ImagingChipActionProvider.java
+++ b/catalog/imaging/imaging-actionprovider-chip/src/main/java/org/codice/alliance/imaging/chip/actionprovider/ImagingChipActionProvider.java
@@ -83,7 +83,7 @@ public class ImagingChipActionProvider implements MultiActionProvider {
       final String defaultChippingUrlString =
           String.format(
               "%s%s?id=%s&source=%s",
-              SystemBaseUrl.getBaseUrl(), PATH, metacard.getId(), metacard.getSourceId());
+              SystemBaseUrl.EXTERNAL.getBaseUrl(), PATH, metacard.getId(), metacard.getSourceId());
       try {
         return Optional.of(new URL(defaultChippingUrlString));
       } catch (MalformedURLException e) {

--- a/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/ResultDAGConverter.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/org/codice/alliance/nsili/common/ResultDAGConverter.java
@@ -1742,7 +1742,7 @@ public class ResultDAGConverter {
       try {
         String thumbnailURL =
             new URI(
-                    SystemBaseUrl.constructUrl(
+                    SystemBaseUrl.EXTERNAL.constructUrl(
                         CATALOG_SOURCE_PATH
                             + "/"
                             + metacard.getSourceId()

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/LibraryImpl.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/org/codice/alliance/nsili/endpoint/LibraryImpl.java
@@ -295,7 +295,7 @@ public class LibraryImpl extends LibraryPOA {
   @Override
   public LibraryDescription get_library_description() throws ProcessingFault, SystemFault {
     LOGGER.trace("get_library_description called");
-    String host = System.getProperty("org.codice.ddf.system.hostname");
+    String host = System.getProperty("org.codice.ddf.external.hostname");
     String country = System.getProperty("user.country");
     String organization = System.getProperty("org.codice.ddf.system.organization");
     String libraryDescr = country + "|" + organization;

--- a/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/NsiliLibraryImplTest.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/test/java/org/codice/alliance/nsili/endpoint/NsiliLibraryImplTest.java
@@ -60,7 +60,7 @@ public class NsiliLibraryImplTest extends NsiliTestCommon {
   public void setUp()
       throws SecurityServiceException, AdapterInactive, InvalidName, ServantNotActive, WrongPolicy,
           IOException {
-    System.setProperty("org.codice.ddf.system.hostname", TEST_HOSTNAME);
+    System.setProperty("org.codice.ddf.external.hostname", TEST_HOSTNAME);
     System.setProperty("user.country", TEST_COUNTRY);
     System.setProperty("org.codice.ddf.system.organization", TEST_ORGANIZATION);
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <ddf.version>2.11.6</ddf.version>
+        <ddf.version>2.11.7-SNAPSHOT</ddf.version>
         <ddf.support.version>2.3.9</ddf.support.version>
         <ddf.scm.connection.url />
         <snapshots.repository.url />


### PR DESCRIPTION
#### What does this PR do?
DDF-3817 introduced support for explicit internal and external url properties which is useful when an Alliance is behind a proxy and the URL a user sees is different than the local url Alliance uses.

#### Who is reviewing it? 
@alexaabrd @SmithJosh @rzwiefel 

#### Choose 2 committers to review/merge the PR.
@bdeining
@brendan-hofmann 

#### How should this be tested?
Build this PR on top of: https://github.com/codice/ddf/pull/3225 and follow the instructions in that PR

#### What are the relevant tickets?
[CAL-438](https://codice.atlassian.net/browse/CAL-438)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
