### PR TITLE
CAL-291 added adoc file to create quick start document

### DIFF
--- a/distribution/docs/pom.xml
+++ b/distribution/docs/pom.xml
@@ -72,6 +72,16 @@
                                             <type>pdf</type>
                                             <classifier>documentation</classifier>
                                         </artifact>
+                                        <artifact>
+                                            <file>${project.build.directory}/docs/pdf/introduction.pdf</file>
+                                            <type>pdf</type>
+                                            <classifier>introduction</classifier>
+                                        </artifact>
+                                        <artifact>
+                                            <file>${project.build.directory}/docs/pdf/quickstart.pdf</file>
+                                            <type>pdf</type>
+                                            <classifier>quickstart</classifier>
+                                        </artifact>
                                     </artifacts>
                                 </configuration>
                             </execution>
@@ -454,6 +464,16 @@
                                     <file>${project.build.directory}/docs/html/documentation.html</file>
                                     <type>html</type>
                                     <classifier>documentation</classifier>
+                                </artifact>
+                                <artifact>
+                                    <file>${project.build.directory}/docs/html/introduction.html</file>
+                                    <type>html</type>
+                                    <classifier>introduction</classifier>
+                                </artifact>
+                                <artifact>
+                                    <file>${project.build.directory}/docs/html/quickstart.html</file>
+                                    <type>html</type>
+                                    <classifier>quickstart</classifier>
                                 </artifact>
                             </artifacts>
                         </configuration>

--- a/distribution/docs/src/assembly/docs-export.xml
+++ b/distribution/docs/src/assembly/docs-export.xml
@@ -28,7 +28,9 @@
             <directoryMode>0755</directoryMode>
             <directory>${project.build.directory}/docs/html</directory>
             <includes>
-                <include>documentation*.html</include>
+                <include>documentation.html</include>
+                <include>introduction.html</include>
+                <include>quickstart.html</include>
             </includes>
             <outputDirectory>html</outputDirectory>
         </fileSet>
@@ -38,6 +40,8 @@
             <directory>${project.build.directory}/docs/pdf</directory>
             <includes>
                 <include>documentation.pdf</include>
+                <include>introduction.pdf</include>
+                <include>quickstart.pdf</include>
             </includes>
             <outputDirectory>pdf</outputDirectory>
         </fileSet>

--- a/distribution/docs/src/main/resources/content/quickstart.adoc
+++ b/distribution/docs/src/main/resources/content/quickstart.adoc
@@ -1,0 +1,9 @@
+:type: quickStart
+:status: published
+:section: na
+:priority: 01
+:order: na
+:level: na
+:parent: na
+:title: Quickstart
+:toc: left


### PR DESCRIPTION
#### What does this PR do?

- fixes template to work with changes made in DDF in PR https://github.com/codice/ddf/pull/3321. 
- creates a standalone Quick Start document.

#### Who is reviewing it? 

@mcalcote @ahoffer @austinsteffes @rzwiefel @garrettfreibott 

#### Choose 2 committers to review/merge the PR.
@lessarderic
@ricklarsen - Documentation
@rzwiefel
@shaundmorris

#### How should this be tested?

. (checkout and build changes on this branch: https://github.com/codice/ddf/pull/3321)
. build these changes
.. documentation.html should appear the same.
.. quickstart.html should build successfully. 

#### What are the relevant tickets?

[CAL-291](https://codice.atlassian.net/browse/CAL-291)
[DDF-3870](https://codice.atlassian.net/browse/DDF-3870)

#### Screenshots (if appropriate)
#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
