### PR TITLE
CAL-291 added deprecation verbiage to pom file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,12 @@
         <at-symbol>@</at-symbol>
         <variable-prefix>${</variable-prefix>
         <image-width>500</image-width>
+        <deprecated>
+[IMPORTANT]
+====
+This Feature has been *DEPRECATED* and will be removed in a future version.
+====
+        </deprecated>
         <!-- Individual application names -->
         <catalog-ui>Intrigue</catalog-ui>
         <ddf-admin>Admin</ddf-admin>


### PR DESCRIPTION
#### What does this PR do?

added `deprecated` property to the pom file to resolve `${deprecated}` usage in documentation

#### Who is reviewing it? 
@mcalcote @ahoffer @austinsteffes @garrettfreibott 

#### Choose 2 committers to review/merge the PR.
@lessarderic
@ricklarsen - Documentation
@rzwiefel
@shaundmorris

#### How should this be tested?
#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-291](https://codice.atlassian.net/browse/CAL-291)
[DDF-3954](https://codice.atlassian.net/browse/CAL-3954)
#### Screenshots (if appropriate)
#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
