### PR TITLE
DDF-3981 Removed javadoc:aggregate step from pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -164,7 +164,6 @@ pipeline {
             }
             steps {
                 withMaven(maven: 'M3', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LINUX_MVN_RANDOM}') {
-                    sh 'mvn javadoc:aggregate -B -DskipStatic=true -DskipTests=true $DISABLE_DOWNLOAD_PROGRESS_OPTS'
                     sh 'mvn deploy -B -DskipStatic=true -DskipTests=true -DretryFailedDeploymentCount=10 $DISABLE_DOWNLOAD_PROGRESS_OPTS'
                 }
             }


### PR DESCRIPTION
#### What does this PR do?
Removes the javadoc:aggregate step from the pipeline. This step is no longer needed.

#### Who is reviewing it? 
<!--(please choose AT LEAST two reviewers that need to approve the PR before it can get merged)-->
@LinkMJB @oconnormi 

#### Ask 2 committers to review/merge the PR and tag them here.
<!--
If you don't know who to ask, you can request reviews in https://groups.google.com/forum/#!forum/ddf-developers .
(please choose ONLY two committers from below, delete the rest)
-->
@lessarderic
@ricklarsen - Documentation
@shaundmorris

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
The Jenkins pipeline is not used in CI at the moment

#### Any background context you want to provide?
There has been recent CI instability in this maven execution. It is believed to no longer be needed, so we're removing it.

#### What are the relevant tickets?
[DDF-3981](https://codice.atlassian.net/browse/DDF-3981)
#### Screenshots
<!--(if appropriate)-->
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
