### PR TITLE
[1.1.x] CAL-459 Updated how attributes are populated with from the ImageSegment.TGTID

### DIFF
--- a/catalog/imaging/imaging-transformer-nitf/pom.xml
+++ b/catalog/imaging/imaging-transformer-nitf/pom.xml
@@ -12,8 +12,8 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -30,29 +30,29 @@
             <groupId>ddf.catalog.core</groupId>
             <artifactId>catalog-core-api</artifactId>
             <version>${ddf.version}</version>
+            <scope>compile</scope>
         </dependency>
-
         <dependency>
             <groupId>ddf.catalog.core</groupId>
             <artifactId>catalog-core-api-impl</artifactId>
             <version>${ddf.version}</version>
+            <scope>compile</scope>
         </dependency>
-
         <dependency>
             <groupId>ddf.platform.util</groupId>
             <artifactId>platform-util</artifactId>
             <version>${ddf.version}</version>
         </dependency>
-
         <dependency>
             <groupId>ddf.platform.country</groupId>
             <artifactId>platform-country-converter-api</artifactId>
             <version>${ddf.version}</version>
+            <scope>compile</scope>
         </dependency>
-
         <dependency>
             <groupId>com.vividsolutions</groupId>
             <artifactId>jts-core</artifactId>
+            <version>${jts.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>xerces</groupId>
@@ -60,94 +60,44 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
-        <dependency>
-            <groupId>com.vividsolutions</groupId>
-            <artifactId>jts-io</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.codice.alliance.catalog.core</groupId>
-            <artifactId>catalog-core-api</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
         <dependency>
             <groupId>org.codice.alliance.catalog.core</groupId>
             <artifactId>catalog-core-api-impl</artifactId>
             <version>${project.version}</version>
+            <scope>compile</scope>
         </dependency>
-
         <dependency>
             <groupId>org.codice.imaging.nitf</groupId>
             <artifactId>codice-imaging-nitf-core-api</artifactId>
             <version>${nitf-imaging.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.codice.imaging.nitf</groupId>
             <artifactId>codice-imaging-nitf-core</artifactId>
             <version>${nitf-imaging.version}</version>
+            <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.codice.imaging.nitf</groupId>
-            <artifactId>codice-imaging-nitf-render</artifactId>
-            <version>${nitf-imaging.version}</version>
-        </dependency>
-
         <dependency>
             <groupId>org.codice.imaging.nitf</groupId>
             <artifactId>codice-imaging-nitf-fluent-api</artifactId>
             <version>${nitf-imaging.version}</version>
+            <scope>compile</scope>
         </dependency>
-
         <dependency>
             <groupId>org.codice.imaging.nitf</groupId>
             <artifactId>codice-imaging-nitf-fluent</artifactId>
             <version>${nitf-imaging.version}</version>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.github.jai-imageio</groupId>
-            <artifactId>jai-imageio-core</artifactId>
-            <version>${jai-imageio-core.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.github.jai-imageio</groupId>
-            <artifactId>jai-imageio-jpeg2000</artifactId>
-            <version>${jpeg2000.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.servicemix.bundles</groupId>
-            <artifactId>org.apache.servicemix.bundles.jsr305</artifactId>
-        </dependency>
-
-        <!--Spock dependencies-->
-        <dependency>
-            <groupId>ddf.lib</groupId>
-            <artifactId>spock-shaded</artifactId>
-            <version>${ddf.version}</version>
-            <scope>test</scope>
-        </dependency>
-
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>${commons-lang3.version}</version>
         </dependency>
-
         <dependency>
-            <groupId>org.codice.usng4j</groupId>
-            <artifactId>usng4j-impl</artifactId>
-            <version>${usng4j.version}</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>${commons-collections4.version}</version>
         </dependency>
     </dependencies>
 
@@ -163,9 +113,6 @@
                         <Embed-Dependency>
                             catalog-core-api-impl,
                             platform-util,
-                            jai-imageio-core,
-                            jai-imageio-jpeg2000,
-                            usng4j-impl,
                             commons-lang3
                         </Embed-Dependency>
                         <Export-Package/>
@@ -203,7 +150,6 @@
                                             <value>COVEREDRATIO</value>
                                             <minimum>0.77</minimum>
                                         </limit>
-
                                     </limits>
                                 </rule>
                             </rules>

--- a/catalog/imaging/imaging-transformer-nitf/pom.xml
+++ b/catalog/imaging/imaging-transformer-nitf/pom.xml
@@ -191,17 +191,17 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.85</minimum>
+                                            <minimum>0.90</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.65</minimum>
+                                            <minimum>0.78</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.63</minimum>
+                                            <minimum>0.77</minimum>
                                         </limit>
 
                                     </limits>

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/AbstractNitfMetacardType.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/AbstractNitfMetacardType.java
@@ -61,7 +61,7 @@ public abstract class AbstractNitfMetacardType extends MetacardTypeImpl {
   }
 
   public static <T> Set<AttributeDescriptor> getDescriptors(List<NitfAttribute<T>> attributes) {
-    return getDescriptors(attributes.toArray(new NitfAttribute[attributes.size()]));
+    return getDescriptors(attributes.toArray(new NitfAttribute[0]));
   }
 
   private void setDefaultDescriptors() {

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/ExtNitfUtility.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/ExtNitfUtility.java
@@ -22,6 +22,7 @@ import org.codice.alliance.transformer.nitf.common.NitfAttribute;
  * not map to the taxonomy.
  */
 public class ExtNitfUtility {
+
   public static final String EXT_NITF_PREFIX = "ext.nitf.";
 
   private ExtNitfUtility() {}

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/MetacardFactory.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/MetacardFactory.java
@@ -26,13 +26,13 @@ import org.slf4j.LoggerFactory;
 
 public class MetacardFactory {
 
-  private static final String ID = "ddf/catalog/transformer/nitf";
-
   private static final Logger LOGGER = LoggerFactory.getLogger(MetacardFactory.class);
 
   public static final MimeType MIME_TYPE;
 
   static final String MIME_TYPE_STRING = "image/nitf";
+
+  private static final String ID = "ddf/catalog/transformer/nitf";
 
   private static final String TO_STRING_PATTERN = "InputTransformer {Impl=%s, id=%s, mime-type=%s}";
 

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/NitfAttributeConverters.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/NitfAttributeConverters.java
@@ -18,7 +18,7 @@ import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.List;
 import javax.annotation.Nullable;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.codice.ddf.internal.country.converter.api.CountryCodeConverter;
 import org.codice.imaging.nitf.core.common.DateTime;
 

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/OverviewPredicate.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/OverviewPredicate.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import java.util.function.Predicate;
 
 public class OverviewPredicate implements Predicate<Metacard> {
+
   private final Predicate<String> isDerivedResourceOverviewUri =
       uri -> uri.startsWith(ContentItem.CONTENT_SCHEME) && uri.endsWith("#overview");
 

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/OverviewSupplier.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/OverviewSupplier.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 
 public class OverviewSupplier
     implements BiFunction<Metacard, Map<String, Serializable>, Optional<BufferedImage>> {
+
   private static final Logger LOGGER = LoggerFactory.getLogger(OverviewSupplier.class);
 
   private final MetacardTransformer resourceMetacardTransformer;

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/RoutingSlip.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/RoutingSlip.java
@@ -20,6 +20,7 @@ import org.codice.imaging.nitf.core.tre.TreCollection;
 import org.codice.imaging.nitf.fluent.NitfSegmentsFlow;
 
 public class RoutingSlip {
+
   public static final String GMTI_ROUTE = "direct://gmti";
 
   public static final String IMAGE_ROUTE = "direct://image";

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/HistoaAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/HistoaAttribute.java
@@ -13,7 +13,6 @@
  */
 package org.codice.alliance.transformer.nitf.common;
 
-import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.AttributeType;
 import ddf.catalog.data.impl.BasicTypes;
 import java.io.Serializable;
@@ -96,16 +95,6 @@ public class HistoaAttribute extends NitfAttributeImpl<Tre> {
       Function<Tre, Serializable> accessorFunction,
       AttributeType attributeType) {
     super(longName, shortName, accessorFunction, attributeType);
-    ATTRIBUTES.add(this);
-  }
-
-  private HistoaAttribute(
-      final String longName,
-      final String shortName,
-      final Function<Tre, Serializable> accessorFunction,
-      AttributeDescriptor attributeDescriptor,
-      String extNitfName) {
-    super(longName, shortName, accessorFunction, attributeDescriptor, extNitfName);
     ATTRIBUTES.add(this);
   }
 

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/NitfAttributeImpl.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/NitfAttributeImpl.java
@@ -22,7 +22,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.codice.alliance.transformer.nitf.ExtNitfUtility;
 import org.codice.imaging.nitf.core.tre.TreGroup;
 
@@ -36,7 +36,7 @@ public class NitfAttributeImpl<T> implements NitfAttribute<T> {
 
   private final Function<T, Serializable> extAccessorFunction;
 
-  private Set<AttributeDescriptor> attributeDescriptors;
+  private final Set<AttributeDescriptor> attributeDescriptors;
 
   private List<NitfAttribute<TreGroup>> indexedAttributes;
 
@@ -102,35 +102,6 @@ public class NitfAttributeImpl<T> implements NitfAttribute<T> {
       AttributeType attributeType,
       List<NitfAttribute<TreGroup>> indexedAttributes) {
     this(extNitfName, shortName, accessorFunction, attributeType);
-    this.indexedAttributes = indexedAttributes;
-  }
-
-  protected NitfAttributeImpl(
-      final String attributeName,
-      final String shortName,
-      final Function<T, Serializable> accessorFunction,
-      AttributeDescriptor attributeDescriptor,
-      String extNitfName,
-      List<NitfAttribute<TreGroup>> indexedAttributes) {
-    this(attributeName, shortName, accessorFunction, attributeDescriptor, extNitfName);
-    this.indexedAttributes = indexedAttributes;
-  }
-
-  protected NitfAttributeImpl(
-      final String attributeName,
-      final String shortName,
-      final Function<T, Serializable> accessorFunction,
-      final Function<T, Serializable> extAccessorFunction,
-      AttributeDescriptor attributeDescriptor,
-      String extNitfName,
-      List<NitfAttribute<TreGroup>> indexedAttributes) {
-    this(
-        attributeName,
-        shortName,
-        accessorFunction,
-        extAccessorFunction,
-        attributeDescriptor,
-        extNitfName);
     this.indexedAttributes = indexedAttributes;
   }
 

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/NitfHeaderAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/NitfHeaderAttribute.java
@@ -32,7 +32,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.codice.alliance.catalog.core.api.impl.types.IsrAttributes;
 import org.codice.alliance.catalog.core.api.impl.types.SecurityAttributes;
 import org.codice.alliance.catalog.core.api.types.Isr;

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/NitfHeaderTransformer.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/NitfHeaderTransformer.java
@@ -14,7 +14,6 @@
 package org.codice.alliance.transformer.nitf.common;
 
 import ddf.catalog.data.Metacard;
-import java.io.IOException;
 import org.codice.imaging.nitf.core.header.NitfHeader;
 import org.codice.imaging.nitf.fluent.NitfSegmentsFlow;
 
@@ -22,8 +21,7 @@ public class NitfHeaderTransformer extends SegmentHandler {
 
   private static final String NULL_ARGUMENT_MESSAGE = "Cannot transform null input.";
 
-  public NitfSegmentsFlow transform(NitfSegmentsFlow nitfSegmentsFlow, Metacard metacard)
-      throws IOException {
+  public NitfSegmentsFlow transform(NitfSegmentsFlow nitfSegmentsFlow, Metacard metacard) {
     if (nitfSegmentsFlow == null) {
       throw new IllegalArgumentException(NULL_ARGUMENT_MESSAGE);
     }

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/TreDescriptor.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/common/TreDescriptor.java
@@ -31,7 +31,7 @@ public enum TreDescriptor {
   PIATGB(PiatgbAttribute.getAttributes()),
   STDIDC(StdidcAttribute.getAttributes());
 
-  private List<NitfAttribute<Tre>> nitfAttributes;
+  private final List<NitfAttribute<Tre>> nitfAttributes;
 
   TreDescriptor(List<NitfAttribute<Tre>> nitfAttributes) {
     this.nitfAttributes = nitfAttributes;

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/gmti/GmtiMetacardType.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/gmti/GmtiMetacardType.java
@@ -16,6 +16,7 @@ package org.codice.alliance.transformer.nitf.gmti;
 import org.codice.alliance.transformer.nitf.AbstractNitfMetacardType;
 
 public class GmtiMetacardType extends AbstractNitfMetacardType {
+
   private static final String NAME = "isr.gmti";
 
   public GmtiMetacardType() {

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/gmti/IndexedMtirpbAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/gmti/IndexedMtirpbAttribute.java
@@ -128,13 +128,13 @@ public class IndexedMtirpbAttribute extends NitfAttributeImpl<TreGroup> {
   }
 
   private static String getClassificationCategory(TreGroup treGroup) {
-    Serializable value =
+    String value =
         TreUtility.getTreValue(
             treGroup, INDEXED_TARGET_CLASSIFICATION_CATEGORY_ATTRIBUTE.getShortName());
     if (value == null) {
       return MtiTargetClassificationCategory.U.getLongName();
     }
-    return MtiTargetClassificationCategory.valueOf((String) value).getLongName();
+    return MtiTargetClassificationCategory.valueOf(value).getLongName();
   }
 
   public static List<NitfAttribute<TreGroup>> getAttributes() {

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/gmti/MtiTargetClassificationCategory.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/gmti/MtiTargetClassificationCategory.java
@@ -19,7 +19,7 @@ enum MtiTargetClassificationCategory {
   U("Unknown"),
   W("Wheeled");
 
-  private String longName;
+  private final String longName;
 
   MtiTargetClassificationCategory(String longName) {
     this.longName = longName;

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/gmti/NitfGmtiTransformer.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/gmti/NitfGmtiTransformer.java
@@ -23,7 +23,7 @@ import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.data.types.Core;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.codice.alliance.transformer.nitf.common.SegmentHandler;
 import org.codice.imaging.nitf.fluent.NitfSegmentsFlow;
 import org.slf4j.Logger;

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/GraphicAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/GraphicAttribute.java
@@ -120,13 +120,13 @@ public enum GraphicAttribute implements NitfAttribute<GraphicSegment> {
 
   private static final String ATTRIBUTE_NAME_PREFIX = "graphic.";
 
-  private String shortName;
+  private final String shortName;
 
-  private String longName;
+  private final String longName;
 
-  private Function<GraphicSegment, Serializable> accessorFunction;
+  private final Function<GraphicSegment, Serializable> accessorFunction;
 
-  private Set<AttributeDescriptor> attributeDescriptors;
+  private final Set<AttributeDescriptor> attributeDescriptors;
 
   GraphicAttribute(
       final String lName,

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/ImageAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/ImageAttribute.java
@@ -16,13 +16,16 @@ package org.codice.alliance.transformer.nitf.image;
 import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.AttributeType;
 import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.impl.types.LocationAttributes;
 import ddf.catalog.data.impl.types.MediaAttributes;
+import ddf.catalog.data.types.Location;
 import ddf.catalog.data.types.Media;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Function;
+import org.apache.commons.lang3.StringUtils;
 import org.codice.alliance.catalog.core.api.impl.types.IsrAttributes;
 import org.codice.alliance.catalog.core.api.types.Isr;
 import org.codice.alliance.transformer.nitf.ExtNitfUtility;
@@ -31,6 +34,7 @@ import org.codice.alliance.transformer.nitf.common.NitfAttribute;
 import org.codice.alliance.transformer.nitf.common.NitfAttributeImpl;
 import org.codice.imaging.nitf.core.common.NitfFormatException;
 import org.codice.imaging.nitf.core.image.ImageSegment;
+import org.codice.imaging.nitf.core.image.TargetId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -236,6 +240,16 @@ public class ImageAttribute extends NitfAttributeImpl<ImageSegment> {
           ImageAttribute::getTargetId,
           new IsrAttributes().getAttributeDescriptor(Isr.TARGET_ID),
           TARGET_IDENTIFIER);
+
+  public static final ImageAttribute TARGET_IDENTIFIER_COUNTRY_CODE_ATTRIBUTE =
+      new ImageAttribute(
+          Location.COUNTRY_CODE,
+          "COUNTRY",
+          imageSegment ->
+              NitfAttributeConverters.fipsToStandardCountryCode(
+                  getTargetIdCountryCode(imageSegment)),
+          new LocationAttributes().getAttributeDescriptor(Location.COUNTRY_CODE),
+          "");
 
   /*
    * Non-normalized attributes
@@ -581,6 +595,20 @@ public class ImageAttribute extends NitfAttributeImpl<ImageSegment> {
       return imageSegment.getImageTargetId().textValue().trim();
     } catch (NitfFormatException nfe) {
       LOGGER.debug(nfe.getMessage(), nfe);
+    }
+
+    return null;
+  }
+
+  private static String getTargetIdCountryCode(ImageSegment imageSegment) {
+    final TargetId imageTargetId = imageSegment.getImageTargetId();
+
+    if (imageTargetId != null) {
+      final String countryCode = imageTargetId.getCountryCode();
+
+      if (StringUtils.isNotBlank(countryCode)) {
+        return countryCode;
+      }
     }
 
     return null;

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/ImageAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/ImageAttribute.java
@@ -233,13 +233,13 @@ public class ImageAttribute extends NitfAttributeImpl<ImageSegment> {
           new MediaAttributes().getAttributeDescriptor(Media.COMPRESSION),
           IMAGE_COMPRESSION);
 
-  public static final ImageAttribute TARGET_IDENTIFIER_ATTRIBUTE =
+  public static final ImageAttribute ISR_TARGET_IDENTIFIER_ATTRIBUTE =
       new ImageAttribute(
           Isr.TARGET_ID,
           "TGTID",
-          ImageAttribute::getTargetId,
+          imageSegment -> StringUtils.trimToNull(getTargetId(imageSegment)),
           new IsrAttributes().getAttributeDescriptor(Isr.TARGET_ID),
-          TARGET_IDENTIFIER);
+          "");
 
   public static final ImageAttribute TARGET_IDENTIFIER_COUNTRY_CODE_ATTRIBUTE =
       new ImageAttribute(
@@ -550,6 +550,10 @@ public class ImageAttribute extends NitfAttributeImpl<ImageSegment> {
           ImageSegment::getImageMagnificationAsDouble,
           BasicTypes.DOUBLE_TYPE);
 
+  public static final ImageAttribute NITF_TARGET_IDENTIFIER_ATTRIBUTE =
+      new ImageAttribute(
+          TARGET_IDENTIFIER, "TGTID", ImageAttribute::getTargetId, BasicTypes.STRING_TYPE);
+
   private ImageAttribute(
       final String longName,
       final String shortName,
@@ -587,14 +591,17 @@ public class ImageAttribute extends NitfAttributeImpl<ImageSegment> {
   }
 
   private static String getTargetId(ImageSegment imageSegment) {
-    if (imageSegment == null || imageSegment.getImageTargetId() == null) {
-      return null;
-    }
-
     try {
-      return imageSegment.getImageTargetId().textValue().trim();
-    } catch (NitfFormatException nfe) {
-      LOGGER.debug(nfe.getMessage(), nfe);
+      final TargetId targetId = imageSegment.getImageTargetId();
+      if (targetId != null) {
+        final String targetIdValue = targetId.textValue();
+        if (StringUtils.isNotBlank(targetIdValue)) {
+          return targetIdValue;
+        }
+      }
+    } catch (NitfFormatException e) {
+      LOGGER.debug(
+          "Unable to get valid target id from image segment id={}", imageSegment.getIdentifier());
     }
 
     return null;

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/ImageMetacardType.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/ImageMetacardType.java
@@ -16,6 +16,7 @@ package org.codice.alliance.transformer.nitf.image;
 import org.codice.alliance.transformer.nitf.AbstractNitfMetacardType;
 
 public class ImageMetacardType extends AbstractNitfMetacardType {
+
   private static final String NAME = "isr.image";
 
   public ImageMetacardType() {

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/LabelAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/LabelAttribute.java
@@ -102,13 +102,13 @@ public enum LabelAttribute implements NitfAttribute<LabelSegment> {
 
   private static final String ATTRIBUTE_NAME_PREFIX = "label.";
 
-  private String shortName;
+  private final String shortName;
 
-  private String longName;
+  private final String longName;
 
-  private Function<LabelSegment, Serializable> accessorFunction;
+  private final Function<LabelSegment, Serializable> accessorFunction;
 
-  private Set<AttributeDescriptor> attributeDescriptors;
+  private final Set<AttributeDescriptor> attributeDescriptors;
 
   LabelAttribute(
       final String lName, final String sName, final Function<LabelSegment, Serializable> accessor) {

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/NitfImageTransformer.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/NitfImageTransformer.java
@@ -26,7 +26,7 @@ import ddf.catalog.data.types.constants.core.DataType;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.codice.alliance.catalog.core.api.types.Isr;
 import org.codice.alliance.transformer.nitf.NitfAttributeConverters;
 import org.codice.alliance.transformer.nitf.common.SegmentHandler;
@@ -86,7 +86,7 @@ public class NitfImageTransformer extends SegmentHandler {
     if (polygonList.size() == 1) {
       metacard.setAttribute(new AttributeImpl(Core.LOCATION, polygonList.get(0).toText()));
     } else if (polygonList.size() > 1) {
-      Polygon[] polyAry = polygonList.toArray(new Polygon[polygonList.size()]);
+      Polygon[] polyAry = polygonList.toArray(new Polygon[0]);
       MultiPolygon multiPolygon = GEOMETRY_FACTORY.createMultiPolygon(polyAry);
       metacard.setAttribute(new AttributeImpl(Core.LOCATION, multiPolygon.toText()));
     }
@@ -157,7 +157,7 @@ public class NitfImageTransformer extends SegmentHandler {
       comments.forEach(
           comment -> {
             if (StringUtils.isNotBlank(comment)) {
-              sb.append(comment + " ");
+              sb.append(comment).append(" ");
             }
           });
 

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/SymbolAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/SymbolAttribute.java
@@ -125,13 +125,13 @@ public enum SymbolAttribute implements NitfAttribute<SymbolSegment> {
 
   private static final String ATTRIBUTE_NAME_PREFIX = "symbol.";
 
-  private String shortName;
+  private final String shortName;
 
-  private String longName;
+  private final String longName;
 
-  private Function<SymbolSegment, Serializable> accessorFunction;
+  private final Function<SymbolSegment, Serializable> accessorFunction;
 
-  private Set<AttributeDescriptor> attributeDescriptors;
+  private final Set<AttributeDescriptor> attributeDescriptors;
 
   SymbolAttribute(
       final String lName,

--- a/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/TextAttribute.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/java/org/codice/alliance/transformer/nitf/image/TextAttribute.java
@@ -114,13 +114,13 @@ public enum TextAttribute implements NitfAttribute<TextSegment> {
 
   private static final String ATTRIBUTE_NAME_PREFIX = "text.";
 
-  private String shortName;
+  private final String shortName;
 
-  private String longName;
+  private final String longName;
 
-  private Function<TextSegment, Serializable> accessorFunction;
+  private final Function<TextSegment, Serializable> accessorFunction;
 
-  private Set<AttributeDescriptor> attributeDescriptors;
+  private final Set<AttributeDescriptor> attributeDescriptors;
 
   TextAttribute(
       final String lName, final String sName, final Function<TextSegment, Serializable> accessor) {

--- a/catalog/imaging/imaging-transformer-nitf/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -14,11 +14,8 @@
  -->
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
            xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0
-           http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
-           http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0
-           http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd">
+           http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
 
     <bean id="imageMetacardType"
           class="org.codice.alliance.transformer.nitf.image.ImageMetacardType">

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/MetacardFactoryTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/MetacardFactoryTest.java
@@ -29,15 +29,14 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class MetacardFactoryTest {
-  private MetacardFactory metacardFactory;
 
   private static final String TEST_ID = "101";
 
   private static final String IMAGE_METACARD = "isr.image";
 
-  private static final String GMTI_METACARD = "isr.gmti";
+  private final List<MetacardType> metacardTypeList = new ArrayList<>();
 
-  List<MetacardType> metacardTypeList = new ArrayList<>();
+  private MetacardFactory metacardFactory;
 
   @Before
   public void setUp() {

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/OverviewPredicateTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/OverviewPredicateTest.java
@@ -23,6 +23,7 @@ import ddf.catalog.data.types.Core;
 import org.junit.Test;
 
 public class OverviewPredicateTest {
+
   private final OverviewPredicate predicate = new OverviewPredicate();
 
   @Test

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/OverviewSupplierTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/OverviewSupplierTest.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 
 public class OverviewSupplierTest {
+
   private OverviewSupplier supplier;
 
   private class IsMetacardWithDerivedOverviewResource extends ArgumentMatcher<Metacard> {

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/TreUtilityTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/TreUtilityTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.function.Consumer;
 import org.codice.alliance.transformer.nitf.common.TreUtility;
 import org.codice.imaging.nitf.core.common.DateTime;
@@ -56,10 +55,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class TreUtilityTest {
+
   private static final Logger LOGGER = LoggerFactory.getLogger(TreUtilityTest.class);
 
   @Test
-  public void testConvertToFloat() throws NitfFormatException, IOException {
+  public void testConvertToFloat() {
     Tre tre = TreFactory.getDefault("TestTre", TreSource.ImageExtendedSubheaderData);
     tre.add(new TreEntryImpl("FLOAT_VALID_1", "+123.456e2", "float"));
     tre.add(new TreEntryImpl("FLOAT_VALID_2", "-123", "float"));
@@ -87,7 +87,7 @@ public class TreUtilityTest {
   }
 
   @Test
-  public void testConvertToInteger() throws NitfFormatException, IOException {
+  public void testConvertToInteger() {
     Tre tre = TreFactory.getDefault("TestTre", TreSource.ImageExtendedSubheaderData);
     tre.add(new TreEntryImpl("INTEGER_VALID_1", "12345", "UINT"));
     tre.add(new TreEntryImpl("INTEGER_VALID_2", "-12345", "UINT"));
@@ -115,13 +115,13 @@ public class TreUtilityTest {
   }
 
   public static void createNitfNoImageNoTres(String filename) {
-    new NitfCreationFlowImpl().fileHeader(() -> createFileHeader()).write(filename);
+    new NitfCreationFlowImpl().fileHeader(TreUtilityTest::createFileHeader).write(filename);
   }
 
   public static void createNitfImageNoTres(String filename) {
     new NitfCreationFlowImpl()
-        .fileHeader(() -> createFileHeader())
-        .imageSegment(() -> createImageSegment())
+        .fileHeader(TreUtilityTest::createFileHeader)
+        .imageSegment(TreUtilityTest::createImageSegment)
         .write(filename);
   }
 
@@ -152,18 +152,18 @@ public class TreUtilityTest {
 
               return null;
             })
-        .imageSegment(() -> createImageSegment())
+        .imageSegment(TreUtilityTest::createImageSegment)
         .write(filename);
   }
 
-  public static NitfHeader createFileHeaderWithMtirpb() throws NitfFormatException {
+  private static NitfHeader createFileHeaderWithMtirpb() throws NitfFormatException {
     NitfHeader nitfHeader = createFileHeader();
     TreCollection treCollection = nitfHeader.getTREsRawStructure();
     treCollection.add(createMtirpbTre());
     return nitfHeader;
   }
 
-  public static Tre createMtirpbTre() throws NitfFormatException {
+  private static Tre createMtirpbTre() throws NitfFormatException {
     final String[] fieldNames = {
       "MTI_DP",
       "MTI_PACKET_ID",
@@ -216,7 +216,7 @@ public class TreUtilityTest {
     return tre;
   }
 
-  public static TreGroup createTreGroup(StringBuilder stringBuilder) throws NitfFormatException {
+  private static TreGroup createTreGroup(StringBuilder stringBuilder) throws NitfFormatException {
     final String[] treGroupFields = {
       "TGT_LOC", "TGT_LOC_ACCY", "TGT_VEL_R", "TGT_SPEED", "TGT_HEADING", "TGT_AMPLITUDE", "TGT_CAT"
     };
@@ -286,7 +286,7 @@ public class TreUtilityTest {
     return createFileHeader(DateTimeImpl.getNitfDateTimeForNow(), fileSecurityMetadata);
   }
 
-  public static NitfHeader createFileHeader(
+  private static NitfHeader createFileHeader(
       DateTime fileDateTime, FileSecurityMetadata fileSecurityMetadata) {
     NitfHeader nitfHeader = createFileHeader(fileDateTime);
     when(nitfHeader.getFileSecurityMetadata()).thenReturn(fileSecurityMetadata);

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/AcftbAttributeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/AcftbAttributeTest.java
@@ -16,13 +16,12 @@ package org.codice.alliance.transformer.nitf.common;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertThat;
 
-import org.codice.imaging.nitf.core.common.NitfFormatException;
 import org.junit.Test;
 
 public class AcftbAttributeTest {
 
   @Test
-  public void testAcftbAttribute() throws NitfFormatException {
+  public void testAcftbAttribute() {
     AcftbAttribute.getAttributes()
         .forEach(attribute -> assertThat(attribute.getShortName(), notNullValue()));
     AcftbAttribute.getAttributes()

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/NitfHeaderAttributeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/common/NitfHeaderAttributeTest.java
@@ -42,7 +42,7 @@ public class NitfHeaderAttributeTest {
   }
 
   @Test
-  public void testValidFileClassificationSystem() throws Exception {
+  public void testValidFileClassificationSystem() {
     NitfTestCommons.setupNitfUtilities("US", Collections.singletonList("ABC"));
 
     FileSecurityMetadata fsmMock = mock(FileSecurityMetadata.class);
@@ -58,7 +58,7 @@ public class NitfHeaderAttributeTest {
 
   @SuppressWarnings("ReturnValueIgnored")
   @Test(expected = NitfAttributeTransformException.class)
-  public void testMultipleConvertedCountryCodesForFileClassificationSystem() throws Exception {
+  public void testMultipleConvertedCountryCodesForFileClassificationSystem() {
     NitfTestCommons.setupNitfUtilities("US", Arrays.asList("ABC", "XYZ"));
 
     FileSecurityMetadata fsmMock = mock(FileSecurityMetadata.class);
@@ -70,7 +70,7 @@ public class NitfHeaderAttributeTest {
   }
 
   @Test
-  public void testNitfFileReleasabilityWithMultipleSpaces() throws Exception {
+  public void testNitfFileReleasabilityWithMultipleSpaces() {
     CountryCodeConverter mockCountryCodeConverter = mock(CountryCodeConverter.class);
     doReturn(Collections.singletonList("USA"))
         .when(mockCountryCodeConverter)

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/gmti/GmtiAttributesTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/gmti/GmtiAttributesTest.java
@@ -17,37 +17,24 @@ import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertThat;
 
 import java.util.stream.Stream;
-import org.codice.imaging.nitf.core.common.NitfFormatException;
 import org.junit.Test;
 
 public class GmtiAttributesTest {
 
   @Test
-  public void testImageAttributes() throws NitfFormatException {
+  public void testImageAttributes() {
 
     MtirpbAttribute.getAttributes()
-        .forEach(
-            attribute -> {
-              assertThat(attribute.getShortName(), notNullValue());
-            });
+        .forEach(attribute -> assertThat(attribute.getShortName(), notNullValue()));
 
     MtirpbAttribute.getAttributes()
-        .forEach(
-            attribute -> {
-              assertThat(attribute.getLongName(), notNullValue());
-            });
+        .forEach(attribute -> assertThat(attribute.getLongName(), notNullValue()));
 
     IndexedMtirpbAttribute.getAttributes()
-        .forEach(
-            attribute -> {
-              assertThat(attribute.getShortName(), notNullValue());
-            });
+        .forEach(attribute -> assertThat(attribute.getShortName(), notNullValue()));
 
     IndexedMtirpbAttribute.getAttributes()
-        .forEach(
-            attribute -> {
-              assertThat(attribute.getLongName(), notNullValue());
-            });
+        .forEach(attribute -> assertThat(attribute.getLongName(), notNullValue()));
 
     Stream.of(MtiTargetClassificationCategory.values())
         .forEach(attribute -> assertThat(attribute.getLongName(), notNullValue()));

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/gmti/GmtiMetacardTypeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/gmti/GmtiMetacardTypeTest.java
@@ -75,6 +75,6 @@ public class GmtiMetacardTypeTest {
     descriptors.addAll(AbstractNitfMetacardType.getDescriptors(StdidcAttribute.getAttributes()));
     assertThat(
         gmtiCardType.getAttributeDescriptors(),
-        containsInAnyOrder(descriptors.toArray(new AttributeDescriptor[descriptors.size()])));
+        containsInAnyOrder(descriptors.toArray(new AttributeDescriptor[0])));
   }
 }

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/gmti/NitfGmtiTransformerTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/gmti/NitfGmtiTransformerTest.java
@@ -28,7 +28,6 @@ import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.MetacardTypeImpl;
-import ddf.catalog.transform.CatalogTransformerException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -56,17 +55,18 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class NitfGmtiTransformerTest {
+
   private static final String GMTI_TEST_NITF = "src/test/resources/gmti-test.ntf";
 
   private static final String GMTI_METACARD = "isr.gmti";
+
+  private final List<MetacardType> metacardTypeList = new ArrayList<>();
 
   private MetacardFactory metacardFactory;
 
   private NitfHeaderTransformer nitfHeaderTransformer;
 
   private NitfGmtiTransformer nitfGmtiTransformer;
-
-  private List<MetacardType> metacardTypeList = new ArrayList<>();
 
   @Before
   public void setUp() {
@@ -81,18 +81,18 @@ public class NitfGmtiTransformerTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testNullNitfSegmentsFlow() throws Exception {
+  public void testNullNitfSegmentsFlow() {
     nitfGmtiTransformer.transform(null, new MetacardImpl());
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testNullMetacard() throws Exception {
+  public void testNullMetacard() {
     NitfSegmentsFlow nitfSegmentsFlow = mock(NitfSegmentsFlow.class);
     nitfGmtiTransformer.transform(nitfSegmentsFlow, null);
   }
 
   @Test
-  public void testTre() throws IOException, CatalogTransformerException, NitfFormatException {
+  public void testTre() throws IOException, NitfFormatException {
     NitfSegmentsFlow nitfSegmentsFlow =
         new NitfParserInputFlowImpl().inputStream(getInputStream(GMTI_TEST_NITF)).allData();
 

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageAttributeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageAttributeTest.java
@@ -99,7 +99,15 @@ public class ImageAttributeTest {
         is(COMMENT_9));
 
     assertThat(
-        ImageAttribute.TARGET_IDENTIFIER_ATTRIBUTE.getAccessorFunction().apply(imageSegment),
+        ImageAttribute.NITF_TARGET_IDENTIFIER_ATTRIBUTE.getAccessorFunction().apply(imageSegment),
+        is(nullValue()));
+    assertThat(
+        ImageAttribute.ISR_TARGET_IDENTIFIER_ATTRIBUTE.getAccessorFunction().apply(imageSegment),
+        is(nullValue()));
+    assertThat(
+        ImageAttribute.TARGET_IDENTIFIER_COUNTRY_CODE_ATTRIBUTE
+            .getAccessorFunction()
+            .apply(imageSegment),
         is(nullValue()));
     assertThat(
         ImageAttribute.TARGET_IDENTIFIER_COUNTRY_CODE_ATTRIBUTE

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageAttributeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageAttributeTest.java
@@ -102,6 +102,11 @@ public class ImageAttributeTest {
         ImageAttribute.TARGET_IDENTIFIER_ATTRIBUTE.getAccessorFunction().apply(imageSegment),
         is(nullValue()));
     assertThat(
+        ImageAttribute.TARGET_IDENTIFIER_COUNTRY_CODE_ATTRIBUTE
+            .getAccessorFunction()
+            .apply(imageSegment),
+        is(nullValue()));
+    assertThat(
         ImageAttribute.IMAGE_DATE_AND_TIME_ATTRIBUTE.getAccessorFunction().apply(imageSegment),
         is(nullValue()));
     assertThat(

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageAttributeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageAttributeTest.java
@@ -21,30 +21,29 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.codice.imaging.nitf.core.common.NitfFormatException;
 import org.codice.imaging.nitf.core.image.ImageSegment;
 import org.junit.Before;
 import org.junit.Test;
 
 public class ImageAttributeTest {
 
-  public static final String COMMENT_1 = "comment 1";
+  private static final String COMMENT_1 = "comment 1";
 
-  public static final String COMMENT_2 = "comment 2";
+  private static final String COMMENT_2 = "comment 2";
 
-  public static final String COMMENT_3 = "comment 3";
+  private static final String COMMENT_3 = "comment 3";
 
-  public static final String COMMENT_4 = "comment 4";
+  private static final String COMMENT_4 = "comment 4";
 
-  public static final String COMMENT_5 = "comment 5";
+  private static final String COMMENT_5 = "comment 5";
 
-  public static final String COMMENT_6 = "comment 6";
+  private static final String COMMENT_6 = "comment 6";
 
-  public static final String COMMENT_7 = "comment 7";
+  private static final String COMMENT_7 = "comment 7";
 
-  public static final String COMMENT_8 = "comment 8";
+  private static final String COMMENT_8 = "comment 8";
 
-  public static final String COMMENT_9 = "comment 9";
+  private static final String COMMENT_9 = "comment 9";
 
   private ImageSegment imageSegment;
 
@@ -65,7 +64,7 @@ public class ImageAttributeTest {
   }
 
   @Test
-  public void testImageAttributes() throws NitfFormatException {
+  public void testImageAttributes() {
     ImageAttribute.getAttributes()
         .forEach(
             attribute ->

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageInputTransformerTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageInputTransformerTest.java
@@ -732,7 +732,8 @@ public class ImageInputTransformerTest {
         NitfHeaderAttribute.ORIGINATORS_PHONE_NUMBER_ATTRIBUTE, new NitfValue("(520) 538-5458"));
     map.put(ImageAttribute.FILE_PART_TYPE_ATTRIBUTE, new NitfValue("IM"));
     map.put(ImageAttribute.IMAGE_IDENTIFIER_1_ATTRIBUTE, new NitfValue("Missing ID"));
-    map.put(ImageAttribute.TARGET_IDENTIFIER_ATTRIBUTE, new NitfValue(null));
+    map.put(ImageAttribute.ISR_TARGET_IDENTIFIER_ATTRIBUTE, new NitfValue(null));
+    map.put(ImageAttribute.NITF_TARGET_IDENTIFIER_ATTRIBUTE, new NitfValue(null));
     map.put(ImageAttribute.TARGET_IDENTIFIER_COUNTRY_CODE_ATTRIBUTE, new NitfValue(null));
     final String imageIdentifier2 = "- BASE IMAGE -";
     map.put(ImageAttribute.MISSION_ID_ATTRIBUTE, new NitfValue(imageIdentifier2));

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageInputTransformerTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageInputTransformerTest.java
@@ -32,9 +32,6 @@ import ddf.catalog.data.Attribute;
 import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.MetacardImpl;
-import ddf.catalog.federation.FederationException;
-import ddf.catalog.source.SourceUnavailableException;
-import ddf.catalog.source.UnsupportedQueryException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -88,7 +85,8 @@ import org.junit.Test;
 public class ImageInputTransformerTest {
 
   private static final String GEO_NITF = "i_3001a.ntf";
-  public static final String TEST_CLASSIFICATION_SYSTEM = "US";
+
+  private static final String TEST_CLASSIFICATION_SYSTEM = "US";
 
   private NitfImageTransformer transformer = null;
 
@@ -97,8 +95,7 @@ public class ImageInputTransformerTest {
   private MetacardFactory metacardFactory = null;
 
   @Before
-  public void createTransformer()
-      throws UnsupportedQueryException, SourceUnavailableException, FederationException {
+  public void createTransformer() {
     transformer = new NitfImageTransformer();
 
     metacardFactory = new MetacardFactory();
@@ -111,12 +108,12 @@ public class ImageInputTransformerTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testNullNitfSegmentsFlow() throws Exception {
+  public void testNullNitfSegmentsFlow() {
     transformer.transform(null, new MetacardImpl());
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testNullMetacard() throws Exception {
+  public void testNullMetacard() {
     NitfSegmentsFlow nitfSegmentsFlow = mock(NitfSegmentsFlow.class);
     transformer.transform(nitfSegmentsFlow, null);
   }
@@ -151,7 +148,7 @@ public class ImageInputTransformerTest {
   }
 
   @Test
-  public void testHandleCommentsSuccessful() throws Exception {
+  public void testHandleCommentsSuccessful() {
     final String blockComment =
         "The credit belongs to the man who is actually in the arena, whose face is marred"
             + " by dust and sweat and blood; who strives valiantly; who errs, who comes short"
@@ -170,7 +167,7 @@ public class ImageInputTransformerTest {
   }
 
   @Test
-  public void testHandleCommentsEmpty() throws Exception {
+  public void testHandleCommentsEmpty() {
     List<String> commentsList = new ArrayList<>();
     Metacard metacard = metacardFactory.createMetacard("commentsTest");
     transformer.handleComments(metacard, commentsList);
@@ -210,7 +207,7 @@ public class ImageInputTransformerTest {
     imageSegment.getTREsRawStructure().add(aimidb);
 
     new NitfCreationFlowImpl()
-        .fileHeader(() -> TreUtilityTest.createFileHeader())
+        .fileHeader(TreUtilityTest::createFileHeader)
         .imageSegment(() -> imageSegment)
         .write(file.getAbsolutePath());
 
@@ -268,7 +265,7 @@ public class ImageInputTransformerTest {
     imageSegment.getTREsRawStructure().add(expltb);
 
     new NitfCreationFlowImpl()
-        .fileHeader(() -> TreUtilityTest.createFileHeader())
+        .fileHeader(TreUtilityTest::createFileHeader)
         .imageSegment(() -> imageSegment)
         .write(file.getAbsolutePath());
 
@@ -303,8 +300,7 @@ public class ImageInputTransformerTest {
     }
   }
 
-  private static Map<NitfAttribute, NitfValue> createNitfWithPiaprd(File file)
-      throws NitfFormatException {
+  private static Map<NitfAttribute, NitfValue> createNitfWithPiaprd(File file) {
     String accessId = "THIS IS AN IPA FILE.                                       -END-";
     String keyword =
         "FIRST                                                             "
@@ -386,7 +382,7 @@ public class ImageInputTransformerTest {
     ImageSegment imageSegment = TreUtilityTest.createImageSegment();
     imageSegment.getTREsRawStructure().add(piaprd);
     new NitfCreationFlowImpl()
-        .fileHeader(() -> TreUtilityTest.createFileHeader())
+        .fileHeader(TreUtilityTest::createFileHeader)
         .imageSegment(() -> imageSegment)
         .write(file.getAbsolutePath());
 
@@ -829,7 +825,7 @@ public class ImageInputTransformerTest {
       String reason, Attribute attribute, DateTime... expectedDateTimes) {
     List<Date> expectedDates =
         Stream.of(expectedDateTimes)
-            .map(dateTime -> NitfAttributeConverters.nitfDate(dateTime))
+            .map(NitfAttributeConverters::nitfDate)
             .collect(Collectors.toList());
 
     assertThat(reason, attribute.getValues(), is(expectedDates));
@@ -849,25 +845,25 @@ public class ImageInputTransformerTest {
   }
 
   private static final class NitfValue {
-    private Object taxonomyValue;
+    private final Object taxonomyValue;
 
-    private Object extValue;
+    private final Object extValue;
 
-    public NitfValue(@Nullable Object value, @Nullable Object extValue) {
+    NitfValue(@Nullable Object value, @Nullable Object extValue) {
       this.taxonomyValue = value;
       this.extValue = extValue;
     }
 
-    public NitfValue(@Nullable Object value) {
+    NitfValue(@Nullable Object value) {
       this.taxonomyValue = value;
       this.extValue = value;
     }
 
-    public Object getTaxonomyValue() {
+    Object getTaxonomyValue() {
       return taxonomyValue;
     }
 
-    public Object getExtValue() {
+    Object getExtValue() {
       return extValue;
     }
   }

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageInputTransformerTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageInputTransformerTest.java
@@ -733,6 +733,7 @@ public class ImageInputTransformerTest {
     map.put(ImageAttribute.FILE_PART_TYPE_ATTRIBUTE, new NitfValue("IM"));
     map.put(ImageAttribute.IMAGE_IDENTIFIER_1_ATTRIBUTE, new NitfValue("Missing ID"));
     map.put(ImageAttribute.TARGET_IDENTIFIER_ATTRIBUTE, new NitfValue(null));
+    map.put(ImageAttribute.TARGET_IDENTIFIER_COUNTRY_CODE_ATTRIBUTE, new NitfValue(null));
     final String imageIdentifier2 = "- BASE IMAGE -";
     map.put(ImageAttribute.MISSION_ID_ATTRIBUTE, new NitfValue(imageIdentifier2));
     map.put(ImageAttribute.IMAGE_IDENTIFIER_2_ATTRIBUTE, new NitfValue(imageIdentifier2));

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageMetacardTypeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/ImageMetacardTypeTest.java
@@ -83,6 +83,6 @@ public class ImageMetacardTypeTest {
     descriptors.addAll(AbstractNitfMetacardType.getDescriptors(StdidcAttribute.getAttributes()));
     assertThat(
         imageCardType.getAttributeDescriptors(),
-        containsInAnyOrder(descriptors.toArray(new AttributeDescriptor[descriptors.size()])));
+        containsInAnyOrder(descriptors.toArray(new AttributeDescriptor[0])));
   }
 }

--- a/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/TextAttributeTest.java
+++ b/catalog/imaging/imaging-transformer-nitf/src/test/java/org/codice/alliance/transformer/nitf/image/TextAttributeTest.java
@@ -31,24 +31,22 @@ import org.junit.Test;
 
 public class TextAttributeTest {
 
-  public static final int TEXT_ATTACHMENT_LEVEL = 0;
+  private static final int TEXT_ATTACHMENT_LEVEL = 0;
 
-  public static final int EXTENDED_HEADER_DATA_OVERFLOW = 0;
+  private static final int EXTENDED_HEADER_DATA_OVERFLOW = 0;
 
-  public static final String TEXT_TITLE = "TEXT_TITLE";
+  private static final String TEXT_TITLE = "TEXT_TITLE";
 
-  public static final TextFormat TEXT_FORMAT = TextFormat.USMTF;
+  private static final TextFormat TEXT_FORMAT = TextFormat.USMTF;
 
-  public static final String TEXT_IDENTIFIER = "101";
+  private static final String TEXT_IDENTIFIER = "101";
 
   private TextSegment textSegment;
-
-  private DateTime currentDateTime;
 
   @Before
   public void setUp() {
     this.textSegment = mock(TextSegment.class);
-    this.currentDateTime = DateTimeImpl.getNitfDateTimeForNow();
+    final DateTime currentDateTime = DateTimeImpl.getNitfDateTimeForNow();
     when(textSegment.getIdentifier()).thenReturn(TEXT_IDENTIFIER);
     when(textSegment.getSecurityMetadata()).thenReturn(mock(SecurityMetadata.class));
     when(textSegment.getTextDateTime()).thenReturn(currentDateTime);

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_Segment_Image-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_Segment_Image-table.adoc
@@ -112,7 +112,7 @@
 |true
 
 |ImageSegment.TGTID
-|trimmed text value
+|none
 |ext.nitf.image.target-identifier
 |String
 |true

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_Segment_Image-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_Segment_Image-table.adoc
@@ -117,6 +117,16 @@
 |String
 |true
 
+|ImageSegment.TGTID
+|The last 2 characters of ImageSegment.TGTID correspond to the country code. If these characters are not spaces then null. Else,
+
+2char FIPS -> 3char ISO3
+
+If conversion fails, then null. NOTE: Other system plugins could populate the country code based on location.
+|<<location.country-code,location.country-code>>
+|String
+|true
+
 |ImageSegment.IM
 |Constant "IM"
 |ext.nitf.image.file-part-type

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_TRE_STDIDC-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/NITF_TRE_STDIDC-table.adoc
@@ -18,7 +18,7 @@
 |Tre.STDIDC.COUNTRY
 |2char FIPS -> 3char ISO3
 
-If conversion fails other system plugins could populate the country code based on location.
+If conversion fails, then null. NOTE: Other system plugins could populate the country code based on location.
 |<<location.country-code,location.country-code>>
 |String
 |true


### PR DESCRIPTION
#### What does this PR do?
The `ImageSegment.TGTID` may contain a country code that should be used to populate `location.country-code`. This is not easily testable because I would think that if a NITF image segment had a location, then the GeoCoderPlugin would use the `location` attribute to populate the 
`location.country-code`.

Additionally, while the `isr.target-id` attribute contains the stripped value from `ImageSegment.TGTID`, this PR updates the `ext.nitf.image.target-identifier` to contain the original, non-stripped value. This is important because the `ImageSegment.TGTID` consists of 3 parts (characters 0-9, 10-14, 15-16) where each part is optionally stored in the string value as spaces. After stripping the `ImageSegment.TGTID`, it is not obvious which of the 3 parts is left, so it would be worthwhile to keep the original value in at least the non-normalized attribute.
#### Who is reviewing it? 
@peterhuffer @kcover @ethantmanns @JGatley 
#### Choose 2 committers to review/merge the PR.
@clockard
@vinamartin
#### How should this be tested?

- Ingest a NITF with a populated country code in the `ImageSegment.TGTID`. Confirm that the `location.country-code` is populated appropriately.
- Ingest a NITF with a partially-populated `ImageSegment.TGTID`. Confirm that the `ext.nitf.image.target-identifier` contains the original, non-stripped value. @kcover noticed that repeated spaces appear as one space in Intrigue or when `Export as XML`. You can confirm the number of spaces is correct by downloading the metacard xml, instead of just viewing it in the browser.

#### What are the relevant tickets?
[CAL-459](https://codice.atlassian.net/browse/CAL-459)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests