### PR TITLE
1.1.X CAL-458 Update common-bin to include DDF ps script

### DIFF
--- a/distribution/common/src/main/resources/common-bin.xml
+++ b/distribution/common/src/main/resources/common-bin.xml
@@ -86,6 +86,7 @@
                 <include>bin/client.bat</include>
                 <include>bin/inc.bat</include>
                 <include>bin/get_property.bat</include>
+                <include>bin/service.ps1</include>
             </includes>
             <lineEnding>dos</lineEnding>
             <fileMode>0755</fileMode>


### PR DESCRIPTION
This script is needed to run Alliance as a background process using the start.bat command.

What does this PR do?
This allows the system to be run with the start.bat scripts.

Who is reviewing it?
@clockard @rzwiefel @kcover @ahoffer @austinsteffes @peterhuffer @taz77 @kcrowe01

How should this be tested?
Build, unzip the distribution and confirm service.ps1 is present in the bin directory.