### PR TITLE
[1.1.x]CAL-460 Changed to allow mocking of final methods/classes

### DIFF
--- a/catalog/video/video-mpegts-stream/pom.xml
+++ b/catalog/video/video-mpegts-stream/pom.xml
@@ -154,6 +154,13 @@
             <version>1.0-beta-2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <!-- Upgrade mockito to version 2.1.0 for this module to get final mock capability -->
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.1.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/catalog/video/video-mpegts-stream/src/test/java/org/codice/alliance/video/stream/mpegts/plugins/FindChildrenStreamEndPluginTest.java
+++ b/catalog/video/video-mpegts-stream/src/test/java/org/codice/alliance/video/stream/mpegts/plugins/FindChildrenStreamEndPluginTest.java
@@ -189,10 +189,11 @@ public class FindChildrenStreamEndPluginTest {
   public void testSubsequentErrors()
       throws UnsupportedQueryException, SourceUnavailableException, FederationException {
 
-    Class[] exceptions = new Class[FindChildrenStreamEndPlugin.MAX_SUBSEQUENT_ERROR_COUNT + 1];
+    Throwable[] exceptions =
+        new Throwable[FindChildrenStreamEndPlugin.MAX_SUBSEQUENT_ERROR_COUNT + 1];
 
     IntStream.range(0, FindChildrenStreamEndPlugin.MAX_SUBSEQUENT_ERROR_COUNT + 1)
-        .forEach(i -> exceptions[i] = SourceUnavailableException.class);
+        .forEach(i -> exceptions[i] = new SourceUnavailableException());
 
     when(catalogFramework.query(any())).thenThrow(exceptions);
 
@@ -223,7 +224,7 @@ public class FindChildrenStreamEndPluginTest {
     when(catalogFramework.query(any()))
         .thenAnswer(
             invocationOnMock -> {
-              QueryRequest queryRequest = invocationOnMock.getArgumentAt(0, QueryRequest.class);
+              QueryRequest queryRequest = invocationOnMock.getArgument(0);
               switch (queryRequest.getQuery().getStartIndex()) {
                 case 1:
                   return queryResponse1;

--- a/catalog/video/video-mpegts-stream/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/catalog/video/video-mpegts-stream/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
#### What does this PR do?
Prevents overriding of the Security.getSystemSubject method in DDF. These changes are to fix unit tests to allow mocking of final methods and classes. 

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)
@ethantmanns 
@jhunzik 

#### Choose 2 committers to review/merge the PR.
(please choose ONLY two committers from below, delete the rest)
@coyotesqrl 
@tbatie 

#### How should this be tested?
Get changes and test respective unit tests

#### Any background context you want to provide?
In reality, any user who could replace a secured piece of code would already have full access to the system and could do much more. That is why this issue is of low-priority.

#### What are the relevant tickets?
[CAL-460](https://codice.atlassian.net/browse/CAL-460)
[DDF-4055](https://codice.atlassian.net/browse/DDF-4055)

#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
