### PR TITLE
CAL-468 Decrease requested build container resources from linux-large to linux-medium

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 //"Jenkins Pipeline is a suite of plugins which supports implementing and integrating continuous delivery pipelines into Jenkins. Pipeline provides an extensible set of tools for modeling delivery pipelines "as code" via the Pipeline DSL."
 //More information can be found on the Jenkins Documentation page https://jenkins.io/doc/
 pipeline {
-    agent { label 'linux-large' }
+    agent { label 'linux-medium' }
     options {
         buildDiscarder(logRotator(numToKeepStr: '25'))
         disableConcurrentBuilds()


### PR DESCRIPTION
#### What does this PR do?
Decreases requested build container resources from 4 CPU's and 8GB of RAM, to 2 CPU's and 6GB of RAM. This will release resources back for other builds when it is not necessary for Alliance to build successfully
#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)
@oconnormi 
@clockard 
@mcalcote 
#### Choose 2 committers to review/merge the PR.
(please choose ONLY two committers from below, delete the rest)
@clockard
@shaundmorris 
#### How should this be tested?
This will take effect on pipeline builds post-merge. We are already running using 'linux-medium' on the legacy Alliance builds, as well as PR builds.
#### Any background context you want to provide?
#### What are the relevant tickets?
[CAL-468](https://codice.atlassian.net/browse/CAL-468)