### PR TITLE
CAL-469 Upgrade moment in NSILI code to 2.20.1

### DIFF
--- a/catalog/nsili/catalog-nsili-sourcestoquery-ui/pom.xml
+++ b/catalog/nsili/catalog-nsili-sourcestoquery-ui/pom.xml
@@ -108,7 +108,7 @@
         <dependency>
             <groupId>org.webjars.bower</groupId>
             <artifactId>moment</artifactId>
-            <version>2.18.1</version>
+            <version>${moment.version}</version>
         </dependency>
         <dependency>
             <groupId>org.webjars.bower</groupId>

--- a/catalog/video/video-admin-plugin/pom.xml
+++ b/catalog/video/video-admin-plugin/pom.xml
@@ -131,7 +131,7 @@
         <dependency>
             <groupId>org.webjars.bower</groupId>
             <artifactId>moment</artifactId>
-            <version>2.20.1</version>
+            <version>${moment.version}</version>
         </dependency>
         <dependency>
             <groupId>org.webjars.bower</groupId>

--- a/distribution/docs/src/main/resources/content/_reference/_dependency-list/alliance-dependency-list.adoc
+++ b/distribution/docs/src/main/resources/content/_reference/_dependency-list/alliance-dependency-list.adoc
@@ -128,7 +128,6 @@
 * org.webjars.bower:jquery-ui:jar:1.10.4
 * org.webjars.bower:jquery:jar:1.11.0
 * org.webjars.bower:lodash:jar:2.4.1
-* org.webjars.bower:moment:jar:2.18.1
 * org.webjars.bower:moment:jar:2.20.1
 * org.webjars.bower:require-css:jar:0.1.5
 * org.webjars.bower:requirejs-plugins:jar:1.0.2

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <httpcore.version>4.4.6</httpcore.version>
         <httpclient.version>4.5.5</httpclient.version>
         <javax.ws.rs.version>2.1</javax.ws.rs.version>
+        <moment.version>2.20.1</moment.version>
         <!-- output directory for reports -->
         <project.report.output.directory>project-info</project.report.output.directory>
         <joda-time.version>2.9.9</joda-time.version>


### PR DESCRIPTION
#### What does this PR do?

Upgrade moment in NSILI code to 2.20.1 to get rid of a security vulnerability.

Note: When testing alliance as an NSILI source I receive 0 query results and get a series of exceptions printed in the client alliance. Since this occurs on 1.1.1 it is unrelated to my changes and I think should be handled in a separate PR if it can be reproduced. @beyelerb is making some changes in this area and said he would investigate this issue further.

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)

@peterhuffer @emmberk @bakejeyner 

#### Choose 2 committers to review/merge the PR.
(please choose ONLY two committers from below, delete the rest)

@beyelerb 
@clockard

#### How should this be tested?

Install alliance and start the NSILI app. To test the ability to query a source, start the [test server](https://github.com/codice/alliance/tree/master/distribution/sdk/sample-nsili-server) that is provided in alliance, set it up as an nsili source, do a wildcard search on the source, and check that you get results back. To test the ability to respond to a query, simply add the local system as it's own nsili source, search that source, and verify that you get the exceptions that I mentioned above.

#### What are the relevant tickets?

[CAL-469](https://codice.atlassian.net/browse/CAL-469)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
