### PR TITLE
CAL-471 Updated ha profile because of solr-server-standalone removal

### DIFF
--- a/distribution/common/src/main/resources/etc/profiles/ha.json
+++ b/distribution/common/src/main/resources/etc/profiles/ha.json
@@ -63,7 +63,6 @@
     "platform-commands",
     "platform-scheduler",
     "metrics-reporting",
-    "metrics-interceptor",
-    "platform-solr-server-standalone"
+    "metrics-interceptor"
   ]
 }


### PR DESCRIPTION
#### What does this PR do?
Updates the ha profile to remove solr-server-standalone which was removed from DDF.

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)
@figliold
@ethantmanns
@tyler30clemens

#### Choose 2 committers to review/merge the PR.
(please choose ONLY two committers from below, delete the rest)
@clockard
@pklinef
#### How should this be tested?
No impact to production or HA since the entry removed was simply stopping the bundle if present.
PR build should be sufficient.

#### Any background context you want to provide?
#### What are the relevant tickets?
[CAL-471](https://codice.atlassian.net/browse/CAL-471)
[DDF-4136](https://codice.atlassian.net/browse/DDF-4136)

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
