### PR TITLE
CAL-447 updated docs template to publish user guide

### DIFF
--- a/distribution/docs/src/main/resources/content/using.adoc
+++ b/distribution/docs/src/main/resources/content/using.adoc
@@ -1,0 +1,11 @@
+:type: using
+:status: published
+:section: na
+:priority: 01
+:order: na
+:level: na
+:parent: na
+:title:
+:summary:
+:link:
+:toc: left


### PR DESCRIPTION
#### What does this PR do?

updates documentation templates to publish standalone User documentation. 

#### Who is reviewing it? 
@mcalcote @ahoffer @garrettfreibott @austinsteffes 
#### Choose 2 committers to review/merge the PR.
@clockard
@lessarderic
@ricklarsen - Documentation
@shaundmorris

#### How should this be tested?

Builds successfully and creates a `using.html` and a `using.pdf` (if built with the `release` profile)

#### Any background context you want to provide?

Relies on changes found in this upstream PR: https://github.com/codice/ddf/pull/3761

#### What are the relevant tickets?

[DDF-3887](https://codice.atlassian.net/browse/DDF-3887)
[CAL-447](https://codice.atlassian.net/browse/CAL-447)

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
