### PR TITLE
CAL-478 Added acdbugger to itests

### DIFF
--- a/distribution/test/itests/test-itests-alliance/pom.xml
+++ b/distribution/test/itests/test-itests-alliance/pom.xml
@@ -369,8 +369,40 @@
                             <asyncDestroyOnShutdown>${solr.async}</asyncDestroyOnShutdown>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>attach-ace-debugger</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>java</executable>
+                            <arguments>
+                                <argument>-jar</argument>
+                                <argument>
+                                    ${settings.localRepository}/org/codice/acdebugger/acdebugger-debugger/${acdebugger.version}/acdebugger-debugger-${acdebugger.version}-jar-with-dependencies.jar
+                                </argument>
+                                <argument>--continuous</argument>
+                                <argument>--debug</argument>
+                                <argument>--wait</argument>
+                                <argument>--reconnect</argument>
+                                <argument>--fail</argument>
+                            </arguments>
+                            <async>true</async>
+                        </configuration>
+                    </execution>
                 </executions>
-            </plugin>
-        </plugins>
-    </build>
-</project>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codice.acdebugger</groupId>
+                        <artifactId>acdebugger-debugger</artifactId>
+                        <version>${acdebugger.version}</version>
+                        <classifier>jar-with-dependencies</classifier>
+                        <type>jar</type>
+                    </dependency>
+                </dependencies>
+            </executions>
+        </plugin>
+    </plugins>
+</build>
+        </project>


### PR DESCRIPTION
**DEPENDS ON: https://github.com/codice/ddf/pull/3867**
#### What does this PR do?
Attaches the acdebugger during itests.
#### Who is reviewing it? 
@paouelle @coyotesqrl 
#### Choose 2 committers to review/merge the PR.
@lessarderic 
@tbatie
#### How should this be tested?
#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-478](https://codice.atlassian.net/browse/CAL-478)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
