### PR TITLE
CAL-484 CSD Search lock (multithreading issue)

### DIFF
--- a/catalog/nsili/catalog-nsili-source/src/main/java/org/codice/alliance/nsili/source/NsiliSource.java
+++ b/catalog/nsili/catalog-nsili-source/src/main/java/org/codice/alliance/nsili/source/NsiliSource.java
@@ -250,8 +250,6 @@ public class NsiliSource extends MaskableImpl
 
   private ExecutorService executorService;
 
-  private CompletionService<Result> completionService;
-
   private CorbaOrb corbaOrb = null;
 
   private Object queryLockObj = new Object();
@@ -726,7 +724,7 @@ public class NsiliSource extends MaskableImpl
    * Uses the NsiliFilterDelegate to create a STANAG 4559 BQS (Boolean Syntax Query) from the DDF
    * Query
    *
-   * @param query - the incoming query
+   * @param query - the query recieved from the Search-Ui
    * @return - a STANAG4559 complaint query
    * @throws UnsupportedQueryException
    */
@@ -822,7 +820,9 @@ public class NsiliSource extends MaskableImpl
     if (dagListHolder.value != null) {
       List<Result> results = new ArrayList<>();
       String id = getId();
-      List<Future> futures = new ArrayList<>(dagListHolder.value.length);
+      List<Future<Result>> futures = new ArrayList<>(dagListHolder.value.length);
+      CompletionService<Result> completionService =
+          new ExecutorCompletionService<Result>(executorService);
 
       for (DAG dag : dagListHolder.value) {
         Callable<Result> convertRunner =
@@ -1063,7 +1063,6 @@ public class NsiliSource extends MaskableImpl
     }
 
     executorService = Executors.newFixedThreadPool(numberWorkerThreads);
-    completionService = new ExecutorCompletionService(executorService);
     if (waitingTasks != null) {
       for (Runnable task : waitingTasks) {
         executorService.submit(task);


### PR DESCRIPTION
#### What does this PR do?
- move the completionService instance to the submitQuery function
- makes the list with Futures and the completionService operate in the same context (thread) and stay in sync
#### Who is reviewing it? 
@blen-desta
@brjeter
@Kjames5269
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)
#### Choose 2 committers to review/merge the PR.
(please choose ONLY two committers from below, delete the rest)
@clockard
@coyotesqrl
#### How should this be tested?
Deploy a version of Alliance and attempt multiple quick searches against a CSD source.  It should not lock anymore.

#### Any background context you want to provide?
When searching the CSD the search can lock (i.e. does not complete). This can be reproduced by several consecutive clicks on the search/cancel search button when querying the CSD source.

#### What are the relevant tickets?
[CAL-484](https://codice.atlassian.net/browse/CAL-484)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
