### PR TITLE
CAL-496 added external link icon to external links in docs

### DIFF
--- a/distribution/docs/src/main/resources/content/_core-concepts/data-standards.adoc
+++ b/distribution/docs/src/main/resources/content/_core-concepts/data-standards.adoc
@@ -13,15 +13,15 @@
 |File Extensions
 |Additional Metadata Attributes Available (if populated)
 
-|http://www.gwg.nga.mil/ntb/baseline/docs/2500c/index.html[NITF 2.0 and 2.1]
+|http://www.gwg.nga.mil/ntb/baseline/docs/2500c/index.html[NITF 2.0 and 2.1] {external-link}
 |ntf
 |<<{metadata-prefix}common_metadata_attributes,Standard attributes>> and <<{metadata-prefix}nitf_attribute_mappings,NITF Attribute Mappings>>
 
-|http://www.gwg.nga.mil/ntb/baseline/docs/NSIF/[NSIF/STANAG 4545]
+|http://www.gwg.nga.mil/ntb/baseline/docs/NSIF/[NSIF/STANAG 4545] {external-link}
 |ntf
 |<<{metadata-prefix}common_metadata_attributes,Standard attributes>> and <<{metadata-prefix}nitf_attribute_mappings,NITF Attribute Mappings>>
 
-|http://www.gwg.nga.mil/misb/docs/nato_docs/STANAG_4609_Ed3.pdf[STANAG 4609 FMV]
+|http://www.gwg.nga.mil/misb/docs/nato_docs/STANAG_4609_Ed3.pdf[STANAG 4609 FMV] {external-link}
 |fmv
 |<<{metadata-prefix}common_metadata_attributes,Standard attributes>>
 
@@ -33,7 +33,7 @@
 |
 |<<{metadata-prefix}common_metadata_attributes,Standard attributes>>
 
-|http://www.gwg.nga.mil/documents/ntb/STANAG_4559_ed2.pdf[STANAG 4559 / NSILI] mpeg4 with KLV
+|http://www.gwg.nga.mil/documents/ntb/STANAG_4559_ed2.pdf[STANAG 4559 / NSILI] {external-link} mpeg4 with KLV
 |mpeg4
 |<<{metadata-prefix}common_metadata_attributes,Standard attributes>>
 

--- a/distribution/docs/src/main/resources/content/_core-concepts/service-standards.adoc
+++ b/distribution/docs/src/main/resources/content/_core-concepts/service-standards.adoc
@@ -14,13 +14,13 @@
 |Sources
 |Status
 
-|http://www.gwg.nga.mil/documents/ntb/STANAG_4559_ed2.pdf[Standardization Agreement (STANAG) 4559 - NATO Standard ISR Library Interface (NSILI)]
+|http://www.gwg.nga.mil/documents/ntb/STANAG_4559_ed2.pdf[Standardization Agreement (STANAG) 4559 - NATO Standard ISR Library Interface (NSILI)] {external-link}
 |<<{metadata-prefix}nsili_endpoint,NSILI Endpoint>>
 |<<{metadata-prefix}nsili_connected_source,NSILI Connected Source>>, <<{metadata-prefix}nsili_federated_source,NSILI Federated Source>>
 |Supported
 
 
-|http://www.isotc211.org/schemas/2005/gmd/[Geographic MetaData extensible markup language (GMD)/ISO 19115:2003]
+|http://www.isotc211.org/schemas/2005/gmd/[Geographic MetaData extensible markup language (GMD)/ISO 19115:2003] {external-link}
 |
 |<<{metadata-prefix}gmd_csw_source,GMD CSW Source>>
 |Supported

--- a/distribution/docs/src/main/resources/content/_endpoints/nsili-endpoint.adoc
+++ b/distribution/docs/src/main/resources/content/_endpoints/nsili-endpoint.adoc
@@ -5,7 +5,7 @@
 :summary: 
 :implements: 
 
-The NSILI Endpoint enables a client to search by http://www.gwg.nga.mil/documents/ntb/STANAG_4559_ed2.pdf[NSILI] compliant metadata.
+The NSILI Endpoint enables a client to search by http://www.gwg.nga.mil/documents/ntb/STANAG_4559_ed2.pdf[NSILI] {external-link} compliant metadata.
 
 ===== Installing NSILI Endpoint
 

--- a/distribution/docs/src/main/resources/content/_managing/attributes-added-by-pre-ingest-plugins.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/attributes-added-by-pre-ingest-plugins.adoc
@@ -6,7 +6,7 @@
 :order: 051
 
 * The <<{application-prefix}default_security_attribute_plugin,Default Security Attribute Plugin>> is a configurable plugin that maps system high user attribute values to metacard attribute values.
-"System high user attributes" refers to the attributes on the ${branding}'s https://en.wikipedia.org/wiki/Second-level_domain[Second-Level Domain] user, who is defined in the `etc/users.attributes` file.
+"System high user attributes" refers to the attributes on the ${branding}'s https://en.wikipedia.org/wiki/Second-level_domain[Second-Level Domain] {external-link} user, who is defined in the `etc/users.attributes` file.
 For example, if `https://localhost:8993` is the ${branding}'s domain name, then the `localhost` user has the system high user attributes.
 See <<{architecture-prefix}configuring_the_default_security_attribute_plugin,Configuring the Default Security Attribute Plugin>> for configuration details.
 Note that if security markings have already been applied to the metacard, the values will not be overridden by this plugin.

--- a/distribution/docs/src/main/resources/content/_metadataAttributes/isr-attributes-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataAttributes/isr-attributes-table.adoc
@@ -66,7 +66,7 @@
 |[[_isr.nato-reporting-code]]isr.nato-reporting-code
 |A reporting code as defined in STANAG 3596.
 |String
-|One or more of the values in STANAG 3596. Refer to http://ncap.org.uk/feature/nato-target-reporting-categories.
+|One or more of the values in STANAG 3596. Refer to http://ncap.org.uk/feature/nato-target-reporting-categories {external-link}.
 |01, 02, ... 19
 
 |[[_isr.mission-id]]isr.mission-id

--- a/distribution/docs/src/main/resources/content/config.adoc
+++ b/distribution/docs/src/main/resources/content/config.adoc
@@ -11,6 +11,7 @@ Version: ${project.version}. Copyright (c) Codice Foundation
 :sectnums:
 :sectnumlevels: 5
 :title-logo-image: image::alliance-logo.png[]
+:external-link: image:external-link.png[This link is outside the ${branding} documentation]
 :branding: Alliance
 :hardening-step: Required Step for Security Hardening
 :adoc-include: ${project.build.directory}/doc-contents/_ddf/docs-${ddf.version}


### PR DESCRIPTION
#### What does this PR do?

Adds a visual icon to mark external links that take the user away from the Alliance documentation.

(https://github.com/codice/ddf/pull/4053)

#### Who is reviewing it? 
@mcalcote @ahoffer @austinsteffes @garrettfreibott @vinamartin @alexaabrd 

#### Choose 2 committers to review/merge the PR.

@clockard
@lessarderic
@ricklarsen - Documentation
@shaundmorris
@vinamartin

#### How should this be tested?

- builds successfully
- icons added. 

#### What are the relevant tickets?

[CAL-496](https://codice.atlassian.net/browse/CAL-496)
[DDF-4291](https://codice.atlassian.net/browse/DDF-4291)

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
