### PR TITLE
[Java11] CAL-498 Upgrade Jacoco, codice-maven, codice-test, ac debugger versions in support of Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>ddf</groupId>
         <artifactId>ddf-parent</artifactId>
-        <version>1.0.4</version>
+        <version>1.0.5</version>
     </parent>
     <properties>
         <!--Documentation Replacements-->
@@ -122,9 +122,10 @@
 
         <!--Project properties-->
         <ddf.version>2.14.0-SNAPSHOT</ddf.version>
-        <ddf.support.version>2.3.14</ddf.support.version>
-        <codice-maven.version>0.1</codice-maven.version>
-        <codice-test.version>0.1</codice-test.version>
+        <ddf.support.version>2.3.16</ddf.support.version>
+        <codice-maven.version>0.2</codice-maven.version>
+        <codice-test.version>0.3</codice-test.version>
+	<acdebugger.version>1.7</acdebugger.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.report.output.directory>project-info</project.report.output.directory>
 
@@ -230,15 +231,23 @@
   -->
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
+            <groupId>org.codice.test</groupId>
+            <artifactId>spock-all</artifactId>
+            <version>${codice-test.version}</version>
+            <type>pom</type>
             <scope>test</scope>
         </dependency>
         <dependency>
+            <!--Hamcrest first, then JUnit, then Mockito. See http://goo.gl/e5bJA5-->
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <version>${hamcrest-all.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -256,12 +265,6 @@
         <dependency>
             <groupId>org.codice.test</groupId>
             <artifactId>junit-extensions</artifactId>
-            <version>${codice-test.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.codice.test</groupId>
-            <artifactId>spock-shaded</artifactId>
             <version>${codice-test.version}</version>
             <scope>test</scope>
         </dependency>
@@ -553,6 +556,11 @@
                                     <artifactId>support-checkstyle</artifactId>
                                     <version>${ddf.support.version}</version>
                                     <optional>true</optional>
+                                </dependency>
+				 <dependency>
+                                    <groupId>com.puppycrawl.tools</groupId>
+                                    <artifactId>checkstyle</artifactId>
+                                    <version>8.13</version>
                                 </dependency>
                             </dependencies>
                             <executions>


### PR DESCRIPTION
#### What does this PR do?
Upgrade Jacoco, codice-maven, codice-test, ac debugger versions in support of Java 11	
Updated ddf-parent to 1.5 and ddf-support to 2.3.16

#### Who is reviewing it? 
@ethantmanns 
@tyler30clemens 
@jhunzik 
@AzGoalie 

#### Select relevant component teams: 

#### Ask 2 committers to review/merge the PR and tag them here.
@coyotesqrl
@figliold
@tbatie

#### How should this be tested?
<!--(List steps with links to updated documentation)-->
- The PR build should be sufficient

#### Any background context you want to provide?
#### What are the relevant tickets?
[CAL-498](https://codice.atlassian.net/browse/CAL-498)
[DDF-4223](https://codice.atlassian.net/browse/DDF-4223)

#### Screenshots
<!--(if appropriate)-->

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
