### PR TITLE
CAL-448 updated docs templates for standalone integrator docs (#651)

### DIFF
--- a/distribution/docs/pom.xml
+++ b/distribution/docs/pom.xml
@@ -70,36 +70,6 @@
                                             <type>pdf</type>
                                             <classifier>documentation</classifier>
                                         </artifact>
-                                        <artifact>
-                                            <file>${project.build.directory}/docs/pdf/introduction.pdf</file>
-                                            <type>pdf</type>
-                                            <classifier>introduction</classifier>
-                                        </artifact>
-                                        <artifact>
-                                            <file>${project.build.directory}/docs/pdf/quickstart.pdf</file>
-                                            <type>pdf</type>
-                                            <classifier>quickstart</classifier>
-                                        </artifact>
-                                        <artifact>
-                                            <file>${project.build.directory}/docs/pdf/managing.pdf</file>
-                                            <type>pdf</type>
-                                            <classifier>managing</classifier>
-                                        </artifact>
-                                        <artifact>
-                                            <file>${project.build.directory}/docs/pdf/architecture.pdf</file>
-                                            <type>pdf</type>
-                                            <classifier>architecture</classifier>
-                                        </artifact>
-                                        <artifact>
-                                            <file>${project.build.directory}/docs/pdf/developing.pdf</file>
-                                            <type>pdf</type>
-                                            <classifier>developing</classifier>
-                                        </artifact>
-                                        <artifact>
-                                            <file>${project.build.directory}/docs/pdf/reference.pdf</file>
-                                            <type>pdf</type>
-                                            <classifier>reference</classifier>
-                                        </artifact>
                                     </artifacts>
                                 </configuration>
                             </execution>
@@ -482,36 +452,6 @@
                                     <file>${project.build.directory}/docs/html/documentation.html</file>
                                     <type>html</type>
                                     <classifier>documentation</classifier>
-                                </artifact>
-                                <artifact>
-                                    <file>${project.build.directory}/docs/html/introduction.html</file>
-                                    <type>html</type>
-                                    <classifier>introduction</classifier>
-                                </artifact>
-                                <artifact>
-                                    <file>${project.build.directory}/docs/html/quickstart.html</file>
-                                    <type>html</type>
-                                    <classifier>quickstart</classifier>
-                                </artifact>
-                                <artifact>
-                                    <file>${project.build.directory}/docs/html/managing.html</file>
-                                    <type>html</type>
-                                    <classifier>managing</classifier>
-                                </artifact>
-                                <artifact>
-                                    <file>${project.build.directory}/docs/html/architecture.html</file>
-                                    <type>html</type>
-                                    <classifier>architecture</classifier>
-                                </artifact>
-                                <artifact>
-                                    <file>${project.build.directory}/docs/html/developing.html</file>
-                                    <type>html</type>
-                                    <classifier>developing</classifier>
-                                </artifact>
-                                <artifact>
-                                    <file>${project.build.directory}/docs/html/reference.html</file>
-                                    <type>html</type>
-                                    <classifier>reference</classifier>
                                 </artifact>
                             </artifacts>
                         </configuration>

--- a/distribution/docs/src/main/resources/content/_endpoints/nsili-endpoint.adoc
+++ b/distribution/docs/src/main/resources/content/_endpoints/nsili-endpoint.adoc
@@ -22,11 +22,11 @@ Configure the NSILI Endpoint through the ${admin-console}.
 
 . Navigate to the ${admin-console}.
 . Select the *NSILI* application.
-.. If the application is not installed, see <<_installing_nsili,Installing NSILI>> to install.
+.. If the application is not installed, see <<{reference-prefix}installing_nsili,Installing NSILI>> to install.
 . Select *Configuration*.
 . Select *NSILI Endpoint Configuration*.
 
-See <<_org.codice.alliance.nsili.endpoint,NSILI Endpoint configurations>> for all possible configurations.
+See <<{reference-prefix}org.codice.alliance.nsili.endpoint,NSILI Endpoint configurations>> for all possible configurations.
 
 ===== NSILI Endpoint URL
 

--- a/distribution/docs/src/main/resources/content/integrating.adoc
+++ b/distribution/docs/src/main/resources/content/integrating.adoc
@@ -1,0 +1,11 @@
+:type: integratingIntro
+:status: published
+:section: na
+:priority: 01
+:order: na
+:level: na
+:parent: na
+:title:
+:summary:
+:link:
+:toc: left


### PR DESCRIPTION
**Port to `1.1.x` of PR [#651](https://github.com/codice/alliance/pull/639)**

#### What does this PR do?

Updates docs templates to publish standalone Integrator docs.

#### Who is reviewing it? 

@garrettfreibott @bakejeyner @austinsteffes 

#### Choose 2 committers to review/merge the PR.
@mcalcote 
@brjeter
@clockard
@lessarderic
@ricklarsen - Documentation
@shaundmorris

#### How should this be tested?

integrating.html file is generated during build; tests pass

#### What are the relevant tickets?

[CAL-448](https://codice.atlassian.net/browse/CAL-448)

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
