### PR TITLE
CAL-291 fixed typo in NITF transformer docs

### DIFF
--- a/distribution/docs/src/main/resources/content/_transformers/nitf-input-transformer.adoc
+++ b/distribution/docs/src/main/resources/content/_transformers/nitf-input-transformer.adoc
@@ -20,7 +20,7 @@ a|* video/avi
 * video/vnd.avi
 * video/x-msvideo
 * video/mp4
-* video/MP2T
+* video/mp2t
 * video/mpeg
 * video/quicktime
 * video/wmv


### PR DESCRIPTION
#### What does this PR do?

fixes a typo in the NITF transformer docs.

#### Who is reviewing it? 

@ahoffer @austinsteffes @bakejeyner 

#### Choose 2 committers to review/merge the PR.
@clockard
@coyotesqrl
@lessarderic
@ricklarsen - Documentation
@shaundmorris

#### How should this be tested?

verify content

#### What are the relevant tickets?

[CAL-291](https://codice.atlassian.net/browse/CAL-291)

#### Screenshots (if appropriate)

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
