### PR TITLE
CAL-291 fixed typo in NITF transformer docs

### DIFF
--- a/distribution/docs/src/main/resources/content/_architecture/_transformers/nitf-input-transformer.adoc
+++ b/distribution/docs/src/main/resources/content/_architecture/_transformers/nitf-input-transformer.adoc
@@ -20,7 +20,7 @@ a|* video/avi
 * video/vnd.avi
 * video/x-msvideo
 * video/mp4
-* video/MP2T
+* video/mp2t
 * video/mpeg
 * video/quicktime
 * video/wmv


### PR DESCRIPTION
**Port to master of PR: [#691](https://github.com/codice/alliance/pull/691)**
---
#### What does this PR do?

corrects typo in NITF transformer docs.

#### Who is reviewing it? 

@bakejeyner @ahoffer @austinsteffes 

#### Choose 2 committers to review/merge the PR.
@brendan-hofmann
@brjeter
@clockard
@lessarderic
@ricklarsen - Documentation
@shaundmorris
@mcalcote 

#### How should this be tested?

verify correction.

#### What are the relevant tickets?

[CAL-291](https://codice.atlassian.net/browse/CAL-291)

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
