### PR TITLE
CAL-505 removed Coverity stage from Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -198,32 +198,6 @@ pipeline {
                         }
                     }
                 }
-                // Coverity will be skipped on all PR builds
-                stage ('Coverity') {
-                    agent { label 'linux-medium' }
-                    steps {
-                        retry(3) {
-                            checkout scm
-                        }
-                        script {
-                            if (env.BRANCH_NAME != 'master') {
-                                echo "Coverity is only run on master"
-                            } else {
-                                withMaven(maven: 'M35', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LINUX_MVN_RANDOM}') {
-                                    withCredentials([string(credentialsId: 'alliance-coverity-token', variable: 'COVERITY_TOKEN')]) {
-                                        withEnv(["PATH=${tool 'coverity-linux'}/bin:${env.PATH}"]) {
-                                            configFileProvider([configFile(fileId: 'coverity-maven-settings', replaceTokens: true, variable: 'MAVEN_SETTINGS')]) {
-                                                sh 'cov-build --dir cov-int mvn -DskipTests=true -DskipStatic=true install -B -pl !$DOCS $DISABLE_DOWNLOAD_PROGRESS_OPTS --settings $MAVEN_SETTINGS'
-                                                sh 'tar czvf alliance.tgz cov-int'
-                                                sh 'curl --form token=$COVERITY_TOKEN --form email=cmp-security-team@connexta.com --form file=@alliance.tgz --form version="master" --form description="Description: Alliance CI Build" https://scan.coverity.com/builds?project=codice%2Falliance'
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
                 stage ('Codecov') {
                     agent { label 'linux-small' }
                     steps {


### PR DESCRIPTION
#### What does this PR do?
Remove Coverity stage from the Jenkins file
#### Who is reviewing it? 
@codice/build 
@LinkMJB 
@rymach

#### Choose 2 committers to review/merge the PR.
(please choose ONLY two committers from below, delete the rest)
@jrnorth 
@vinamartin
@oconnormi 
#### How should this be tested?
Verification of the syntax on the build file should be sufficient
#### Any background context you want to provide?
We haven't been able to build with Coverity in about a year
#### What are the relevant tickets?
[CAL-505](https://codice.atlassian.net/browse/CAL-505)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/codice/alliance/694)
<!-- Reviewable:end -->
