### PR TITLE
[1.1.x]CAL-506 Update MpegTsInputTransformer to set media type to video/mp2t

### DIFF
--- a/catalog/video/video-mpegts-transformer/src/main/java/org/codice/alliance/transformer/video/MpegTsInputTransformer.java
+++ b/catalog/video/video-mpegts-transformer/src/main/java/org/codice/alliance/transformer/video/MpegTsInputTransformer.java
@@ -21,6 +21,7 @@ import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.types.Core;
+import ddf.catalog.data.types.Media;
 import ddf.catalog.data.types.constants.core.DataType;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.InputTransformer;
@@ -259,6 +260,7 @@ public class MpegTsInputTransformer implements InputTransformer {
 
       MetacardImpl metacard = new MetacardImpl(innerMetacard, metacardType);
 
+      metacard.setAttribute(Media.TYPE, CONTENT_TYPE);
       metacard.setContentTypeName(CONTENT_TYPE);
 
       return metacard;

--- a/catalog/video/video-mpegts-transformer/src/test/java/org/codice/alliance/transformer/video/MpegTsInputTransformerTest.java
+++ b/catalog/video/video-mpegts-transformer/src/test/java/org/codice/alliance/transformer/video/MpegTsInputTransformerTest.java
@@ -14,6 +14,7 @@
 package org.codice.alliance.transformer.video;
 
 import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
@@ -27,6 +28,7 @@ import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.types.Core;
+import ddf.catalog.data.types.Media;
 import ddf.catalog.transform.CatalogTransformerException;
 import ddf.catalog.transform.InputTransformer;
 import java.io.ByteArrayInputStream;
@@ -180,6 +182,10 @@ public class MpegTsInputTransformerTest {
 
       Metacard finalMetacard = t.transform(inputStream);
 
+      assertThat(finalMetacard.getAttribute(Media.TYPE), is(notNullValue()));
+      assertThat(
+          finalMetacard.getAttribute(Media.TYPE).getValue(),
+          is(MpegTsInputTransformer.CONTENT_TYPE));
       assertThat(finalMetacard.getContentTypeName(), is(MpegTsInputTransformer.CONTENT_TYPE));
       assertThat(finalMetacard.getMetadata(), is("the metadata"));
     }


### PR DESCRIPTION
#### What does this PR do?
#### Who is reviewing it? 
@ahoffer @tyler30clemens @austinsteffes 
#### Choose 2 committers to review/merge the PR.
@emmberk 
@vinamartin
#### How should this be tested?
- Install Alliance.
- `feature:install video-app`
- `catalog:ingest -t mpegts <path-to-mpegts-file>` (https://github.com/codice/alliance/blob/master/catalog/video/video-mpegts-stream/src/test/resources/Closed_Caption_EIA_MPEG2.ts can be used)
- Verify through Intrigue that the media type is `video/mp2t` instead of `application/octet-stream`
#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-506](https://codice.atlassian.net/browse/CAL-506)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
