### PR TITLE
CAL-477 Declare dependencies that were received transitively

### DIFF
--- a/catalog/imaging/imaging-actionprovider-chip/pom.xml
+++ b/catalog/imaging/imaging-actionprovider-chip/pom.xml
@@ -49,6 +49,11 @@
             <version>${ddf.version}</version>
         </dependency>
         <dependency>
+            <groupId>ddf.platform</groupId>
+            <artifactId>platform-configuration</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+        <dependency>
             <groupId>ddf.catalog.core</groupId>
             <artifactId>catalog-core-api-impl</artifactId>
             <version>${ddf.version}</version>

--- a/catalog/nsili/catalog-nsili-common/pom.xml
+++ b/catalog/nsili/catalog-nsili-common/pom.xml
@@ -41,6 +41,11 @@
         </dependency>
         <dependency>
             <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
             <artifactId>catalog-core-api-impl</artifactId>
             <version>${ddf.version}</version>
         </dependency>

--- a/catalog/nsili/catalog-nsili-endpoint/pom.xml
+++ b/catalog/nsili/catalog-nsili-endpoint/pom.xml
@@ -31,6 +31,11 @@
     <dependencies>
         <dependency>
             <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
             <artifactId>catalog-core-api-impl</artifactId>
             <version>${ddf.version}</version>
         </dependency>

--- a/dependency-check-maven-config.xml
+++ b/dependency-check-maven-config.xml
@@ -84,4 +84,12 @@
         <cve>CVE-2017-7657</cve>
     </suppress>
 
+    <suppress>
+        <notes>FFMpeg vulnerabilities that don't affect our updated version</notes>
+        <cve>CVE-2009-0385</cve>
+        <cve>CVE-2011-4031</cve>
+        <cve>CVE-2005-4048</cve>
+        <cve>CVE-2018-1999012</cve>
+    </suppress>
+
 </suppressions>


### PR DESCRIPTION
#### What does this PR do?
https://github.com/codice/ddf/pull/4334 cleans up catalog core api dependencies and this pr addressed the now missing transitive dependences that were previously provided.
Also addressed owasp findings.
#### Who is reviewing it? 
@peterhuffer @kcover
#### Choose 2 committers to review/merge the PR.
@paouelle 
@vinamartin
#### How should this be tested?
Good CI Build
#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-477](https://codice.atlassian.net/browse/CAL-477)
