### PR TITLE
CAL-291 fixed typo in dependency list docs and added a dependency check suppression

### DIFF
--- a/dependency-check-maven-config.xml
+++ b/dependency-check-maven-config.xml
@@ -84,4 +84,20 @@
         <cve>CVE-2017-7657</cve>
     </suppress>
 
+    <suppress>
+        <notes>FFMpeg vulnerabilities that don't affect our updated version</notes>
+        <cve>CVE-2009-0385</cve>
+        <cve>CVE-2011-4031</cve>
+        <cve>CVE-2005-4048</cve>
+        <cve>CVE-2018-1999012</cve>
+    </suppress>
+
+    <suppress>
+        <notes>
+            XXE vulnerability in the Karaf deploy folder, up to (including) Karaf 4.2.1. This is
+            mitigated by file system hardening.
+        </notes>
+        <cve>CVE-2018-11788</cve>
+    </suppress>
+
 </suppressions>

--- a/distribution/docs/src/main/resources/content/_reference/_dependency-list/alliance-dependency-list.adoc
+++ b/distribution/docs/src/main/resources/content/_reference/_dependency-list/alliance-dependency-list.adoc
@@ -1,5 +1,5 @@
 :title: Dependency List
-:type: metadataReference
+:type: reference
 :status: published
 :parent: ${cal-branding} Dependency List
 :order: 00


### PR DESCRIPTION
**PORT to `master` of PR #701**

#### What does this PR do?

fixes incorrect document type in dependency list docs. 

#### Who is reviewing it? 

@ahoffer @bakejeyner @blen-desta @garrettfreibott 

#### Choose 2 committers to review/merge the PR.
@clockard
@lessarderic
@ricklarsen - Documentation
@shaundmorris

#### How should this be tested?
builds successfully with dependency list included. 

#### What are the relevant tickets?

[CAL-291](https://codice.atlassian.net/browse/CAL-291)

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
