### PR TITLE
[1.1.x] CAL-0705 Commented out the windows build stage until Jenkins issues are resolved

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,6 +62,8 @@ pipeline {
                         }
                     }
                 }
+                //Commenting out Windows builds until pipeline issues can be resolved
+                /*
                 stage ('Windows') {
                     agent { label 'server-2016-large' }
                     steps {
@@ -77,6 +79,7 @@ pipeline {
                         }
                     }
                 }
+                */
             }
         }
         // The full build will be run against all regular branches
@@ -94,6 +97,8 @@ pipeline {
                         }
                     }
                 }
+                //Commenting out Windows builds until pipeline issues can be resolved
+                /*
                 stage ('Windows') {
                     agent { label 'server-2016-large' }
                     steps {
@@ -108,6 +113,7 @@ pipeline {
                         }
                     }
                 }
+                */
             }
         }
         stage('Security Analysis') {


### PR DESCRIPTION
#### What does this PR do?
The pipeline builds are constantly failing on Windows which prevents them from running the static analysis steps such as OWASP. We're temporarily skipping the windows build stages in the Jenkins builds until pipeline issues are resolved.

#### Who is reviewing it? 
@brjeter
@clockard
@LinkMJB 
@shaundmorris 

#### What are the relevant tickets?
Fixes: https://github.com/codice/alliance/issues/705

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests