### PR TITLE
[1.1.x] CAL-516 updated docs module to add version checking

### DIFF
--- a/distribution/docs/pom.xml
+++ b/distribution/docs/pom.xml
@@ -138,7 +138,7 @@
                                     <classifier>adoc-files</classifier>
                                     <type>zip</type>
                                     <overWrite>false</overWrite>
-                                    <outputDirectory>${project.build.directory}/upstream-adoc/_ddf</outputDirectory>
+                                    <outputDirectory>${project.build.directory}/pre-build-${project.version}/upstream-adoc-${project.version}/_ddf</outputDirectory>
                                     <includes>**</includes>
                                 </artifactItem>
                                 <artifactItem>
@@ -157,7 +157,7 @@
                                     <classifier>adoc-files</classifier>
                                     <version>${ddf.version}</version>
                                     <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/upstream-adoc/ui-help</outputDirectory>
+                                    <outputDirectory>${project.build.directory}/pre-build-${project.version}/upstream-adoc-${project.version}/ui-help</outputDirectory>
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>ddf.ui.search</groupId>
@@ -174,7 +174,7 @@
                                     <classifier>doc-templates</classifier>
                                     <type>zip</type>
                                     <overWrite>false</overWrite>
-                                    <outputDirectory>${project.build.directory}/upstream-templates</outputDirectory>
+                                    <outputDirectory>${project.build.directory}/pre-build-${project.version}/upstream-templates-${project.version}</outputDirectory>
                                     <includes>**</includes>
                                 </artifactItem>
                             </artifactItems>
@@ -193,7 +193,7 @@
                             <goal>copy-resources</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>${project.build.directory}/doc-contents/</outputDirectory>
+                            <outputDirectory>${project.build.directory}/build-${project.version}/filtered-adoc</outputDirectory>
                             <resources>
                                 <resource>
                                     <directory>src/main/resources</directory>
@@ -219,14 +219,51 @@
                             <goal>copy-resources</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>${project.build.directory}/doc-contents/content</outputDirectory>
+                            <outputDirectory>${project.build.directory}/build-${project.version}/filtered-adoc/content</outputDirectory>
                             <resources>
                                 <resource>
-                                    <directory>${project.build.directory}/upstream-adoc/</directory>
+                                    <directory>${project.build.directory}/pre-build-${project.version}/upstream-adoc-${project.version}</directory>
                                     <filtering>true</filtering>
                                     <includes>
                                         <include>**/*.adoc</include>
-                                        <include>**/*.html</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-config</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/asciidoctor-ready-${project.version}/</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>src/main/resources/content</directory>
+                                    <filtering>true</filtering>
+                                    <includes>
+                                        <include>config.adoc</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-scripts</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/asciidoctor-ready-${project.version}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.build.directory}/pre-build-${project.version}/upstream-adoc-${project.version}/_ddf/docs-${ddf.version}</directory>
+                                    <filtering>true</filtering>
+                                    <includes>
+                                        <include>scripts.html</include>
                                     </includes>
                                 </resource>
                             </resources>
@@ -239,10 +276,10 @@
                             <goal>copy-resources</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>${project.build.directory}/doc-contents/templates</outputDirectory>
+                            <outputDirectory>${project.build.directory}/build-${project.version}/filtered-adoc/templates</outputDirectory>
                             <resources>
                                 <resource>
-                                    <directory>${project.build.directory}/upstream-templates/docs-${ddf.version}</directory>
+                                    <directory>${project.build.directory}/pre-build-${project.version}/upstream-templates-${project.version}/docs-${ddf.version}</directory>
                                     <filtering>true</filtering>
                                     <includes>
                                         <include>**/*.ftl</include>
@@ -258,14 +295,13 @@
                             <goal>copy-resources</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>${project.build.directory}/doc-contents/</outputDirectory>
+                            <outputDirectory>${project.build.directory}/build-${project.version}/filtered-adoc</outputDirectory>
                             <resources>
                                 <resource>
-                                    <directory>${project.build.directory}/upstream-templates/docs-${ddf.version}/</directory>
+                                    <directory>${project.build.directory}/pre-build-${project.version}/upstream-templates-${project.version}/docs-${ddf.version}/</directory>
                                     <filtering>true</filtering>
                                     <includes>
                                         <include>jbake.properties</include>
-                                        <include>content/scripts.html</include>
                                     </includes>
                                 </resource>
                             </resources>
@@ -278,8 +314,15 @@
                             <goal>copy-resources</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>${project.build.directory}/doc-contents/images</outputDirectory>
+                            <outputDirectory>${project.build.directory}/images</outputDirectory>
                             <resources>
+                                <resource>
+                                    <directory>src/main/resources/images</directory>
+                                    <filtering>false</filtering>
+                                    <includes>
+                                        <include>*</include>
+                                    </includes>
+                                </resource>
                                 <resource>
                                     <directory>${project.build.directory}/images/docs-${ddf.version}</directory>
                                     <filtering>false</filtering>
@@ -312,8 +355,8 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <inputDirectory>${project.build.directory}/doc-contents/</inputDirectory>
-                    <outputDirectory>${project.build.directory}/asciidoctor-ready</outputDirectory>
+                    <inputDirectory>${project.build.directory}/build-${project.version}/filtered-adoc</inputDirectory>
+                    <outputDirectory>${project.build.directory}/asciidoctor-ready-${project.version}</outputDirectory>
                 </configuration>
                 <dependencies>
                     <dependency>
@@ -385,10 +428,10 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <sourceDirectory>${project.build.directory}/asciidoctor-ready</sourceDirectory>
+                    <sourceDirectory>${project.build.directory}/asciidoctor-ready-${project.version}</sourceDirectory>
                     <gemPath>${project.build.directory}/gems-provided</gemPath>
                     <headerFooter>true</headerFooter>
-                    <imagesDir>${project.build.directory}/doc-contents/images</imagesDir>
+                    <imagesDir>${project.build.directory}/images</imagesDir>
                     <sourceHighlighter>${asciidoctor.source.highlighter}</sourceHighlighter>
                     <requires>
                         <require>asciidoctor-diagram</require>

--- a/distribution/docs/src/main/resources/content/config.adoc
+++ b/distribution/docs/src/main/resources/content/config.adoc
@@ -1,6 +1,7 @@
 Version: ${project.version}. Copyright (c) Codice Foundation
 :imagesdir: target/doc-contents/images
-:type: config
+:type: documentation
+:status: published
 :toc: left
 :toclevels: 6
 :example-caption!:

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <ddf.version>2.13.8</ddf.version>
+        <ddf.version>2.13.10-SNAPSHOT</ddf.version>
         <ddf.support.version>2.3.9</ddf.support.version>
         <codice-maven.version>0.2</codice-maven.version>
         <codice-test.version>0.3</codice-test.version>


### PR DESCRIPTION
#### What does this PR do?

Reconfigures the directory structure of the documentation build to include version number to prevent issues on quickbuilds or releases

#### Who is reviewing it? 
@ahoffer @austinsteffes @Kjames5269 

#### Select relevant component teams: 

@codice/build 
@codice/docs 

#### Ask 2 committers to review/merge the PR and tag them here.

@brjeter
@clockard
@lessarderic
@mcalcote
@ricklarsen - Documentation

#### How should this be tested?

(Depends on changes in this PR: https://github.com/codice/ddf/pull/4707)

- check out `master` branch
- build docs module with `mvn clean install`
- check out this branch
- build docs module with `mvn install` (leave previous build artifacts in target directory)
- smoke test

#### What are the relevant tickets?

[CAL-516](https://codice.atlassian.net/browse/CAL-516)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
