### PR TITLE
suppress cve that does not apply to alliance

### DIFF
--- a/dependency-check-maven-config.xml
+++ b/dependency-check-maven-config.xml
@@ -100,4 +100,15 @@
         <cve>CVE-2018-11788</cve>
     </suppress>
 
+    <suppress>
+        <notes><![CDATA[
+   file name: lodash-2.4.1.jar
+
+        video-admin-plugin and catalog-nsili-sourcestoquery-ui use the lodash jar, but only the min function.
+        This CVE does not apply.
+   ]]></notes>
+        <gav regex="true">^org\.webjars\.bower:lodash:.*$</gav>
+        <cve>CVE-2018-16487</cve>
+    </suppress>
+
 </suppressions>


### PR DESCRIPTION
#### What does this PR do?

Suppress cve that does not apply to alliance.

The lodash jar from org.webjars.bower is used in Alliance by the video-admin-plugin and catalog-nsili-sourcestoquery-ui. In both cases, only the `min` function is being used (indicated by `underscore: 'lodash/2.4.1/dist/lodash.underscore.min'` in `main.js`). The CVE speaks of `merge, mergeWith, and defaultsDeep`. So, it seems like this CVE does not apply to our code.

I'm not 100% certain that this suppression is OK. Please review and comment.
#### Who is reviewing it? 
@rzwiefel 
@Bdthomson 
@andrewkfiedler 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)
#### Choose 2 committers to review/merge the PR.
(please choose ONLY two committers from below, delete the rest)

@bdeining
@jlcsmith
#### How should this be tested?
#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-xxx](https://codice.atlassian.net/browse/CAL-xxx)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
