### PR TITLE
[1.3.x] CAL-734 add none check on specific mpeg transformers

### DIFF
--- a/catalog/video/video-mpegts-transformer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/video/video-mpegts-transformer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -125,7 +125,7 @@
         <argument value="0.0001"/>
     </bean>
 
-    <service ref="transformer" interface="ddf.catalog.transform.InputTransformer">
+    <service ref="transformer" interface="ddf.catalog.transform.InputTransformer" ranking="1">
         <service-properties>
             <entry key="id" value="mpegts"/>
             <!-- shortname only exists for backwards compatibility -->
@@ -137,6 +137,7 @@
                 <list>
                     <value>video/mp2t</value>
                     <value>video/vnd.dlna.mpeg-tts</value>
+                    <value>video/mpeg</value>
                 </list>
             </entry>
         </service-properties>

--- a/libs/klv/src/main/java/org/codice/alliance/libs/klv/AlphanumericDistinctKlvProcessor.java
+++ b/libs/klv/src/main/java/org/codice/alliance/libs/klv/AlphanumericDistinctKlvProcessor.java
@@ -23,6 +23,8 @@ public class AlphanumericDistinctKlvProcessor extends DistinctKlvProcessor {
 
   @Override
   protected boolean isValidAttributeValue(Serializable value) {
-    return Utilities.isNotBlankString(value) && Utilities.isAlphanumericString(value);
+    return Utilities.isNotBlankString(value)
+        && Utilities.isAlphanumericString(value)
+        && Utilities.isNotStringNone(value);
   }
 }

--- a/libs/klv/src/main/java/org/codice/alliance/libs/klv/SecurityReleasingInstructionsKlvProcessor.java
+++ b/libs/klv/src/main/java/org/codice/alliance/libs/klv/SecurityReleasingInstructionsKlvProcessor.java
@@ -15,7 +15,7 @@ package org.codice.alliance.libs.klv;
 
 import org.codice.alliance.libs.stanag4609.Stanag4609TransportStreamParser;
 
-public class SecurityReleasingInstructionsKlvProcessor extends DistinctKlvProcessor {
+public class SecurityReleasingInstructionsKlvProcessor extends AlphanumericDistinctKlvProcessor {
   public SecurityReleasingInstructionsKlvProcessor() {
     super(
         AttributeNameConstants.RELEASING_INSTRUCTIONS,

--- a/libs/klv/src/main/java/org/codice/alliance/libs/klv/Utilities.java
+++ b/libs/klv/src/main/java/org/codice/alliance/libs/klv/Utilities.java
@@ -43,7 +43,8 @@ public class Utilities {
   // Used to see if certain security attributes are variant of string "None" so they are not put on
   // the metacard.
   public static boolean isNotStringNone(Serializable serializable) {
-    return serializable instanceof String && (!((String) serializable).trim().equalsIgnoreCase(("None")));
+    return serializable instanceof String
+        && (!((String) serializable).trim().equalsIgnoreCase(("None")));
   }
 
   static void safelySetAttribute(Metacard metacard, Attribute attribute) {

--- a/libs/klv/src/main/java/org/codice/alliance/libs/klv/Utilities.java
+++ b/libs/klv/src/main/java/org/codice/alliance/libs/klv/Utilities.java
@@ -40,6 +40,12 @@ public class Utilities {
     return serializable instanceof String && StringUtils.isAlphanumeric((String) serializable);
   }
 
+  // Used to see if certain security attributes are variant of string "None" so they are not put on
+  // the metacard.
+  public static boolean isNotStringNone(Serializable serializable) {
+    return serializable instanceof String && (!((String) serializable).trim().equalsIgnoreCase(("None")));
+  }
+
   static void safelySetAttribute(Metacard metacard, Attribute attribute) {
     notNull(attribute, "Attribute cannot be null");
     safelySetAttribute(metacard, attribute.getName(), attribute.getValues());

--- a/libs/klv/src/test/java/org/codice/alliance/libs/klv/UtilitiesTest.java
+++ b/libs/klv/src/test/java/org/codice/alliance/libs/klv/UtilitiesTest.java
@@ -98,6 +98,16 @@ public class UtilitiesTest {
   }
 
   @Test
+  public void testIsNotNoneString() throws Exception {
+    assertThat(Utilities.isNotStringNone(" "), is(true));
+    assertThat(Utilities.isNotStringNone("non"), is(true));
+    assertThat(Utilities.isNotStringNone("none"), is(false));
+    assertThat(Utilities.isNotStringNone("None"), is(false));
+    assertThat(Utilities.isNotStringNone("NONE"), is(false));
+    assertThat(Utilities.isNotStringNone("None "), is(false));
+  }
+
+  @Test
   public void testNullDescriptorDoesNotSetAttribute() throws Exception {
     AttributeImpl attribute = new AttributeImpl(ATTRIBUTE_KEY_POC, EXPECTED_POC);
     Metacard mockedMetacard = setupMetacardWithNullDescriptor();

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
         <yarn.version>v1.5.1</yarn.version>
 
         <!--Project properties-->
-        <ddf.version>2.16.1</ddf.version>
+        <ddf.version>2.16.2</ddf.version>
         <ddf.support.version>2.3.16</ddf.support.version>
         <codice-maven.version>0.2</codice-maven.version>
         <codice-test.version>0.3</codice-test.version>


### PR DESCRIPTION
#### What does this PR do?
adds a none check into the mpeginputtransformer
#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)
@tyler30clemens 
#### Choose 2 committers to review/merge the PR.
(please choose ONLY two committers from below, delete the rest)
@brjeter @brendan-hofmann 

#### How should this be tested?
see me for testing protocol
#### Any background context you want to provide?
#### What are the relevant tickets?
#734 

[CAL-xxx](https://codice.atlassian.net/browse/CAL-xxx)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
