### PR TITLE
Upgrade Guava to 25.1

### DIFF
--- a/catalog/nsili/nsili-app/src/main/resources/features.xml
+++ b/catalog/nsili/nsili-app/src/main/resources/features.xml
@@ -56,7 +56,9 @@
 
     <feature name="nsili-app" version="${project.version}"
              description="The NSILI App provides interoperability with STANAG 4559 compliant services.::NSILI">
+        <feature prerequisite="true">wrap</feature>
         <feature>catalog-app</feature>
+        <bundle>wrap:mvn:org.checkerframework/checker-qual/2.0.0$Bundle-Name=checker-qual&amp;Bundle-SymbolicName=checker-qual&amp;Bundle-Version=2.0.0&amp;Export-Package=org.checkerframework.checker.nullness.qual;version="2.0.0"</bundle>
         <bundle>mvn:org.apache.commons/commons-lang3/${commons-lang3.version}</bundle>
         <feature>catalog-email</feature>
         <feature>catalog-nsili-orb-api</feature>

--- a/distribution/sdk/sample-content-metadata-extractor/pom.xml
+++ b/distribution/sdk/sample-content-metadata-extractor/pom.xml
@@ -60,13 +60,16 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-                        <Export-Package />
+                        <Export-Package>
+                            org.codice.alliance.sdk.extraction
+                        </Export-Package>
                         <Embed-Dependency>
                             catalog-core-api-impl;groupId=org.codice.alliance.catalog.core;version=${project.version},
                             banner-marking
                             platform-util
                         </Embed-Dependency>
                         <Private-Package>
+                            org.codice.alliance.security.banner.marking.*,
                             ddf.catalog.data.impl.*
                         </Private-Package>
                     </instructions>

--- a/distribution/test/itests/test-itests-dependencies-app/src/main/filtered-resources/features.xml
+++ b/distribution/test/itests/test-itests-dependencies-app/src/main/filtered-resources/features.xml
@@ -50,6 +50,7 @@
 
     <feature name="alliance-dependencies">
         <feature>security-core</feature>
+        <bundle>mvn:com.google.guava/guava/${guava.version}</bundle>
         <bundle>mvn:org.codice.alliance.distribution/sample-nsili-server/${project.version}</bundle>
         <bundle>mvn:org.codice.alliance.test.itests/test-itests-common/${project.version}</bundle>
     </feature>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,9 @@
         <cxf.version>3.2.9</cxf.version>
         <ftpserver-version>1.0.6</ftpserver-version>
         <geotools.version>19.1</geotools.version>
-        <guava.version>20.0</guava.version>
+        <guava.version-number>25.1</guava.version-number>
+        <guava.platform>jre</guava.platform>
+        <guava.version>${guava.version-number}-${guava.platform}</guava.version>
         <jai-imageio-core.version>1.3.1</jai-imageio-core.version>
         <javax.inject.version>1</javax.inject.version>
         <javax.ws.rs.version>2.1</javax.ws.rs.version>


### PR DESCRIPTION
#### What does this PR do?
Upgrades Guava to `25.1-jre`. Depends on https://github.com/codice/ddf/pull/5379. 

#### Who is reviewing it? 
@ryeats 
@mojogitoverhere 
@brianfelix 

#### Choose 2 committers to review/merge the PR.
@bdeining
@stustison

#### How should this be tested?
- Full build. ✅ 
- Container starts up, Intrigue is usable logged in. ✅ 
- Features that depend on older Guava versions can be installed (i.e. camel-protobuf). ✅ 

#### What are the relevant tickets?
Will create a ticket upon request if we deem it necessary. 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
