### PR TITLE
CAL-753 Upgraded to DDF-Parent 1.0.8 and Dependency-Check 5.2.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,31 +135,9 @@ pipeline {
                             script {
                                 // If this build is not a pull request, run full owasp scan. Otherwise run incremental scan
                                 if (env.CHANGE_ID == null) {
-                                    sh 'mvn install -q -B -Powasp -DskipTests=true -DskipStatic=true -pl !$DOCS $DISABLE_DOWNLOAD_PROGRESS_OPTS'
+                                    sh 'mvn dependency-check:check -q -B -Powasp -DskipTests=true -DskipStatic=true -pl !$DOCS $DISABLE_DOWNLOAD_PROGRESS_OPTS'
                                 } else {
-                                    sh 'mvn install -q -B -Powasp -DskipTests=true -DskipStatic=true -pl !$DOCS -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/$CHANGE_TARGET $DISABLE_DOWNLOAD_PROGRESS_OPTS'
-                                }
-                            }
-                        }
-                    }
-                }
-                stage ('NodeJsSecurity') {
-                    agent { label 'linux-small' }
-                    steps {
-                        retry(3) {
-                            checkout scm
-                        }
-                        script {
-                            def packageFiles = findFiles(glob: '**/package.json')
-                            for (int i = 0; i < packageFiles.size(); i++) {
-                                dir(packageFiles[i].path.split('package.json')[0]) {
-                                    def packageFile = readJSON file: 'package.json'
-                                    if (packageFile.scripts =~ /.*webpack.*/ || packageFile.containsKey("browserify")) {
-                                        nodejs(configId: 'npmrc-default', nodeJSInstallationName: 'nodejs') {
-                                            echo "Scanning ${packageFiles[i].path}"
-                                            sh 'nsp check'
-                                        }
-                                    }
+                                    sh 'mvn dependency-check:check -q -B -Powasp -DskipTests=true -DskipStatic=true -pl !$DOCS -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/$CHANGE_TARGET $DISABLE_DOWNLOAD_PROGRESS_OPTS'
                                 }
                             }
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,9 +135,9 @@ pipeline {
                             script {
                                 // If this build is not a pull request, run full owasp scan. Otherwise run incremental scan
                                 if (env.CHANGE_ID == null) {
-                                    sh 'mvn dependency-check:check -q -B -Powasp -DskipTests=true -DskipStatic=true -pl !$DOCS $DISABLE_DOWNLOAD_PROGRESS_OPTS'
+                                    sh 'mvn org.commonjava.maven.plugins:directory-maven-plugin:highest-basedir@directories dependency-check:check dependency-check:aggregate -q -B -Powasp -DskipTests=true -DskipStatic=true -pl !$DOCS $DISABLE_DOWNLOAD_PROGRESS_OPTS'
                                 } else {
-                                    sh 'mvn dependency-check:check -q -B -Powasp -DskipTests=true -DskipStatic=true -pl !$DOCS -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/$CHANGE_TARGET $DISABLE_DOWNLOAD_PROGRESS_OPTS'
+                                    sh 'mvn org.commonjava.maven.plugins:directory-maven-plugin:highest-basedir@directories dependency-check:check -q -B -Powasp -DskipTests=true -DskipStatic=true -pl !$DOCS -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/$CHANGE_TARGET $DISABLE_DOWNLOAD_PROGRESS_OPTS'
                                 }
                             }
                         }

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>ddf</groupId>
         <artifactId>ddf-parent</artifactId>
-        <version>1.0.8-SNAPSHOT</version>
+        <version>1.0.8</version>
     </parent>
     <properties>
         <!--Documentation Replacements-->

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>ddf</groupId>
         <artifactId>ddf-parent</artifactId>
-        <version>1.0.7</version>
+        <version>1.0.8-SNAPSHOT</version>
     </parent>
     <properties>
         <!--Documentation Replacements-->
@@ -787,12 +787,12 @@
                         <version>${dependency-check-maven.version}</version>
                         <configuration>
                             <!-- The following properties enable using a mirror for nist NVD data -->
-                            <cveUrl12Modified>${owasp.cveUrl12Modified}</cveUrl12Modified>
-                            <cveUrl20Modified>${owasp.cveUrl20Modified}</cveUrl20Modified>
-                            <cveUrl12Base>${owasp.cveUrl12Base}</cveUrl12Base>
-                            <cveUrl20Base>${owasp.cveUrl20Base}</cveUrl20Base>
+                            <cveUrlModified>${owasp.cveUrl20Modified}</cveUrlModified>
+                            <cveUrlBase>${owasp.cveUrl20Base}</cveUrlBase>
                             <!-- End NVD mirror configuration -->
+                            <!--
                             <failBuildOnCVSS>7</failBuildOnCVSS>
+                            -->
                             <suppressionFiles>
                                 <suppressionFile>https://raw.githubusercontent.com/codice/ddf/master/dependency-check-maven-config.xml</suppressionFile>
                                 <suppressionFile>https://raw.githubusercontent.com/codice/ddf-support/master/support-owasp/src/main/resources/dependency-check-maven-config.xml</suppressionFile>
@@ -801,8 +801,6 @@
                             <skipTestScope>true</skipTestScope>
                             <!--Disable by plugin maintainer recommendation on https://github.com/jeremylong/DependencyCheck/issues/978#issuecomment-349620687-->
                             <centralAnalyzerEnabled>false</centralAnalyzerEnabled>
-                            <!--Disable because we have a separate NSP analysis step and this plugin has no way to suppress NSP issues as of 3.0.2-->
-                            <nspAnalyzerEnabled>false</nspAnalyzerEnabled>
                             <!--Disable .NET analyzers-->
                             <nuspecAnalyzerEnabled>false</nuspecAnalyzerEnabled>
                             <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
@@ -813,6 +811,8 @@
                             <cocoapodsAnalyzerEnabled>false</cocoapodsAnalyzerEnabled>
                             <autoconfAnalyzerEnabled>false</autoconfAnalyzerEnabled>
                             <rubygemsAnalyzerEnabled>false</rubygemsAnalyzerEnabled>
+                            <!-- Prevents a build failure on jdk tools in catalog-nsili-endpoint -->
+                            <skipSystemScope>true</skipSystemScope>
                         </configuration>
                         <executions>
                             <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -793,6 +793,8 @@
                             <!--
                             <failBuildOnCVSS>7</failBuildOnCVSS>
                             -->
+                            <!-- occasionally seeing a "Failed to request component-reports" error -->
+                            <failOnError>false</failOnError>
                             <suppressionFiles>
                                 <suppressionFile>https://raw.githubusercontent.com/codice/ddf/master/dependency-check-maven-config.xml</suppressionFile>
                                 <suppressionFile>https://raw.githubusercontent.com/codice/ddf-support/master/support-owasp/src/main/resources/dependency-check-maven-config.xml</suppressionFile>

--- a/pom.xml
+++ b/pom.xml
@@ -787,8 +787,8 @@
                         <version>${dependency-check-maven.version}</version>
                         <configuration>
                             <!-- The following properties enable using a mirror for nist NVD data -->
-                            <cveUrlModified>${owasp.cveUrl20Modified}</cveUrlModified>
-                            <cveUrlBase>${owasp.cveUrl20Base}</cveUrlBase>
+                            <cveUrlModified>${owasp.cveUrlModified}</cveUrlModified>
+                            <cveUrlBase>${owasp.cveUrlBase}</cveUrlBase>
                             <!-- End NVD mirror configuration -->
                             <!--
                             <failBuildOnCVSS>7</failBuildOnCVSS>


### PR DESCRIPTION
#### What does this PR do?
Upgraded depdency-check from 3.1.1 to 5.2.2
Updated dependency-check stage to be more efficient. Instead of using Maven verify phase, directly call dependency-check.
Re-adds dependency-check into the build with the -POwasp profile
The build does not fail on CVEs currently, instead it enables reporting to take place. Need to consider our process improvements for those cases. It seems most PRs will be unrelated to the CVE that was reported yesterday.
Also switches to the JSON feed rather than the removed XML feed that was causing builds to fail

Removed obsolete NodeJsSecurity stage

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)
@TonyMorrison 
@AdamBurstynski 
@bakejeyner 

@codice/security 
@codice/build 

#### Choose 2 committers to review/merge the PR.
(please choose ONLY two committers from below, delete the rest)
@jlcsmith
@clockard 

#### How should this be tested?
Build passes with -Powasp profile running

#### Any background context you want to provide?

#### What are the relevant tickets?
#753 

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/codice/alliance/755)
<!-- Reviewable:end -->
