### PR TITLE
Update DDF version to 2.21.0-SNAPSHOT

### DIFF
--- a/catalog/ddms/catalog-ddms-transformer/src/test/java/org/codice/alliance/ddms/v2/Ddms20InputTransformerTest.java
+++ b/catalog/ddms/catalog-ddms-transformer/src/test/java/org/codice/alliance/ddms/v2/Ddms20InputTransformerTest.java
@@ -36,13 +36,12 @@ import org.codice.alliance.ddms.types.Ddms20MetacardType;
 import org.codice.alliance.ddms.types.RestrictionAttributes;
 import org.codice.ddf.transformer.xml.streaming.Gml3ToWkt;
 import org.codice.ddf.transformer.xml.streaming.impl.Gml3ToWktImpl;
-import org.geotools.gml3.GMLConfiguration;
 import org.junit.Before;
 import org.junit.Test;
 
 public class Ddms20InputTransformerTest {
 
-  private final Gml3ToWkt gml3ToWkt = new Gml3ToWktImpl(new GMLConfiguration());
+  private final Gml3ToWkt gml3ToWkt = Gml3ToWktImpl.newGml3ToWkt();
 
   private Ddms20InputTransformer ddms20InputTransformer;
 

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
         <yarn.version>v1.5.1</yarn.version>
 
         <!--Project properties-->
-        <ddf.version>2.20.0</ddf.version>
+        <ddf.version>2.21.0-SNAPSHOT</ddf.version>
         <!--
            NOTE: ddf-sdk.version should be removed if itests no longer require the sdk
          -->


### PR DESCRIPTION
#### What does this PR do?
Updates Alliance's DDF version to 2.21.0-SNAPSHOT and fixes a compilation error due to the update.

#### Choose 2 committers to review/merge the PR.
@bdeining
@ricklarsen - Documentation
@shaundmorris 