### PR TITLE
Update Jenkinsfile so that 1.13.x is deployed

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -159,7 +159,7 @@ pipeline {
             when {
               allOf {
                 expression { env.CHANGE_ID == null }
-                expression { env.BRANCH_NAME ==~ /((?:\d*\.)?\d.x|master)/ }
+                expression { env.BRANCH_NAME ==~ /((?:\d+\.)?\d+.x|master)/ }
                 environment name: 'JENKINS_ENV', value: 'prod'
               }
             }


### PR DESCRIPTION
#### What does this PR do?
`1.13.1-SNAPSHOT` artifacts aren't being deployed to http://artifacts.connexta.com/content/groups/public.

Kudus to @AdamBurstynski for finding the solution 👏 

#### Who is reviewing it? 
@AdamBurstynski 
@blen-desta
@shaundmorris

#### How should this be tested?
I don't think we can test this before merging and confirming that `1.13.1-SNAPSHOT` artifacts are deployed to http://artifacts.connexta.com/content/groups/public.

#### Any background context you want to provide?
`+` = one or more
`*` = zero or more
https://github.com/codice/ddf/blob/67f76f9eb62a8df9cb31038fa7b770a9cacf9889/Jenkinsfile#L149