### PR TITLE
MPEG-TS Streaming Fixes

### DIFF
--- a/catalog/core/catalog-core-api-impl/pom.xml
+++ b/catalog/core/catalog-core-api-impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.alliance.catalog</groupId>
         <artifactId>core</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <groupId>org.codice.alliance.catalog.core</groupId>
     <artifactId>catalog-core-api-impl</artifactId>

--- a/catalog/core/catalog-core-api/pom.xml
+++ b/catalog/core/catalog-core-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.alliance.catalog</groupId>
         <artifactId>core</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <groupId>org.codice.alliance.catalog.core</groupId>
     <artifactId>catalog-core-api</artifactId>

--- a/catalog/core/catalog-core-classification-api/pom.xml
+++ b/catalog/core/catalog-core-classification-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.alliance.catalog</groupId>
         <artifactId>core</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <groupId>org.codice.alliance.catalog.core</groupId>
     <artifactId>catalog-core-classification-api</artifactId>

--- a/catalog/core/catalog-core-classification-impl/pom.xml
+++ b/catalog/core/catalog-core-classification-impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.alliance.catalog</groupId>
         <artifactId>core</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <groupId>org.codice.alliance.catalog.core</groupId>
     <artifactId>catalog-core-classification-impl</artifactId>

--- a/catalog/core/catalog-core-metacardtypes/pom.xml
+++ b/catalog/core/catalog-core-metacardtypes/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.alliance.catalog</groupId>
         <artifactId>core</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <groupId>org.codice.alliance.catalog.core</groupId>
     <artifactId>catalog-core-metacardtypes</artifactId>

--- a/catalog/core/catalog-email-api/pom.xml
+++ b/catalog/core/catalog-email-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.alliance.catalog</groupId>
         <artifactId>core</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <groupId>org.codice.alliance.catalog.core</groupId>
     <artifactId>catalog-email-api</artifactId>

--- a/catalog/core/catalog-email-impl/pom.xml
+++ b/catalog/core/catalog-email-impl/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.codice.alliance.catalog</groupId>
         <artifactId>core</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Alliance :: Catalog :: Email :: Impl</name>

--- a/catalog/core/pom.xml
+++ b/catalog/core/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>catalog</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <groupId>org.codice.alliance.catalog</groupId>
     <artifactId>core</artifactId>

--- a/catalog/ddms/catalog-ddms-transformer/pom.xml
+++ b/catalog/ddms/catalog-ddms-transformer/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>ddms</artifactId>
         <groupId>org.codice.alliance.ddms</groupId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/ddms/ddms-app/pom.xml
+++ b/catalog/ddms/ddms-app/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>ddms</artifactId>
         <groupId>org.codice.alliance.ddms</groupId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/ddms/pom.xml
+++ b/catalog/ddms/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>catalog</artifactId>
         <groupId>org.codice.alliance</groupId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/imaging/imaging-actionprovider-chip/pom.xml
+++ b/catalog/imaging/imaging-actionprovider-chip/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.alliance.imaging</groupId>
         <artifactId>imaging</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <artifactId>imaging-actionprovider-chip</artifactId>
     <packaging>bundle</packaging>

--- a/catalog/imaging/imaging-app/pom.xml
+++ b/catalog/imaging/imaging-app/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.alliance.imaging</groupId>
         <artifactId>imaging</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <artifactId>imaging-app</artifactId>
     <packaging>pom</packaging>

--- a/catalog/imaging/imaging-nitf-api/pom.xml
+++ b/catalog/imaging/imaging-nitf-api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>imaging</artifactId>
         <groupId>org.codice.alliance.imaging</groupId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/imaging/imaging-nitf-impl/pom.xml
+++ b/catalog/imaging/imaging-nitf-impl/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>imaging</artifactId>
         <groupId>org.codice.alliance.imaging</groupId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/imaging/imaging-plugin-nitf/pom.xml
+++ b/catalog/imaging/imaging-plugin-nitf/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>imaging</artifactId>
         <groupId>org.codice.alliance.imaging</groupId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/imaging/imaging-service-api/pom.xml
+++ b/catalog/imaging/imaging-service-api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>imaging</artifactId>
         <groupId>org.codice.alliance.imaging</groupId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>imaging-service-api</artifactId>

--- a/catalog/imaging/imaging-service-impl/pom.xml
+++ b/catalog/imaging/imaging-service-impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>imaging</artifactId>
         <groupId>org.codice.alliance.imaging</groupId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>imaging-service-impl</artifactId>

--- a/catalog/imaging/imaging-transformer-chipping/pom.xml
+++ b/catalog/imaging/imaging-transformer-chipping/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.alliance.imaging</groupId>
         <artifactId>imaging</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>imaging-transformer-chipping</artifactId>

--- a/catalog/imaging/imaging-transformer-nitf/pom.xml
+++ b/catalog/imaging/imaging-transformer-nitf/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>imaging</artifactId>
         <groupId>org.codice.alliance.imaging</groupId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <artifactId>imaging-transformer-nitf</artifactId>
     <packaging>bundle</packaging>

--- a/catalog/imaging/pom.xml
+++ b/catalog/imaging/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>catalog</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/catalog/nsili/catalog-nsili-bqs/pom.xml
+++ b/catalog/nsili/catalog-nsili-bqs/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.alliance.nsili</groupId>
         <artifactId>nsili</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>catalog-nsili-bqs</artifactId>

--- a/catalog/nsili/catalog-nsili-common/pom.xml
+++ b/catalog/nsili/catalog-nsili-common/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.alliance.nsili</groupId>
         <artifactId>nsili</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>catalog-nsili-common</artifactId>

--- a/catalog/nsili/catalog-nsili-endpoint/pom.xml
+++ b/catalog/nsili/catalog-nsili-endpoint/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.codice.alliance.nsili</groupId>
         <artifactId>nsili</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Alliance :: NSILI :: Endpoint</name>

--- a/catalog/nsili/catalog-nsili-orb-api/pom.xml
+++ b/catalog/nsili/catalog-nsili-orb-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.alliance.nsili</groupId>
         <artifactId>nsili</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>catalog-nsili-orb-api</artifactId>

--- a/catalog/nsili/catalog-nsili-orb-impl/pom.xml
+++ b/catalog/nsili/catalog-nsili-orb-impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.alliance.nsili</groupId>
         <artifactId>nsili</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>catalog-nsili-orb-impl</artifactId>

--- a/catalog/nsili/catalog-nsili-source/pom.xml
+++ b/catalog/nsili/catalog-nsili-source/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.alliance.nsili</groupId>
         <artifactId>nsili</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>catalog-nsili-source</artifactId>

--- a/catalog/nsili/catalog-nsili-sourcestoquery-ui/pom.xml
+++ b/catalog/nsili/catalog-nsili-sourcestoquery-ui/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>nsili</artifactId>
         <groupId>org.codice.alliance.nsili</groupId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <artifactId>catalog-nsili-sourcestoquery-ui</artifactId>
     <name>Alliance :: NSILI :: UI Plugin</name>

--- a/catalog/nsili/catalog-nsili-transformer/pom.xml
+++ b/catalog/nsili/catalog-nsili-transformer/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.alliance.nsili</groupId>
         <artifactId>nsili</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>catalog-nsili-transformer</artifactId>

--- a/catalog/nsili/nsili-app/pom.xml
+++ b/catalog/nsili/nsili-app/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.alliance.nsili</groupId>
         <artifactId>nsili</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>nsili-app</artifactId>

--- a/catalog/nsili/pom.xml
+++ b/catalog/nsili/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>catalog</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>nsili</artifactId>

--- a/catalog/plugin/catalog-plugin-auditcontrolledaccess/pom.xml
+++ b/catalog/plugin/catalog-plugin-auditcontrolledaccess/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>plugin</artifactId>
     <groupId>org.codice.alliance.catalog.plugin</groupId>
-    <version>1.10.0</version>
+    <version>1.10.1-SNAPSHOT</version>
   </parent>
   <name>Alliance :: Catalog :: Plugin :: Audit Controlled Access Plugin</name>
   <artifactId>catalog-plugin-auditcontrolledaccess</artifactId>

--- a/catalog/plugin/catalog-plugin-defaultsecurityattributevalues/pom.xml
+++ b/catalog/plugin/catalog-plugin-defaultsecurityattributevalues/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.alliance.catalog.plugin</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <name>Alliance :: Catalog :: Plugin :: Default Security Attribute Value Plugin</name>
     <artifactId>catalog-plugin-defaultsecurityattributevalues</artifactId>

--- a/catalog/plugin/pom.xml
+++ b/catalog/plugin/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>catalog</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.codice.alliance.catalog.plugin</groupId>

--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice</groupId>
         <artifactId>alliance</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <groupId>org.codice.alliance</groupId>
     <artifactId>catalog</artifactId>

--- a/catalog/security/banner-marking/pom.xml
+++ b/catalog/security/banner-marking/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.codice.alliance.security</groupId>
         <artifactId>security</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>banner-marking</artifactId>

--- a/catalog/security/pom.xml
+++ b/catalog/security/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>catalog</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.codice.alliance.security</groupId>

--- a/catalog/security/security-app/pom.xml
+++ b/catalog/security/security-app/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.alliance.security</groupId>
         <artifactId>security</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <artifactId>security-app</artifactId>
     <packaging>pom</packaging>

--- a/catalog/video/pom.xml
+++ b/catalog/video/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>catalog</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>video</artifactId>

--- a/catalog/video/video-admin-plugin/pom.xml
+++ b/catalog/video/video-admin-plugin/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>video</artifactId>
         <groupId>org.codice.alliance.video</groupId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <artifactId>video-admin-plugin</artifactId>
     <name>Alliance :: Video :: UI Plugin</name>

--- a/catalog/video/video-app/pom.xml
+++ b/catalog/video/video-app/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.alliance.video</groupId>
         <artifactId>video</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <artifactId>video-app</artifactId>
     <packaging>pom</packaging>

--- a/catalog/video/video-mpegts-stream/pom.xml
+++ b/catalog/video/video-mpegts-stream/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>video</artifactId>
         <groupId>org.codice.alliance.video</groupId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/catalog/video/video-mpegts-stream/pom.xml
+++ b/catalog/video/video-mpegts-stream/pom.xml
@@ -252,7 +252,7 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.73</minimum>
+                                            <minimum>0.72</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
@@ -262,7 +262,7 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.66</minimum>
+                                            <minimum>0.65</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/video/video-mpegts-stream/pom.xml
+++ b/catalog/video/video-mpegts-stream/pom.xml
@@ -234,8 +234,6 @@
                     </execution>
                 </executions>
             </plugin>
-
-
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
@@ -254,19 +252,18 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.67</minimum>
+                                            <minimum>0.73</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.57</minimum>
+                                            <minimum>0.64</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.59</minimum>
+                                            <minimum>0.66</minimum>
                                         </limit>
-
                                     </limits>
                                 </rule>
                             </rules>
@@ -276,5 +273,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/UdpStreamMonitor.java
+++ b/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/UdpStreamMonitor.java
@@ -51,6 +51,8 @@ import org.codice.alliance.video.stream.mpegts.plugins.StreamEndPlugin;
 import org.codice.alliance.video.stream.mpegts.plugins.StreamShutdownPlugin;
 import org.codice.alliance.video.stream.mpegts.rollover.MegabyteCountRolloverCondition;
 import org.codice.alliance.video.stream.mpegts.rollover.RolloverCondition;
+import org.codice.ddf.platform.util.uuidgenerator.UuidGenerator;
+import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -117,7 +119,7 @@ public class UdpStreamMonitor implements StreamMonitor {
 
   private ChannelFuture channelFuture;
 
-  private UdpStreamProcessor udpStreamProcessor;
+  private final UdpStreamProcessor udpStreamProcessor;
 
   private String monitoredAddress;
 
@@ -131,7 +133,7 @@ public class UdpStreamMonitor implements StreamMonitor {
 
   private Integer byteCountRolloverCondition;
 
-  private Long elapsedTimeRolloverConditon;
+  private Long elapsedTimeRolloverCondition;
 
   private URI streamUri;
 
@@ -145,8 +147,8 @@ public class UdpStreamMonitor implements StreamMonitor {
 
   private String networkInterface;
 
-  public UdpStreamMonitor() {
-    udpStreamProcessor = new UdpStreamProcessor(this);
+  public UdpStreamMonitor(final BundleContext bundleContext) {
+    udpStreamProcessor = new UdpStreamProcessor(this, bundleContext);
   }
 
   UdpStreamMonitor(UdpStreamProcessor udpStreamProcessor) {
@@ -230,6 +232,11 @@ public class UdpStreamMonitor implements StreamMonitor {
   public void setRolloverCondition(RolloverCondition rolloverCondition) {
     notNull(rolloverCondition, "rolloverCondition must be non-null");
     udpStreamProcessor.setRolloverCondition(rolloverCondition);
+  }
+
+  public void setUuidGenerator(final UuidGenerator uuidGenerator) {
+    notNull(uuidGenerator, "uuidGenerator must be non-null");
+    udpStreamProcessor.setUuidGenerator(uuidGenerator);
   }
 
   private boolean isReady() {
@@ -500,7 +507,7 @@ public class UdpStreamMonitor implements StreamMonitor {
   }
 
   public Long getElapsedTimeRolloverCondition() {
-    return this.elapsedTimeRolloverConditon;
+    return this.elapsedTimeRolloverCondition;
   }
 
   /** @param milliseconds must be non-null and &gt;= {@link #ELAPSED_TIME_MIN} */
@@ -511,7 +518,7 @@ public class UdpStreamMonitor implements StreamMonitor {
         ELAPSED_TIME_MAX,
         milliseconds,
         String.format("milliseconds must be >=%d", ELAPSED_TIME_MIN));
-    this.elapsedTimeRolloverConditon = milliseconds;
+    this.elapsedTimeRolloverCondition = milliseconds;
     udpStreamProcessor.setElapsedTimeRolloverCondition(milliseconds);
   }
 
@@ -593,7 +600,7 @@ public class UdpStreamMonitor implements StreamMonitor {
     }
 
     @Override
-    protected void initChannel(NioDatagramChannel nioDatagramChannel) throws Exception {
+    protected void initChannel(NioDatagramChannel nioDatagramChannel) {
       nioDatagramChannel.pipeline().addLast(udpStreamProcessor.createChannelHandlers());
     }
   }

--- a/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/UdpStreamMonitor.java
+++ b/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/UdpStreamMonitor.java
@@ -343,6 +343,7 @@ public class UdpStreamMonitor implements StreamMonitor {
         eventLoopGroup.shutdownGracefully().sync();
       } catch (InterruptedException e) {
         LOGGER.debug("Graceful shutdown of channel interrupted", e);
+        Thread.currentThread().interrupt();
       }
     }
 
@@ -351,6 +352,7 @@ public class UdpStreamMonitor implements StreamMonitor {
         channelFuture.channel().closeFuture().sync();
       } catch (InterruptedException e) {
         LOGGER.debug("Graceful shutdown of channel future interrupted", e);
+        Thread.currentThread().interrupt();
       }
     }
 
@@ -372,6 +374,7 @@ public class UdpStreamMonitor implements StreamMonitor {
       serverThread.join();
     } catch (InterruptedException e) {
       LOGGER.debug("interrupted while waiting for server thread to join", e);
+      Thread.currentThread().interrupt();
     } finally {
       monitoring = false;
       startTime = null;
@@ -576,6 +579,7 @@ public class UdpStreamMonitor implements StreamMonitor {
       ch.joinGroup(new InetSocketAddress(monitoredAddress, monitoredPort), networkInterface).sync();
     } catch (InterruptedException e) {
       LOGGER.debug("interrupted while waiting for shutdown", e);
+      Thread.currentThread().interrupt();
     }
   }
 
@@ -588,6 +592,7 @@ public class UdpStreamMonitor implements StreamMonitor {
       channelFuture = bootstrap.bind(monitoredAddress, monitoredPort).sync();
     } catch (InterruptedException e) {
       LOGGER.debug("interrupted while waiting for shutdown", e);
+      Thread.currentThread().interrupt();
     }
   }
 

--- a/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/framework/CatalogUpdateRetry.java
+++ b/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/framework/CatalogUpdateRetry.java
@@ -66,7 +66,7 @@ public class CatalogUpdateRetry {
       Thread.sleep(sleep);
     } catch (InterruptedException e) {
       LOGGER.trace("interrupted while waiting to attempt update request", e);
-      Thread.interrupted();
+      Thread.currentThread().interrupt();
       return true;
     }
     return false;

--- a/catalog/video/video-mpegts-stream/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/video/video-mpegts-stream/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -81,126 +81,126 @@
 
     <reference id="uuidGenerator" interface="org.codice.ddf.platform.util.uuidgenerator.UuidGenerator" filter="(id=uuidGenerator)"/>
 
-<cm:managed-service-factory
-    id="videoMpegtsStream"
-    factory-pid="org.codice.alliance.video.stream.mpegts.UdpStreamMonitor"
-    interface="org.codice.alliance.video.stream.mpegts.StreamMonitor">
-<cm:managed-component class="org.codice.alliance.video.stream.mpegts.UdpStreamMonitor"
-                      init-method="init" destroy-method="destroy">
+    <cm:managed-service-factory
+        id="videoMpegtsStream"
+        factory-pid="org.codice.alliance.video.stream.mpegts.UdpStreamMonitor"
+        interface="org.codice.alliance.video.stream.mpegts.StreamMonitor">
+      <cm:managed-component class="org.codice.alliance.video.stream.mpegts.UdpStreamMonitor"
+                              init-method="init" destroy-method="destroy">
+        <argument ref="blueprintBundleContext"/>
 
-    <property name="startImmediately" value="false"/>
+        <property name="startImmediately" value="false"/>
 
-    <property name="distanceTolerance" value="0.01"/>
+        <property name="distanceTolerance" value="0.01"/>
 
-    <property name="rolloverCondition">
-        <bean class="org.codice.alliance.video.stream.mpegts.rollover.BooleanOrRolloverCondition">
-            <argument>
-                <bean class="org.codice.alliance.video.stream.mpegts.rollover.MegabyteCountRolloverCondition">
-                    <argument value="10"/>
-                </bean>
-            </argument>
-            <argument>
-                <bean class="org.codice.alliance.video.stream.mpegts.rollover.ElapsedTimeRolloverCondition">
-                    <argument value="60000"/>
-                </bean>
-            </argument>
-        </bean>
-    </property>
+        <property name="uuidGenerator" ref="uuidGenerator"/>
 
-    <property name="filenameGenerator">
-        <bean class="org.codice.alliance.video.stream.mpegts.filename.ListFilenameGenerator">
-            <argument>
-                <list>
-                    <!-- note: order matters -->
-                            <bean class="org.codice.alliance.video.stream.mpegts.filename.FileExtensionFilenameGenerator">
-                                <argument value="ts"/>
-                            </bean>
-                            <bean class="org.codice.alliance.video.stream.mpegts.filename.DateTemplateFilenameGenerator"/>
-                            <bean class="org.codice.alliance.video.stream.mpegts.filename.IllegalCharactersFilenameGenerator"/>
-                        </list>
-                    </argument>
-                </bean>
-            </property>
+        <property name="rolloverCondition">
+            <bean class="org.codice.alliance.video.stream.mpegts.rollover.BooleanOrRolloverCondition">
+                <argument>
+                    <bean class="org.codice.alliance.video.stream.mpegts.rollover.MegabyteCountRolloverCondition">
+                        <argument value="10"/>
+                    </bean>
+                </argument>
+                <argument>
+                    <bean class="org.codice.alliance.video.stream.mpegts.rollover.ElapsedTimeRolloverCondition">
+                        <argument value="60000"/>
+                    </bean>
+                </argument>
+            </bean>
+        </property>
 
-            <property name="metacardTypeList" ref="metacardTypeList"/>
+        <property name="filenameGenerator">
+            <bean class="org.codice.alliance.video.stream.mpegts.filename.ListFilenameGenerator">
+                <argument>
+                    <list>
+                        <!-- note: order matters -->
+                        <bean class="org.codice.alliance.video.stream.mpegts.filename.FileExtensionFilenameGenerator">
+                            <argument value="ts"/>
+                        </bean>
+                        <bean class="org.codice.alliance.video.stream.mpegts.filename.DateTemplateFilenameGenerator"/>
+                        <bean class="org.codice.alliance.video.stream.mpegts.filename.IllegalCharactersFilenameGenerator"/>
+                    </list>
+                </argument>
+            </bean>
+        </property>
 
-            <property name="catalogFramework" ref="catalogFramework"/>
+        <property name="metacardTypeList" ref="metacardTypeList"/>
 
-            <property name="streamCreationPlugin">
-                <bean class="org.codice.alliance.video.stream.mpegts.plugins.ListStreamCreationPlugin">
-                    <argument>
-                        <list>
-                            <!-- note: order matters -->
-                            <bean class="org.codice.alliance.video.stream.mpegts.plugins.ParentMetacardStreamCreationPlugin">
-                                <argument ref="catalogFramework"/>
-                                <argument ref="metacardTypeList"/>
-                            </bean>
-                            <bean class="org.codice.alliance.video.stream.mpegts.plugins.RolloverStreamCreationPlugin"/>
-                            <bean class="org.codice.alliance.video.stream.mpegts.plugins.TimerStreamCreationPlugin">
-                                <argument>
-                                    <bean class="org.codice.alliance.video.stream.mpegts.plugins.TimerFactory"/>
-                                </argument>
-                            </bean>
-                            <bean class="org.codice.alliance.video.stream.mpegts.plugins.TimerTaskStreamCreationPlugin">
-                                <argument value="1000"/>
-                            </bean>
-                        </list>
-                    </argument>
-                </bean>
-            </property>
+        <property name="catalogFramework" ref="catalogFramework"/>
 
-            <property name="streamShutdownPlugin">
-                <bean class="org.codice.alliance.video.stream.mpegts.plugins.ListStreamShutdownPlugin">
-                    <argument>
-                        <list>
-                            <!-- note: order matters -->
-                            <bean class="org.codice.alliance.video.stream.mpegts.plugins.TimerStreamShutdownPlugin"/>
-                            <bean class="org.codice.alliance.video.stream.mpegts.plugins.FlushPacketBufferStreamShutdownPlugin"/>
-                            <bean class="org.codice.alliance.video.stream.mpegts.plugins.ResetPacketBufferStreamShutdownPlugin"/>
-                            <bean class="org.codice.alliance.video.stream.mpegts.plugins.StreamEndShutdownAdapter">
-                                <argument ref="streamEndPlugin"/>
-                            </bean>
-                        </list>
-                    </argument>
-                </bean>
-            </property>
+        <property name="streamCreationPlugin">
+            <bean class="org.codice.alliance.video.stream.mpegts.plugins.ListStreamCreationPlugin">
+                <argument>
+                    <list>
+                        <!-- note: order matters -->
+                        <bean class="org.codice.alliance.video.stream.mpegts.plugins.ParentMetacardStreamCreationPlugin">
+                            <argument ref="catalogFramework"/>
+                            <argument ref="metacardTypeList"/>
+                        </bean>
+                        <bean class="org.codice.alliance.video.stream.mpegts.plugins.RolloverStreamCreationPlugin"/>
+                        <bean class="org.codice.alliance.video.stream.mpegts.plugins.TimerStreamCreationPlugin">
+                            <argument>
+                                <bean class="org.codice.alliance.video.stream.mpegts.plugins.TimerFactory"/>
+                            </argument>
+                        </bean>
+                        <bean class="org.codice.alliance.video.stream.mpegts.plugins.TimerTaskStreamCreationPlugin">
+                            <argument value="1000"/>
+                        </bean>
+                    </list>
+                </argument>
+            </bean>
+        </property>
 
-            <property name="parentMetacardUpdater">
-                <bean class="org.codice.alliance.video.stream.mpegts.metacard.ListMetacardUpdater">
-                    <argument>
-                        <list>
-                            <!-- note: order matters -->
-                            <bean class="org.codice.alliance.video.stream.mpegts.metacard.TemporalStartMetacardUpdater"/>
-                            <bean class="org.codice.alliance.video.stream.mpegts.metacard.TemporalEndMetacardUpdater"/>
-                            <bean class="org.codice.alliance.video.stream.mpegts.metacard.CreatedDateMetacardUpdater"/>
-                            <bean class="org.codice.alliance.video.stream.mpegts.metacard.ModifiedDateMetacardUpdater"/>
-                            <bean class="org.codice.alliance.video.stream.mpegts.metacard.MediaEncodingMetacardUpdater"/>
-                            <bean class="org.codice.alliance.video.stream.mpegts.metacard.MissionIdMetacardUpdater"/>
-                            <bean class="org.codice.alliance.video.stream.mpegts.metacard.PlatformIdMetacardUpdater"/>
-                            <bean class="org.codice.alliance.video.stream.mpegts.metacard.PlatformDesignationMetacardUpdater"/>
-                            <bean class="org.codice.alliance.video.stream.mpegts.metacard.ImageCoordSystemMetacardUpdater"/>
-                            <bean class="org.codice.alliance.video.stream.mpegts.metacard.ImageSourceSensorMetacardUpdater"/>
-                            <bean class="org.codice.alliance.video.stream.mpegts.metacard.SecurityClassificationMetacardUpdater">
-                                <argument ref="securityClassificationService"/>
-                            </bean>
-                            <bean class="org.codice.alliance.video.stream.mpegts.metacard.LocationCountryCodeMetacardUpdater"/>
-                            <bean class="org.codice.alliance.video.stream.mpegts.metacard.SecurityCodewordsMetacardUpdater"/>
-                            <bean class="org.codice.alliance.video.stream.mpegts.metacard.SecurityDisseminationControlsMetacardUpdater"/>
-                            <bean class="org.codice.alliance.video.stream.mpegts.metacard.SecurityClassificationSystemMetacardUpdater"/>
-                            <bean class="org.codice.alliance.video.stream.mpegts.metacard.SecurityReleasabilityMetacardUpdater"/>
-                        </list>
-                    </argument>
-                </bean>
-            </property>
+        <property name="streamShutdownPlugin">
+            <bean class="org.codice.alliance.video.stream.mpegts.plugins.ListStreamShutdownPlugin">
+                <argument>
+                    <list>
+                        <!-- note: order matters -->
+                        <bean class="org.codice.alliance.video.stream.mpegts.plugins.TimerStreamShutdownPlugin"/>
+                        <bean class="org.codice.alliance.video.stream.mpegts.plugins.FlushPacketBufferStreamShutdownPlugin"/>
+                        <bean class="org.codice.alliance.video.stream.mpegts.plugins.ResetPacketBufferStreamShutdownPlugin"/>
+                        <bean class="org.codice.alliance.video.stream.mpegts.plugins.StreamEndShutdownAdapter">
+                            <argument ref="streamEndPlugin"/>
+                        </bean>
+                    </list>
+                </argument>
+            </bean>
+        </property>
 
-            <property name="streamEndPlugin" ref="streamEndPlugin"/>
+        <property name="parentMetacardUpdater">
+            <bean class="org.codice.alliance.video.stream.mpegts.metacard.ListMetacardUpdater">
+                <argument>
+                    <list>
+                        <!-- note: order matters -->
+                        <bean class="org.codice.alliance.video.stream.mpegts.metacard.TemporalStartMetacardUpdater"/>
+                        <bean class="org.codice.alliance.video.stream.mpegts.metacard.TemporalEndMetacardUpdater"/>
+                        <bean class="org.codice.alliance.video.stream.mpegts.metacard.CreatedDateMetacardUpdater"/>
+                        <bean class="org.codice.alliance.video.stream.mpegts.metacard.ModifiedDateMetacardUpdater"/>
+                        <bean class="org.codice.alliance.video.stream.mpegts.metacard.MediaEncodingMetacardUpdater"/>
+                        <bean class="org.codice.alliance.video.stream.mpegts.metacard.MissionIdMetacardUpdater"/>
+                        <bean class="org.codice.alliance.video.stream.mpegts.metacard.PlatformIdMetacardUpdater"/>
+                        <bean class="org.codice.alliance.video.stream.mpegts.metacard.PlatformDesignationMetacardUpdater"/>
+                        <bean class="org.codice.alliance.video.stream.mpegts.metacard.ImageCoordSystemMetacardUpdater"/>
+                        <bean class="org.codice.alliance.video.stream.mpegts.metacard.ImageSourceSensorMetacardUpdater"/>
+                        <bean class="org.codice.alliance.video.stream.mpegts.metacard.SecurityClassificationMetacardUpdater">
+                            <argument ref="securityClassificationService"/>
+                        </bean>
+                        <bean class="org.codice.alliance.video.stream.mpegts.metacard.LocationCountryCodeMetacardUpdater"/>
+                        <bean class="org.codice.alliance.video.stream.mpegts.metacard.SecurityCodewordsMetacardUpdater"/>
+                        <bean class="org.codice.alliance.video.stream.mpegts.metacard.SecurityDisseminationControlsMetacardUpdater"/>
+                        <bean class="org.codice.alliance.video.stream.mpegts.metacard.SecurityClassificationSystemMetacardUpdater"/>
+                        <bean class="org.codice.alliance.video.stream.mpegts.metacard.SecurityReleasabilityMetacardUpdater"/>
+                    </list>
+                </argument>
+            </bean>
+        </property>
 
-            <cm:managed-properties persistent-id=""
-                                   update-strategy="component-managed"
-                                   update-method="updateCallback"/>
+        <property name="streamEndPlugin" ref="streamEndPlugin"/>
 
-        </cm:managed-component>
-
+        <cm:managed-properties persistent-id=""
+                               update-strategy="component-managed"
+                               update-method="updateCallback"/>
+      </cm:managed-component>
     </cm:managed-service-factory>
-
 </blueprint>

--- a/catalog/video/video-mpegts-stream/src/test/java/org/codice/alliance/video/stream/mpegts/plugins/LocationUpdateFieldTest.java
+++ b/catalog/video/video-mpegts-stream/src/test/java/org/codice/alliance/video/stream/mpegts/plugins/LocationUpdateFieldTest.java
@@ -28,18 +28,19 @@ import java.util.Collections;
 import org.codice.alliance.libs.klv.GeometryOperator;
 import org.codice.alliance.video.stream.mpegts.Context;
 import org.junit.Test;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
 import org.mockito.ArgumentCaptor;
 
 public class LocationUpdateFieldTest {
 
   @Test
-  public void testPolygon() {
+  public void testPolygon() throws ParseException {
 
     String wktChild1 = "POLYGON ((0  0, 10 0, 10 10, 0  10, 0  0))";
     String wktChild2 = "POLYGON ((10 0, 20 0, 20 10, 10 10, 10 0))";
     String wktChild3 = "POLYGON ((20 0, 30 0, 30 10, 20 10, 20 0))";
-
-    String wktExpected = "POLYGON ((20 0, 10 0, 0 0, 0 10, 10 10, 20 10, 30 10, 30 0, 20 0))";
 
     Metacard parentMetacard = mock(Metacard.class);
 
@@ -64,7 +65,54 @@ public class LocationUpdateFieldTest {
 
     verify(parentMetacard).setAttribute(captor.capture());
 
-    assertThat(captor.getValue().getValue(), is(wktExpected));
+    WKTReader wktReader = new WKTReader();
+    String expectedWkt = "POLYGON ((20 0, 10 0, 0 0, 0 10, 10 10, 20 10, 30 10, 30 0, 20 0))";
+    Geometry expected = wktReader.read(expectedWkt).norm();
+
+    String actualWkt = (String) captor.getValue().getValue();
+    Geometry actual = wktReader.read(actualWkt).norm();
+
+    assertThat(actual, is(expected));
+  }
+
+  @Test
+  public void testGeometryCollection() throws ParseException {
+    String wktChild1 = "LINESTRING(0 0, 10 10)";
+    String wktChild2 = "LINESTRING(20 20, 30 30)";
+    String wktChild3 = "POINT(40 40)";
+
+    Metacard parentMetacard = mock(Metacard.class);
+
+    Metacard childMetacard1 = mock(Metacard.class);
+    when(childMetacard1.getLocation()).thenReturn(wktChild1);
+    Metacard childMetacard2 = mock(Metacard.class);
+    when(childMetacard2.getLocation()).thenReturn(wktChild2);
+    Metacard childMetacard3 = mock(Metacard.class);
+    when(childMetacard3.getLocation()).thenReturn(wktChild3);
+
+    LocationUpdateField locUpdateField =
+        new LocationUpdateField(GeometryOperator.IDENTITY, GeometryOperator.IDENTITY);
+
+    Context context = mock(Context.class);
+
+    locUpdateField.updateField(parentMetacard, Collections.singletonList(childMetacard1), context);
+    locUpdateField.updateField(
+        parentMetacard, Arrays.asList(childMetacard2, childMetacard3), context);
+    locUpdateField.end(parentMetacard, context);
+
+    ArgumentCaptor<Attribute> captor = ArgumentCaptor.forClass(Attribute.class);
+
+    verify(parentMetacard).setAttribute(captor.capture());
+
+    WKTReader wktReader = new WKTReader();
+    String expectedWkt =
+        "GEOMETRYCOLLECTION(LINESTRING(0 0, 10 10), LINESTRING(20 20, 30 30), POINT(40 40))";
+    Geometry expected = wktReader.read(expectedWkt).norm();
+
+    String actualWkt = (String) captor.getValue().getValue();
+    Geometry actual = wktReader.read(actualWkt).norm();
+
+    assertThat(actual, is(expected));
   }
 
   @Test

--- a/catalog/video/video-mpegts-transformer/pom.xml
+++ b/catalog/video/video-mpegts-transformer/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>video</artifactId>
         <groupId>org.codice.alliance.video</groupId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <artifactId>video-mpegts-transformer</artifactId>
     <packaging>bundle</packaging>

--- a/catalog/video/video-security/pom.xml
+++ b/catalog/video/video-security/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>video</artifactId>
         <groupId>org.codice.alliance.video</groupId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>video-security</artifactId>

--- a/catalog/video/video-security/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/video/video-security/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -23,7 +23,7 @@
         <property name="attributes">
             <array value-type="java.lang.String">
                 <value>http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier=videographer</value>
-                <value>http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=videographer</value>
+                <value>http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=videographer|guest</value>
             </array>
         </property>
     </bean>

--- a/catalog/video/video-security/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/video/video-security/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -18,7 +18,7 @@
          name="Videographer Claims Configuration"
          id="org.codice.alliance.video.security.videographer.realm.VideographerRealm">
         <AD name="Attributes" id="attributes" required="true" type="String"
-            default="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier=videographer,http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=videographer"
+            default="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier=videographer,http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role=videographer|guest"
             cardinality="1000"
             description="The attributes to be returned for any Videographer user.">
         </AD>

--- a/distribution/alliance-branding-app/pom.xml
+++ b/distribution/alliance-branding-app/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>distribution</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <name>Alliance :: Distribution :: Branding App</name>
     <artifactId>alliance-branding-app</artifactId>

--- a/distribution/alliance-branding-plugin/pom.xml
+++ b/distribution/alliance-branding-plugin/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>distribution</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.codice.alliance.distribution</groupId>

--- a/distribution/alliance/pom.xml
+++ b/distribution/alliance/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>distribution</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <groupId>org.codice.alliance.distribution</groupId>
     <artifactId>alliance</artifactId>

--- a/distribution/common/pom.xml
+++ b/distribution/common/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>distribution</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.codice.alliance.distribution</groupId>

--- a/distribution/console-branding/pom.xml
+++ b/distribution/console-branding/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>distribution</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/distribution/docs/pom.xml
+++ b/distribution/docs/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>distribution</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <artifactId>docs</artifactId>
     <name>Alliance :: Docs</name>

--- a/distribution/install-profiles/pom.xml
+++ b/distribution/install-profiles/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>distribution</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
 
     <name>Alliance :: Distribution :: Install Profiles</name>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice</groupId>
         <artifactId>alliance</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>distribution</artifactId>

--- a/distribution/sdk/pom.xml
+++ b/distribution/sdk/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>distribution</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>sdk</artifactId>

--- a/distribution/sdk/sample-content-metadata-extractor/pom.xml
+++ b/distribution/sdk/sample-content-metadata-extractor/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>sdk</artifactId>
         <groupId>org.codice.alliance.distribution</groupId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/distribution/sdk/sample-mpegts-streamgenerator/pom.xml
+++ b/distribution/sdk/sample-mpegts-streamgenerator/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.codice.alliance.distribution</groupId>
         <artifactId>sdk</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/distribution/sdk/sample-mpegts-streamgenerator/src/main/java/org/codice/alliance/distribution/sdk/video/stream/mpegts/MpegTsUdpClient.java
+++ b/distribution/sdk/sample-mpegts-streamgenerator/src/main/java/org/codice/alliance/distribution/sdk/video/stream/mpegts/MpegTsUdpClient.java
@@ -87,7 +87,7 @@ public class MpegTsUdpClient {
     LOGGER = LoggerFactory.getLogger(MpegTsUdpClient.class);
   }
 
-  public static void main(String[] args) {
+  public static void main(String[] args) throws InterruptedException {
 
     LOGGER.info("args: {}", args[0]);
 
@@ -227,7 +227,8 @@ public class MpegTsUdpClient {
       int minDatagramSize,
       int maxDatagramSize,
       boolean fractionalTs,
-      String networkInterfaceName) {
+      String networkInterfaceName)
+      throws InterruptedException {
 
     Optional<InetAddress> inetAddressOptional = findLocalAddress(networkInterfaceName);
 
@@ -354,7 +355,7 @@ public class MpegTsUdpClient {
       }
 
       LOGGER.trace("Bytes sent: {} ", bytesSent);
-    } catch (InterruptedException | IOException e) {
+    } catch (IOException e) {
       LOGGER.error("Unable to generate stream.", e);
     } finally {
       // Shut down the event loop to terminate all threads.
@@ -404,7 +405,7 @@ public class MpegTsUdpClient {
     }
   }
 
-  private static Duration getVideoDuration(final String videoFilePath) {
+  private static Duration getVideoDuration(final String videoFilePath) throws InterruptedException {
     try (final ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
       final PumpStreamHandler streamHandler = new PumpStreamHandler(outputStream);
       final CommandLine command = getFFmpegInfoCommand(videoFilePath);
@@ -412,8 +413,6 @@ public class MpegTsUdpClient {
       resultHandler.waitFor();
       final String output = outputStream.toString(StandardCharsets.UTF_8.name());
       return parseVideoDuration(output);
-    } catch (InterruptedException e) {
-      LOGGER.error("Thread interrupted while executing ffmpeg command.", e);
     } catch (UnsupportedEncodingException e) {
       LOGGER.error("Unsupported encoding in ffmpeg output.", e);
     } catch (IllegalArgumentException e) {
@@ -424,8 +423,7 @@ public class MpegTsUdpClient {
     return null;
   }
 
-  private static Duration parseVideoDuration(final String ffmpegOutput)
-      throws IllegalArgumentException {
+  private static Duration parseVideoDuration(final String ffmpegOutput) {
     final Pattern pattern = Pattern.compile("Duration: \\d\\d:\\d\\d:\\d\\d\\.\\d+");
     final Matcher matcher = pattern.matcher(ffmpegOutput);
 

--- a/distribution/sdk/sample-nsili-client/pom.xml
+++ b/distribution/sdk/sample-nsili-client/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.codice.alliance.distribution</groupId>
         <artifactId>sdk</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Alliance :: Distribution :: SDK :: Sample NSILI Client</name>

--- a/distribution/sdk/sample-nsili-server/pom.xml
+++ b/distribution/sdk/sample-nsili-server/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.codice.alliance.distribution</groupId>
         <artifactId>sdk</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Alliance :: Distribution :: SDK :: Sample NSILI Server</name>

--- a/distribution/sdk/sdk-app/pom.xml
+++ b/distribution/sdk/sdk-app/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>sdk</artifactId>
         <groupId>org.codice.alliance.distribution</groupId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/distribution/test/itests/pom.xml
+++ b/distribution/test/itests/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.alliance.test</groupId>
         <artifactId>test</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <groupId>org.codice.alliance.test.itests</groupId>
     <artifactId>itests</artifactId>

--- a/distribution/test/itests/test-itests-alliance/pom.xml
+++ b/distribution/test/itests/test-itests-alliance/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.alliance.test.itests</groupId>
         <artifactId>itests</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <artifactId>test-itests-alliance</artifactId>
     <name>Alliance :: Integration :: Test</name>

--- a/distribution/test/itests/test-itests-common/pom.xml
+++ b/distribution/test/itests/test-itests-common/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.alliance.test.itests</groupId>
         <artifactId>itests</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <artifactId>test-itests-common</artifactId>
     <name>Alliance :: Test :: Integration :: Common</name>

--- a/distribution/test/itests/test-itests-dependencies-app/pom.xml
+++ b/distribution/test/itests/test-itests-dependencies-app/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>itests</artifactId>
         <groupId>org.codice.alliance.test.itests</groupId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <artifactId>test-itests-dependencies-app</artifactId>
     <name>Alliance :: Test :: Integration :: Dependencies App</name>

--- a/distribution/test/pom.xml
+++ b/distribution/test/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>distribution</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <groupId>org.codice.alliance.test</groupId>
     <artifactId>test</artifactId>

--- a/gitsetup/pom.xml
+++ b/gitsetup/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.codice</groupId>
         <artifactId>alliance</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.codice</groupId>

--- a/libs/klv/pom.xml
+++ b/libs/klv/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>libs</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/libs/klv/pom.xml
+++ b/libs/klv/pom.xml
@@ -182,12 +182,12 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.69</minimum>
+                                            <minimum>0.75</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.67</minimum>
+                                            <minimum>0.71</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/libs/klv/src/main/java/org/codice/alliance/libs/klv/ConvertSubpolygonsToEnvelopes.java
+++ b/libs/klv/src/main/java/org/codice/alliance/libs/klv/ConvertSubpolygonsToEnvelopes.java
@@ -16,6 +16,7 @@ package org.codice.alliance.libs.klv;
 import java.util.stream.IntStream;
 import javax.annotation.concurrent.ThreadSafe;
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,6 +28,8 @@ import org.slf4j.LoggerFactory;
 public class ConvertSubpolygonsToEnvelopes implements GeometryOperator {
   private static final Logger LOGGER = LoggerFactory.getLogger(ConvertSubpolygonsToEnvelopes.class);
 
+  private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory();
+
   @Override
   public Geometry apply(Geometry geometry, Context context) {
 
@@ -36,12 +39,13 @@ public class ConvertSubpolygonsToEnvelopes implements GeometryOperator {
 
     LOGGER.trace("Converting geometry: {}", geometry);
 
-    Geometry envelopePolygons =
+    Geometry[] envelopes =
         IntStream.range(0, geometry.getNumGeometries())
             .mapToObj(geometry::getGeometryN)
             .map(Geometry::getEnvelope)
-            .reduce(Geometry::union)
-            .orElse(geometry);
+            .toArray(Geometry[]::new);
+
+    Geometry envelopePolygons = GEOMETRY_FACTORY.createGeometryCollection(envelopes).union();
 
     LOGGER.trace(
         "Converted geometry: {}\n isValid? {}", envelopePolygons, envelopePolygons.isValid());

--- a/libs/klv/src/test/java/org/codice/alliance/libs/klv/ConvertSubpolygonsToEnvelopesTest.java
+++ b/libs/klv/src/test/java/org/codice/alliance/libs/klv/ConvertSubpolygonsToEnvelopesTest.java
@@ -27,13 +27,13 @@ public class ConvertSubpolygonsToEnvelopesTest {
 
   private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory();
 
+  private final ConvertSubpolygonsToEnvelopes convertSubpolygonsToEnvelopes =
+      new ConvertSubpolygonsToEnvelopes();
+
   @Test
-  public void testNullSubpolygon() throws ParseException {
+  public void testNullSubpolygon() {
 
     Geometry geometry = null;
-
-    ConvertSubpolygonsToEnvelopes convertSubpolygonsToEnvelopes =
-        new ConvertSubpolygonsToEnvelopes();
 
     Geometry actual = convertSubpolygonsToEnvelopes.apply(geometry, new GeometryOperator.Context());
 
@@ -41,12 +41,9 @@ public class ConvertSubpolygonsToEnvelopesTest {
   }
 
   @Test
-  public void testEmptySubpolygon() throws ParseException {
+  public void testEmptySubpolygon() {
 
     Geometry geometry = GEOMETRY_FACTORY.createMultiPolygon(null);
-
-    ConvertSubpolygonsToEnvelopes convertSubpolygonsToEnvelopes =
-        new ConvertSubpolygonsToEnvelopes();
 
     Geometry actual = convertSubpolygonsToEnvelopes.apply(geometry, new GeometryOperator.Context());
 
@@ -61,9 +58,6 @@ public class ConvertSubpolygonsToEnvelopesTest {
     WKTReader wktReader = new WKTReader();
 
     Geometry geometry = wktReader.read(wkt);
-
-    ConvertSubpolygonsToEnvelopes convertSubpolygonsToEnvelopes =
-        new ConvertSubpolygonsToEnvelopes();
 
     Geometry actual = convertSubpolygonsToEnvelopes.apply(geometry, new GeometryOperator.Context());
 
@@ -80,14 +74,33 @@ public class ConvertSubpolygonsToEnvelopesTest {
 
     Geometry geometry = wktReader.read(wkt);
 
-    ConvertSubpolygonsToEnvelopes convertSubpolygonsToEnvelopes =
-        new ConvertSubpolygonsToEnvelopes();
-
     Geometry actual = convertSubpolygonsToEnvelopes.apply(geometry, new GeometryOperator.Context());
 
     Geometry expected =
         wktReader.read(
             "MULTIPOLYGON (((0 0, 0 20, 20 20, 20 0, 0 0)), ((0 40, 0 60, 20 60, 20 40, 0 40)))");
+
+    assertThat(actual, is(expected));
+  }
+
+  // This test was adapted from a real video stream that failed the `ConvertSubpolygonsToEnvelopes`
+  // step. It failed because the geometry was a GeometryCollection of different types of geometries
+  // and the union code couldn't handle unioning GeometryCollections.
+  @Test
+  public void testGeometryCollection() throws ParseException {
+    final String wkt =
+        "GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (10 10, 20 20), LINESTRING (20 20, 10 30))";
+
+    final WKTReader wktReader = new WKTReader();
+
+    final Geometry geometry = wktReader.read(wkt);
+
+    final Geometry actual =
+        convertSubpolygonsToEnvelopes.apply(geometry, new GeometryOperator.Context());
+
+    final Geometry expected =
+        wktReader.read(
+            "GEOMETRYCOLLECTION( POINT (0 0), POLYGON ((10 10, 10 20, 10 30, 20 30, 20 20, 20 10, 10 10)))");
 
     assertThat(actual, is(expected));
   }

--- a/libs/mpegts/pom.xml
+++ b/libs/mpegts/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>libs</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/libs/pom.xml
+++ b/libs/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>alliance</artifactId>
         <groupId>org.codice</groupId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/libs/stanag4609/pom.xml
+++ b/libs/stanag4609/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>libs</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/libs/stanag4609/src/main/java/org/codice/alliance/libs/stanag4609/AbstractMetadataPacket.java
+++ b/libs/stanag4609/src/main/java/org/codice/alliance/libs/stanag4609/AbstractMetadataPacket.java
@@ -14,14 +14,18 @@
 package org.codice.alliance.libs.stanag4609;
 
 import java.util.Arrays;
+import javax.xml.bind.DatatypeConverter;
 import org.codice.ddf.libs.klv.KlvContext;
 import org.codice.ddf.libs.klv.KlvDecoder;
 import org.codice.ddf.libs.klv.KlvDecodingException;
 import org.codice.ddf.libs.klv.data.numerical.KlvUnsignedShort;
 import org.codice.ddf.libs.klv.data.set.KlvLocalSet;
 import org.jcodec.containers.mps.MPSDemuxer.PESPacket;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 abstract class AbstractMetadataPacket {
+  private static final Logger LOGGER = LoggerFactory.getLogger(AbstractMetadataPacket.class);
 
   /**
    * Location of the "PES header length" field which contains the number of extra bytes contained in
@@ -98,6 +102,10 @@ abstract class AbstractMetadataPacket {
     final byte[] klvBytes = getKLVBytes();
 
     if (klvBytes != null && klvBytes.length > 0) {
+      if (LOGGER.isTraceEnabled()) {
+        LOGGER.trace("KLV bytes: {}", DatatypeConverter.printHexBinary(klvBytes));
+      }
+
       final KlvContext decodedKLV = decoder.decode(klvBytes);
 
       if (validateChecksum(decodedKLV, klvBytes)) {

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.codice</groupId>
     <artifactId>alliance</artifactId>
-    <version>1.10.0</version>
+    <version>1.10.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Alliance</name>
     <description>Codice Alliance</description>
@@ -192,7 +192,7 @@
         <url>https://github.com/codice/alliance</url>
         <connection>scm:git:https://github.com/codice/alliance.git</connection>
         <developerConnection>scm:git:https://github.com/codice/alliance.git</developerConnection>
-        <tag>alliance-1.10.0</tag>
+        <tag>HEAD</tag>
     </scm>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
## Do not squash on merge

#### What does this PR do?
- Fix MPEG-TS UDP streaming
  - The stream startup code had been erroneously replaced with the stream shutdown code.
  - The videographer user needs the 'guest' role to create metacards.
- Update location and frame center updaters to handle GeometryCollections
- Fix thread interrupt handling
- Fix and re-enable VideoTest

#### Who is reviewing it? 
@sgalla 
@peterhuffer 
@Bdthomson 
@aj-brooks 
#### Choose 2 committers to review/merge the PR.
@glenhein 
@jlcsmith 

#### How should this be tested?
1. Install Alliance with the video app.
2. Configure a video stream in the Admin UI. The default settings will work fine, but you can change the title or filename template if you want.
3. Stream an MPEG-TS video to the address specified in the stream configuration from the previous step (the default is `127.0.0.1:50000`). Two sample videos are available here: https://samples.ffmpeg.org/MPEG2/mpegts-klv/
a. Using [FFmpeg](https://ffmpeg.org/): `ffmpeg -re -i Night_Flight_IR.mpg -map 0 -c copy -f mpegts udp://127.0.0.1:50000`
b. Using [TSduck](https://tsduck.io/): `tsp -I file Night_Flight_IR.mpg -P regulate -O ip 127.0.0.1:50000`
4. Wait for the video to finish streaming.
5. Open Intrigue and search for the stream title (for the parent metacard) and the filename template (for the chunks). Verify the parent metacard has a location and/or a frame center geometry. Verify the chunk metacards also have locations and/or frame center geometries.
#### Any background context you want to provide?
MPEG-TS UDP streaming has been broken since 1.4.0 due to [this change](https://github.com/codice/alliance/commit/b2200d94aaefd0239b3c1f2563b0be50c043066e#diff-2f6e154f5c64301bbb1ca52d100d4aefR432)

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [x] Update / Add Integration Tests