### PR TITLE
[1.10.x] Set the derived associations on the stream parent metacard instead of the chunk metacards

### DIFF
--- a/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/metacard/DerivedAssociationMetacardUpdater.java
+++ b/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/metacard/DerivedAssociationMetacardUpdater.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.video.stream.mpegts.metacard;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.types.Associations;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.codice.alliance.video.stream.mpegts.Context;
+
+public class DerivedAssociationMetacardUpdater implements MetacardUpdater {
+
+  @Override
+  public void update(final Metacard parent, final Metacard child, final Context context) {
+    final List<Serializable> derivedIds =
+        Optional.ofNullable(parent.getAttribute(Associations.DERIVED))
+            .map(Attribute::getValues)
+            .orElseGet(ArrayList::new);
+    final String childId = child.getId();
+    derivedIds.add(childId);
+    parent.setAttribute(new AttributeImpl(Associations.DERIVED, derivedIds));
+  }
+}

--- a/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/plugins/FindChildrenStreamEndPlugin.java
+++ b/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/plugins/FindChildrenStreamEndPlugin.java
@@ -13,6 +13,10 @@
  */
 package org.codice.alliance.video.stream.mpegts.plugins;
 
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toList;
+
+import ddf.catalog.data.Attribute;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
 import ddf.catalog.data.types.Associations;
@@ -26,7 +30,9 @@ import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.source.SourceUnavailableException;
 import ddf.catalog.source.UnsupportedQueryException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -89,7 +95,14 @@ public class FindChildrenStreamEndPlugin implements StreamEndPlugin {
     Handler handler = factory.build();
 
     Filter filter =
-        filterBuilder.attribute(Associations.DERIVED).is().equalTo().text(parentMetacard.getId());
+        Optional.ofNullable(parentMetacard.getAttribute(Associations.DERIVED))
+            .map(Attribute::getValues)
+            .orElseGet(ArrayList::new)
+            .stream()
+            .filter(String.class::isInstance)
+            .map(String.class::cast)
+            .map(derivedId -> filterBuilder.attribute(Core.ID).is().equalTo().text(derivedId))
+            .collect(collectingAndThen(toList(), filterBuilder::anyOf));
 
     int startIndex = 1;
     Long expectedReturnCount = null;
@@ -186,6 +199,7 @@ public class FindChildrenStreamEndPlugin implements StreamEndPlugin {
 
   /** Factory for building {@link Handler} */
   public interface Factory {
+
     Handler build();
   }
 }

--- a/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/rollover/CatalogRolloverAction.java
+++ b/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/rollover/CatalogRolloverAction.java
@@ -122,8 +122,7 @@ public class CatalogRolloverAction extends BaseRolloverAction {
   }
 
   @Override
-  public MetacardImpl doAction(MetacardImpl metacard, File tempFile)
-      throws RolloverActionException {
+  public MetacardImpl doAction(MetacardImpl metacard, File tempFile) {
 
     return context.modifyParentOrChild(
         isParentDirty -> {
@@ -149,8 +148,6 @@ public class CatalogRolloverAction extends BaseRolloverAction {
 
                 for (Metacard childMetacard : createResponse.getCreatedMetacards()) {
                   LOGGER.trace("created catalog content with id={}", childMetacard.getId());
-
-                  linkChildToParent(childMetacard);
 
                   updateParentWithChildMetadata(childMetacard);
                 }
@@ -206,21 +203,6 @@ public class CatalogRolloverAction extends BaseRolloverAction {
 
   private UpdateRequest createUpdateRequest(String id, Metacard metacard) {
     return new UpdateRequestImpl(id, metacard);
-  }
-
-  private void linkChildToParent(Metacard childMetacard) {
-    setDerivedAttribute(childMetacard);
-
-    UpdateRequest updateChild = createUpdateRequest(childMetacard.getId(), childMetacard);
-
-    submitChildUpdateRequest(updateChild);
-  }
-
-  private void setDerivedAttribute(Metacard childMetacard) {
-    if (context.getParentMetacard().isPresent()) {
-      childMetacard.setAttribute(
-          new AttributeImpl(Metacard.DERIVED, context.getParentMetacard().get().getId()));
-    }
   }
 
   private CreateResponse submitStorageCreateRequest(CreateStorageRequest createRequest)

--- a/catalog/video/video-mpegts-stream/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/video/video-mpegts-stream/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -191,6 +191,7 @@
                         <bean class="org.codice.alliance.video.stream.mpegts.metacard.SecurityDisseminationControlsMetacardUpdater"/>
                         <bean class="org.codice.alliance.video.stream.mpegts.metacard.SecurityClassificationSystemMetacardUpdater"/>
                         <bean class="org.codice.alliance.video.stream.mpegts.metacard.SecurityReleasabilityMetacardUpdater"/>
+                        <bean class="org.codice.alliance.video.stream.mpegts.metacard.DerivedAssociationMetacardUpdater" />
                     </list>
                 </argument>
             </bean>

--- a/catalog/video/video-mpegts-stream/src/test/java/org/codice/alliance/video/stream/mpegts/metacard/DerivedAssociationMetacardUpdaterTest.java
+++ b/catalog/video/video-mpegts-stream/src/test/java/org/codice/alliance/video/stream/mpegts/metacard/DerivedAssociationMetacardUpdaterTest.java
@@ -1,0 +1,48 @@
+package org.codice.alliance.video.stream.mpegts.metacard;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.data.types.Associations;
+import java.util.Arrays;
+import java.util.UUID;
+import org.junit.Test;
+
+public class DerivedAssociationMetacardUpdaterTest {
+
+  private final DerivedAssociationMetacardUpdater updater = new DerivedAssociationMetacardUpdater();
+
+  @Test
+  public void firstChild() {
+    final Metacard parent = new MetacardImpl();
+    final MetacardImpl child = new MetacardImpl();
+    child.setId(UUID.randomUUID().toString());
+
+    updater.update(parent, child, null);
+
+    final Attribute derivedAssociation = parent.getAttribute(Associations.DERIVED);
+    assertThat(derivedAssociation, is(notNullValue()));
+    assertThat(derivedAssociation.getValues(), contains(child.getId()));
+  }
+
+  @Test
+  public void multipleChildren() {
+    final Metacard parent = new MetacardImpl();
+    parent.setAttribute(new AttributeImpl(Associations.DERIVED, Arrays.asList("first", "second")));
+    final MetacardImpl child = new MetacardImpl();
+    child.setId("third");
+
+    updater.update(parent, child, null);
+
+    final Attribute derivedAssociation = parent.getAttribute(Associations.DERIVED);
+    assertThat(derivedAssociation, is(notNullValue()));
+    assertThat(derivedAssociation.getValues(), containsInAnyOrder("first", "second", "third"));
+  }
+}

--- a/catalog/video/video-mpegts-stream/src/test/java/org/codice/alliance/video/stream/mpegts/metacard/DerivedAssociationMetacardUpdaterTest.java
+++ b/catalog/video/video-mpegts-stream/src/test/java/org/codice/alliance/video/stream/mpegts/metacard/DerivedAssociationMetacardUpdaterTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 package org.codice.alliance.video.stream.mpegts.metacard;
 
 import static org.hamcrest.Matchers.contains;

--- a/catalog/video/video-mpegts-stream/src/test/java/org/codice/alliance/video/stream/mpegts/rollover/CatalogRolloverActionTest.java
+++ b/catalog/video/video-mpegts-stream/src/test/java/org/codice/alliance/video/stream/mpegts/rollover/CatalogRolloverActionTest.java
@@ -214,7 +214,7 @@ public class CatalogRolloverActionTest {
 
     ArgumentCaptor<UpdateRequest> argumentCaptor = ArgumentCaptor.forClass(UpdateRequest.class);
 
-    verify(catalogFramework, times(3)).update(argumentCaptor.capture());
+    verify(catalogFramework, times(2)).update(argumentCaptor.capture());
 
     ArgumentCaptor<Attribute> attributeCaptor = ArgumentCaptor.forClass(Attribute.class);
     verify(createdParentMetacard, atLeastOnce()).setAttribute(attributeCaptor.capture());
@@ -238,7 +238,7 @@ public class CatalogRolloverActionTest {
 
     ArgumentCaptor<UpdateRequest> argumentCaptor = ArgumentCaptor.forClass(UpdateRequest.class);
 
-    verify(catalogFramework, times(2)).update(argumentCaptor.capture());
+    verify(catalogFramework).update(argumentCaptor.capture());
 
     ArgumentCaptor<Attribute> attributeCaptor = ArgumentCaptor.forClass(Attribute.class);
     verify(createdParentMetacard, atLeastOnce()).setAttribute(attributeCaptor.capture());
@@ -262,7 +262,7 @@ public class CatalogRolloverActionTest {
 
     ArgumentCaptor<UpdateRequest> argumentCaptor = ArgumentCaptor.forClass(UpdateRequest.class);
 
-    verify(catalogFramework, times(2)).update(argumentCaptor.capture());
+    verify(catalogFramework).update(argumentCaptor.capture());
 
     ArgumentCaptor<Attribute> attributeCaptor = ArgumentCaptor.forClass(Attribute.class);
     verify(createdParentMetacard, atLeastOnce()).setAttribute(attributeCaptor.capture());

--- a/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/VideoTest.java
+++ b/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/VideoTest.java
@@ -16,6 +16,7 @@ package org.codice.alliance.test.itests;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.hasXPath;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
@@ -151,6 +152,7 @@ public class VideoTest extends AbstractAllianceIntegrationTest {
             .extract()
             .xmlPath(xmlPathConfig)
             .getList("metacards.metacard.@gml:id");
+    assertThat("There should be 2 child metacards.", childIds, hasSize(2));
 
     final ValidatableResponse parentMetacardResponse =
         await("The parent metacard location to be updated")

--- a/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/VideoTest.java
+++ b/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/VideoTest.java
@@ -186,7 +186,6 @@ public class VideoTest extends AbstractAllianceIntegrationTest {
             .xmlPath(xmlPathConfig)
             .getList(
                 "metacards.metacard.string.findAll{ it.@name == 'metacard.associations.derived' }*.value");
-    LOGGER.error("derivedIdsOnParent: {}", derivedIdsOnParent);
     assertThat(
         "The derived associations on the parent metacard were not correct.",
         derivedIdsOnParent,

--- a/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/VideoTest.java
+++ b/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/VideoTest.java
@@ -187,7 +187,7 @@ public class VideoTest extends AbstractAllianceIntegrationTest {
             .extract()
             .xmlPath(xmlPathConfig)
             .getList(
-                "metacards.metacard.string.findAll{ it.@name == 'metacard.associations.derived' }*.value");
+                "metacards.metacard.string.find{ it.@name == 'metacard.associations.derived' }.value*.text()");
     assertThat(
         "The derived associations on the parent metacard were not correct.",
         derivedIdsOnParent,

--- a/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/VideoTest.java
+++ b/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/VideoTest.java
@@ -15,6 +15,7 @@ package org.codice.alliance.test.itests;
 
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasXPath;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
@@ -38,6 +39,7 @@ import java.io.InputStream;
 import java.net.DatagramSocket;
 import java.net.SocketException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -143,6 +145,13 @@ public class VideoTest extends AbstractAllianceIntegrationTest {
 
     final XmlPathConfig xmlPathConfig =
         new XmlPathConfig().declaredNamespace("gml", "http://www.opengis.net/gml");
+
+    final List<String> childIds =
+        executeOpenSearch("xml", "q=mpegts-stream*")
+            .extract()
+            .xmlPath(xmlPathConfig)
+            .getList("metacards.metacard.@gml:id");
+
     final ValidatableResponse parentMetacardResponse =
         await("The parent metacard location to be updated")
             .atMost(1, TimeUnit.MINUTES)
@@ -171,27 +180,23 @@ public class VideoTest extends AbstractAllianceIntegrationTest {
             hasXPath(
                 "/metacards/metacard/string[@name='resource-uri']/value", is(udpStreamAddress)));
 
-    final String parentMetacardId =
-        parentMetacardResponse.extract().xmlPath().getString(METACARD_ID_XMLPATH);
-
-    await("The child metacards to be linked to the parent")
-        .atMost(30, TimeUnit.SECONDS)
-        .until(
-            () ->
-                executeOpenSearch("xml", "q=mpegts-stream*")
-                        .extract()
-                        .xmlPath()
-                        .getInt(
-                            "metacards.metacard.string.findAll { it.@name == 'metacard.associations.derived' }.size()")
-                    == 2);
+    final List<String> derivedIdsOnParent =
+        parentMetacardResponse
+            .extract()
+            .xmlPath(xmlPathConfig)
+            .getList(
+                "metacards.metacard.string.findAll{ it.@name == 'metacard.associations.derived' }*.value");
+    LOGGER.error("derivedIdsOnParent: {}", derivedIdsOnParent);
+    assertThat(
+        "The derived associations on the parent metacard were not correct.",
+        derivedIdsOnParent,
+        containsInAnyOrder(childIds.toArray(new String[0])));
 
     final String chunkDividerDate = "2009-06-19T07:26:30Z";
 
-    verifyChunkMetacard(
-        "dtend=" + chunkDividerDate, 1212.82825971, "-110.058257 54.791167", parentMetacardId);
+    verifyChunkMetacard("dtend=" + chunkDividerDate, 1212.82825971, "-110.058257 54.791167");
 
-    verifyChunkMetacard(
-        "dtstart=" + chunkDividerDate, 1206.75516899, "-110.058421 54.791636", parentMetacardId);
+    verifyChunkMetacard("dtstart=" + chunkDividerDate, 1206.75516899, "-110.058421 54.791636");
 
     getServiceManager().stopFeature(true, "sample-mpegts-streamgenerator");
   }
@@ -261,10 +266,7 @@ public class VideoTest extends AbstractAllianceIntegrationTest {
   }
 
   private void verifyChunkMetacard(
-      String dateBound,
-      double expectedAltitude,
-      String expectedFrameCenterWkt,
-      String expectedParentId) {
+      String dateBound, double expectedAltitude, String expectedFrameCenterWkt) {
     final ValidatableResponse response =
         executeOpenSearch("xml", "q=mpegts-stream*", dateBound)
             .log()
@@ -283,11 +285,7 @@ public class VideoTest extends AbstractAllianceIntegrationTest {
             .body(
                 hasXPath(
                     "/metacards/metacard/geometry[@name='media.frame-center']/value/*[local-name()='Point']/*[local-name()='pos']",
-                    is(expectedFrameCenterWkt)))
-            .body(
-                hasXPath(
-                    "/metacards/metacard/string[@name='metacard.associations.derived']/value",
-                    is(expectedParentId)));
+                    is(expectedFrameCenterWkt)));
 
     final double altitude =
         response


### PR DESCRIPTION
#### What does this PR do?
For video streams, the parent metacard (representing the entire stream) now points to its children (the chunk metacards) using the `metacard.associations.derived` attribute, instead of the children pointing to the parent via the same attribute. The DDF documentation states that this attribute is the 'ID of one or more metacards derived from this metacard'.

#### Who is reviewing it? 
@peterhuffer 
@aj-brooks 

#### Choose 2 committers to review/merge the PR.
@jlcsmith
@glenhein 

#### How should this be tested?
1. Install Alliance with the video app.
2. Configure a video stream in the Admin UI. The default settings will work fine, but you can change the title or filename template if you want.
3. Stream an MPEG-TS video to the address specified in the stream configuration from the previous step (the default is `127.0.0.1:50000`). Two sample videos are available here: https://samples.ffmpeg.org/MPEG2/mpegts-klv/
a. Using [FFmpeg](https://ffmpeg.org/): `ffmpeg -re -i Night_Flight_IR.mpg -map 0 -c copy -f mpegts udp://127.0.0.1:50000`
b. Using [TSduck](https://tsduck.io/): `tsp -I file Night_Flight_IR.mpg -P regulate -O ip 127.0.0.1:50000`
4. Wait for the video to finish streaming.
5. Open Intrigue and search for the stream title (for the parent metacard) and the filename template (for the chunks). Verify the `metacard.associations.derived` attribute of the parent metacard contains the IDs of all the chunk metacards.

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [x] Update / Add Integration Tests