### PR TITLE
Upgrade to DDF 2.26.0

### DIFF
--- a/catalog/imaging/imaging-app/src/main/resources/features.xml
+++ b/catalog/imaging/imaging-app/src/main/resources/features.xml
@@ -47,7 +47,7 @@
 
     <feature name="imaging-nitf-transformer" version="${project.version}"
         description="Transformer responsible for converting a NITF into a Metacard">
+        <feature>security-core-api</feature>
         <bundle>mvn:org.codice.alliance.imaging/imaging-transformer-nitf/${project.version}</bundle>
-        <feature>platform-country-local</feature>
     </feature>
 </features>

--- a/catalog/video/video-mpegts-stream/pom.xml
+++ b/catalog/video/video-mpegts-stream/pom.xml
@@ -51,9 +51,34 @@
 
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId>
+            <artifactId>netty-buffer</artifactId>
             <version>${netty.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>com.barchart.udt</groupId>
             <artifactId>barchart-udt-bundle</artifactId>
@@ -179,39 +204,47 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Import-Package>
-                            !com.google.protobuf.*,
-                            !com.fasterxml.aalto.*,
-                            !com.jcraft.jzlib.*,
-                            !com.ning.compress.*,
-                            !com.puppycrawl.tools.checkstyle.api.*,
-                            !com.sun.nio.sctp.*,
-                            !gnu.io.*,
-                            !io.netty.internal.tcnative.*,
-                            !javassist.*,
-                            !lzma.sdk.*,
-                            !net.jpountz.lz4.*,
-                            !net.jpountz.xxhash.*,
-                            !org.apache.tomcat.*,
-                            !org.bouncycastle.cert.*,
-                            !org.bouncycastle.operator.*,
-                            !org.bouncycastle.asn1.x500.*,
-                            !org.bouncycastle.jce.provider.*,
-                            !org.bouncycastle.crypto.*,
-                            !org.conscrypt.*,
-                            !org.eclipse.jetty.alpn.*,
-                            !org.eclipse.jetty.npn.*,
-                            !org.jboss.marshalling.*,
-                            !org.junit.runner.notification.*,
-                            !sun.security.util.*,
-                            !sun.security.x509.*,
-                            !org.codice.transformer.video.*,
-                            !org.apache.commons.collections4.*,
-                            sun.net.dns;resolution:=optional,
                             javax.activation;version="${javax.activation.version}",
+                            <!-- TODO: Don't embed netty dependencies. Maintaining this optional
+                                 import list is a pain -->
+                            <!-- BEGIN: Optional packages taken from the embedded netty
+                                 dependencies. This is the union of all optional packages of the
+                                 embeds minus those actually used by this bundle -->
+                            com.google.protobuf;resolution:=optional,
+                            com.google.protobuf.nano;resolution:=optional,
+                            com.jcraft.jzlib;resolution:=optional,
+                            com.ning.compress;resolution:=optional,
+                            com.ning.compress.lzf;resolution:=optional,
+                            com.ning.compress.lzf.util;resolution:=optional,
+                            com.oracle.svm.core.annotate;resolution:=optional,
+                            javax.security.cert;resolution:=optional,
+                            lzma.sdk;resolution:=optional,
+                            lzma.sdk.lzma;resolution:=optional,
+                            net.jpountz.lz4;resolution:=optional,
+                            net.jpountz.xxhash;resolution:=optional,
+                            org.apache.commons.logging;resolution:=optional,
+                            org.apache.log4j;resolution:=optional,
+                            org.apache.logging.log4j;resolution:=optional,
+                            org.apache.logging.log4j.message;resolution:=optional,
+                            org.apache.logging.log4j.spi;resolution:=optional,
+                            org.jboss.marshalling;resolution:=optional,
+                            org.slf4j.helpers;resolution:=optional,
+                            org.slf4j.spi;resolution:=optional,
+                            reactor.blockhound;resolution:=optional,
+                            reactor.blockhound.integration;resolution:=optional,
+                            sun.misc;resolution:=optional,
+                            sun.nio.ch;resolution:=optional,
+                            org.eclipse.jetty.npn;resolution:=optional,
+                            org.eclipse.jetty.alpn;resolution:=optional,
+                            <!-- END -->
                             *
                         </Import-Package>
                         <Embed-Dependency>
-                            netty-all,
+                            netty-buffer,
+                            netty-codec,
+                            netty-common,
+                            netty-resolver,
+                            netty-transport,
                             barchart-udt-bundle,
                             jcodec,
                             catalog-core-api-impl,

--- a/distribution/install-profiles/src/main/resources/features.xml
+++ b/distribution/install-profiles/src/main/resources/features.xml
@@ -24,7 +24,6 @@
         <feature>platform-app</feature>
         <feature>catalog-app</feature>
         <feature>spatial-app</feature>
-        <feature>security-services-app</feature>
         <feature>search-ui-app</feature>
         <feature>catalog-solr-app</feature>
 

--- a/distribution/test/itests/test-itests-alliance/pom.xml
+++ b/distribution/test/itests/test-itests-alliance/pom.xml
@@ -98,13 +98,6 @@
             <version>${ddf.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>ddf.distribution</groupId>
-            <artifactId>sdk-app</artifactId>
-            <version>${ddf-sdk.version}</version>
-            <classifier>features</classifier>
-            <type>xml</type>
-        </dependency>
         <!--end ddf dependencies-->
 
         <dependency>

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/alliance/test/itests/common/AbstractAllianceIntegrationTest.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/alliance/test/itests/common/AbstractAllianceIntegrationTest.java
@@ -85,13 +85,6 @@ public abstract class AbstractAllianceIntegrationTest extends AbstractIntegratio
             "alliance-itest-dependencies"),
         features(
             maven()
-                .groupId("ddf.distribution")
-                .artifactId("sdk-app")
-                .type("xml")
-                .classifier("features")
-                .versionAsInProject()),
-        features(
-            maven()
                 .groupId("org.codice.alliance.distribution")
                 .artifactId("sdk-app")
                 .type("xml")

--- a/distribution/test/itests/test-itests-dependencies-app/src/main/filtered-resources/features.xml
+++ b/distribution/test/itests/test-itests-dependencies-app/src/main/filtered-resources/features.xml
@@ -48,7 +48,7 @@
     </feature>
 
     <feature name="alliance-dependencies">
-        <feature>security-core</feature>
+        <feature>security-core-services</feature>
         <bundle>mvn:com.google.guava/guava/${guava.version}</bundle>
         <bundle>mvn:org.codice.alliance.test.itests/test-itests-common/${project.version}</bundle>
     </feature>

--- a/libs/klv/src/test/java/org/codice/alliance/libs/klv/KlvUtilities.java
+++ b/libs/klv/src/test/java/org/codice/alliance/libs/klv/KlvUtilities.java
@@ -118,8 +118,8 @@ class KlvUtilities {
             encodedMax);
     final KlvContext decodedKlvContext =
         decodeKLV(
-            Klv.KeyLength.OneByte,
-            Klv.LengthEncoding.OneByte,
+            Klv.KeyLength.ONE_BYTE,
+            Klv.LengthEncoding.ONE_BYTE,
             sensorRelativeElevationAngle,
             klvBytes);
 

--- a/libs/klv/src/test/java/org/codice/alliance/libs/klv/Stanag4609ProcessorImplTest.java
+++ b/libs/klv/src/test/java/org/codice/alliance/libs/klv/Stanag4609ProcessorImplTest.java
@@ -27,7 +27,6 @@ import org.codice.ddf.libs.klv.KlvContext;
 import org.codice.ddf.libs.klv.KlvDataElement;
 import org.codice.ddf.libs.klv.KlvDecodingException;
 import org.codice.ddf.libs.klv.data.Klv;
-import org.codice.ddf.libs.klv.data.Klv.KeyLength;
 import org.codice.ddf.libs.klv.data.numerical.KlvIntegerEncodedFloatingPoint;
 import org.codice.ddf.libs.klv.data.set.KlvLocalSet;
 import org.junit.Before;

--- a/libs/klv/src/test/java/org/codice/alliance/libs/klv/Stanag4609ProcessorImplTest.java
+++ b/libs/klv/src/test/java/org/codice/alliance/libs/klv/Stanag4609ProcessorImplTest.java
@@ -27,6 +27,7 @@ import org.codice.ddf.libs.klv.KlvContext;
 import org.codice.ddf.libs.klv.KlvDataElement;
 import org.codice.ddf.libs.klv.KlvDecodingException;
 import org.codice.ddf.libs.klv.data.Klv;
+import org.codice.ddf.libs.klv.data.Klv.KeyLength;
 import org.codice.ddf.libs.klv.data.numerical.KlvIntegerEncodedFloatingPoint;
 import org.codice.ddf.libs.klv.data.set.KlvLocalSet;
 import org.junit.Before;
@@ -87,8 +88,8 @@ public class Stanag4609ProcessorImplTest {
 
     KlvContext klvContext =
         new KlvContext(
-            Klv.KeyLength.OneByte,
-            Klv.LengthEncoding.OneByte,
+            Klv.KeyLength.ONE_BYTE,
+            Klv.LengthEncoding.ONE_BYTE,
             Collections.singleton(klvIntegerEncodedFloatingPoint));
 
     stanag4609Processor.handle(
@@ -105,8 +106,8 @@ public class Stanag4609ProcessorImplTest {
 
     KlvContext klvContext =
         new KlvContext(
-            Klv.KeyLength.OneByte,
-            Klv.LengthEncoding.OneByte,
+            Klv.KeyLength.ONE_BYTE,
+            Klv.LengthEncoding.ONE_BYTE,
             Collections.singleton(klvIntegerEncodedFloatingPoint));
 
     KlvDataElement klvLocalSet = mock(KlvLocalSet.class);
@@ -140,8 +141,8 @@ public class Stanag4609ProcessorImplTest {
     when(p2.getDecodedKLV())
         .thenReturn(
             new KlvContext(
-                Klv.KeyLength.OneByte,
-                Klv.LengthEncoding.OneByte,
+                Klv.KeyLength.ONE_BYTE,
+                Klv.LengthEncoding.ONE_BYTE,
                 Collections.singleton(klvIntegerEncodedFloatingPoint)));
 
     Map<String, KlvHandler> handlers = Collections.singletonMap(FIELD_NAME, klvHandler);

--- a/libs/stanag4609/src/main/java/org/codice/alliance/libs/stanag4609/Stanag4609TransportStreamParser.java
+++ b/libs/stanag4609/src/main/java/org/codice/alliance/libs/stanag4609/Stanag4609TransportStreamParser.java
@@ -26,6 +26,7 @@ import java.util.function.BiConsumer;
 import org.codice.ddf.libs.klv.KlvContext;
 import org.codice.ddf.libs.klv.KlvDecoder;
 import org.codice.ddf.libs.klv.KlvDecodingException;
+import org.codice.ddf.libs.klv.data.Klv;
 import org.codice.ddf.libs.klv.data.numerical.KlvInt;
 import org.codice.ddf.libs.klv.data.numerical.KlvIntegerEncodedFloatingPoint;
 import org.codice.ddf.libs.klv.data.numerical.KlvLong;
@@ -45,7 +46,7 @@ import org.slf4j.LoggerFactory;
  */
 public class Stanag4609TransportStreamParser {
   public static final KlvContext UAS_DATALINK_LOCAL_SET_CONTEXT =
-      new KlvContext(KeyLength.SixteenBytes, LengthEncoding.BER);
+      new KlvContext(KeyLength.SIXTEEN_BYTES, LengthEncoding.BER);
 
   public static final String UAS_DATALINK_LOCAL_SET = "UAS Datalink Local Set";
 
@@ -151,7 +152,7 @@ public class Stanag4609TransportStreamParser {
   private static final long MAX_UNSIGNED_INT = (1L << 32) - 1;
 
   static {
-    final KlvContext localSetContext = new KlvContext(KeyLength.OneByte, LengthEncoding.BER);
+    final KlvContext localSetContext = new KlvContext(Klv.KeyLength.ONE_BYTE, LengthEncoding.BER);
     final KlvLocalSet outerSet =
         new KlvLocalSet(
             new byte[] {
@@ -372,7 +373,7 @@ public class Stanag4609TransportStreamParser {
             180));
 
     final KlvContext securityLocalSetContext =
-        new KlvContext(KeyLength.OneByte, LengthEncoding.BER);
+        new KlvContext(Klv.KeyLength.ONE_BYTE, LengthEncoding.BER);
 
     securityLocalSetContext.addDataElement(
         new KlvUnsignedByte(new byte[] {1}, SECURITY_CLASSIFICATION));

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <yarn.version>v1.5.1</yarn.version>
 
         <!--Project properties-->
-        <ddf.version>2.25.1</ddf.version>
+        <ddf.version>2.25.2</ddf.version>
         <ddf-admin-ui.version>2.25.0</ddf-admin-ui.version>
         <!--
            NOTE: ddf-sdk.version should be removed if itests no longer require the sdk

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <yarn.version>v1.5.1</yarn.version>
 
         <!--Project properties-->
-        <ddf.version>2.25.2</ddf.version>
+        <ddf.version>2.26.0</ddf.version>
         <ddf-admin-ui.version>2.25.0</ddf-admin-ui.version>
         <ddf.support.version>2.3.16</ddf.support.version>
         <codice-maven.version>0.3</codice-maven.version>
@@ -137,13 +137,13 @@
         <asciidoctorj.version>1.6.2</asciidoctorj.version>
         <jruby.version>9.2.11.1</jruby.version>
 
-        <camel.version>2.22.1</camel.version>
+        <camel.version>2.24.2</camel.version>
         <commons-collections4.version>4.1</commons-collections4.version>
         <commons-configuration.version>1.10</commons-configuration.version>
         <commons-exec.version>1.3</commons-exec.version>
         <commons-io.version>2.6</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
-        <commons-lang3.version>3.8</commons-lang3.version>
+        <commons-lang3.version>3.9</commons-lang3.version>
         <commons-net.version>3.5</commons-net.version>
         <components-backbone.version>1.1.0</components-backbone.version>
         <components-font-awesome.version>4.7.0</components-font-awesome.version>
@@ -153,34 +153,34 @@
         <guava.version-number>25.1</guava.version-number>
         <guava.platform>jre</guava.platform>
         <guava.version>${guava.version-number}-${guava.platform}</guava.version>
-        <jai-imageio-core.version>1.3.1</jai-imageio-core.version>
+        <jai-imageio-core.version>1.4.0</jai-imageio-core.version>
         <javax.activation.version>1.1</javax.activation.version>
         <javax.inject.version>1</javax.inject.version>
         <javax.ws.rs.version>2.1</javax.ws.rs.version>
-        <javax-mail.version>1.5.6</javax-mail.version>
+        <javax-mail.version>1.6.2</javax-mail.version>
         <jcodec.version>0.2.0_1</jcodec.version>
         <jgrapht-core.version>0.9.1</jgrapht-core.version>
         <jodah-failsafe.version>0.9.5</jodah-failsafe.version>
-        <joda-time.version>2.10</joda-time.version>
+        <joda-time.version>2.10.3</joda-time.version>
         <jpeg2000.version>1.3.1_CODICE_3</jpeg2000.version>
         <jsoup.version>1.11.3</jsoup.version>
         <jsr305.version>3.0.2_1</jsr305.version>
         <jts.version>1.16.0</jts.version>
-        <karaf.version>4.2.6</karaf.version>
+        <karaf.version>4.2.9</karaf.version>
         <la4j.version>0.6.0</la4j.version>
-        <log4j.version>2.11.0</log4j.version>
+        <log4j.version>2.11.2</log4j.version>
         <mariadb.version>2.4.1</mariadb.version>
         <!-- Mina version is not the latest version due to Apache FTPServer 1.0.6 not supporting newer releases properly -->
         <mina.version>2.0.6</mina.version>
         <mpegts-streamer.version>0.1.0_2</mpegts-streamer.version>
-        <netty.version>4.1.24.Final</netty.version>
+        <netty.version>4.1.46.Final</netty.version>
         <nitf-imaging.version>0.8.2</nitf-imaging.version>
         <ogc-filter-v_1_1_0-schema.version>1.1.0_5</ogc-filter-v_1_1_0-schema.version>
         <opendj-embedded.app.version>1.3.3</opendj-embedded.app.version>
-        <org.slf4j.version>1.7.1</org.slf4j.version>
+        <org.slf4j.version>1.7.29</org.slf4j.version>
         <plexus-compiler-javac-errorprone.version>2.8.2</plexus-compiler-javac-errorprone.version>
-        <usng4j.version>0.1</usng4j.version>
-        <xstream.version>1.4.9</xstream.version>
+        <usng4j.version>0.4</usng4j.version>
+        <xstream.version>1.4.11.1</xstream.version>
         <!-- Command line argument properties for the maven-surefire-plugin -->
         <surefire.argline.append />
         <surefire.argline>${jacoco.argline} ${surefire.argline.append} -Xmx1024m -XX:MaxPermSize=256m -Djava.awt.headless=true -noverify -Duser.timezone=UTC -Dddf.version=${ddf.version}</surefire.argline>
@@ -905,7 +905,7 @@
     <pluginRepositories>
         <pluginRepository>
             <id>central</id>
-            <name>Central Repository</name>            
+            <name>Central Repository</name>
             <url>https://repo.maven.apache.org/maven2</url>
             <layout>default</layout>
             <snapshots>

--- a/pom.xml
+++ b/pom.xml
@@ -122,10 +122,6 @@
         <!--Project properties-->
         <ddf.version>2.25.2</ddf.version>
         <ddf-admin-ui.version>2.25.0</ddf-admin-ui.version>
-        <!--
-           NOTE: ddf-sdk.version should be removed if itests no longer require the sdk
-         -->
-        <ddf-sdk.version>2.19.0</ddf-sdk.version>
         <ddf.support.version>2.3.16</ddf.support.version>
         <codice-maven.version>0.3</codice-maven.version>
         <codice-test.version>0.3</codice-test.version>


### PR DESCRIPTION
#### What does this PR do?
Bumps DDF version to 2.26.0, and bumps dependency versions to match what DDF uses. Includes the commits from this PR: https://github.com/codice/alliance/pull/829

#### Who is reviewing it? 
@derekwilhelm @jlcsmith

#### How should this be tested?
CI

#### Any background context you want to provide?
N/a

#### What are the relevant tickets?
Fixes: #828 

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
