### PR TITLE
Set the derived association IDs on video stream metacards correctly

### DIFF
--- a/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/metacard/DerivedAssociationMetacardUpdater.java
+++ b/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/metacard/DerivedAssociationMetacardUpdater.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.video.stream.mpegts.metacard;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.types.Associations;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.codice.alliance.video.stream.mpegts.Context;
+
+public class DerivedAssociationMetacardUpdater implements MetacardUpdater {
+
+  @Override
+  public void update(final Metacard parent, final Metacard child, final Context context) {
+    final List<Serializable> derivedIds =
+        Optional.ofNullable(parent.getAttribute(Associations.DERIVED))
+            .map(Attribute::getValues)
+            .orElseGet(ArrayList::new);
+    final String childId = child.getId();
+    derivedIds.add(childId);
+    parent.setAttribute(new AttributeImpl(Associations.DERIVED, derivedIds));
+  }
+}

--- a/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/plugins/FindChildrenStreamEndPlugin.java
+++ b/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/plugins/FindChildrenStreamEndPlugin.java
@@ -13,6 +13,10 @@
  */
 package org.codice.alliance.video.stream.mpegts.plugins;
 
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toList;
+
+import ddf.catalog.data.Attribute;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.Result;
 import ddf.catalog.data.types.Associations;
@@ -26,7 +30,9 @@ import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.source.SourceUnavailableException;
 import ddf.catalog.source.UnsupportedQueryException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -89,7 +95,14 @@ public class FindChildrenStreamEndPlugin implements StreamEndPlugin {
     Handler handler = factory.build();
 
     Filter filter =
-        filterBuilder.attribute(Associations.DERIVED).is().equalTo().text(parentMetacard.getId());
+        Optional.ofNullable(parentMetacard.getAttribute(Associations.DERIVED))
+            .map(Attribute::getValues)
+            .orElseGet(ArrayList::new)
+            .stream()
+            .filter(String.class::isInstance)
+            .map(String.class::cast)
+            .map(derivedId -> filterBuilder.attribute(Core.ID).is().equalTo().text(derivedId))
+            .collect(collectingAndThen(toList(), filterBuilder::anyOf));
 
     int startIndex = 1;
     Long expectedReturnCount = null;
@@ -184,6 +197,7 @@ public class FindChildrenStreamEndPlugin implements StreamEndPlugin {
 
   /** Factory for building {@link Handler} */
   public interface Factory {
+
     Handler build();
   }
 }

--- a/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/plugins/FindChildrenStreamEndPlugin.java
+++ b/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/plugins/FindChildrenStreamEndPlugin.java
@@ -96,9 +96,7 @@ public class FindChildrenStreamEndPlugin implements StreamEndPlugin {
 
     Filter filter =
         Optional.ofNullable(parentMetacard.getAttribute(Associations.DERIVED))
-            .map(Attribute::getValues)
-            .orElseGet(ArrayList::new)
-            .stream()
+            .map(Attribute::getValues).orElseGet(ArrayList::new).stream()
             .filter(String.class::isInstance)
             .map(String.class::cast)
             .map(derivedId -> filterBuilder.attribute(Core.ID).is().equalTo().text(derivedId))

--- a/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/rollover/CatalogRolloverAction.java
+++ b/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/rollover/CatalogRolloverAction.java
@@ -127,8 +127,7 @@ public class CatalogRolloverAction extends BaseRolloverAction {
   }
 
   @Override
-  public MetacardImpl doAction(MetacardImpl metacard, File tempFile)
-      throws RolloverActionException {
+  public MetacardImpl doAction(MetacardImpl metacard, File tempFile) {
 
     return context.modifyParentOrChild(
         isParentDirty -> {
@@ -154,8 +153,6 @@ public class CatalogRolloverAction extends BaseRolloverAction {
 
                 for (Metacard childMetacard : createResponse.getCreatedMetacards()) {
                   LOGGER.trace("created catalog content with id={}", childMetacard.getId());
-
-                  linkChildToParent(childMetacard);
 
                   updateParentWithChildMetadata(childMetacard);
                 }
@@ -211,21 +208,6 @@ public class CatalogRolloverAction extends BaseRolloverAction {
 
   private UpdateRequest createUpdateRequest(String id, Metacard metacard) {
     return new UpdateRequestImpl(id, metacard);
-  }
-
-  private void linkChildToParent(Metacard childMetacard) {
-    setDerivedAttribute(childMetacard);
-
-    UpdateRequest updateChild = createUpdateRequest(childMetacard.getId(), childMetacard);
-
-    submitChildUpdateRequest(updateChild);
-  }
-
-  private void setDerivedAttribute(Metacard childMetacard) {
-    if (context.getParentMetacard().isPresent()) {
-      childMetacard.setAttribute(
-          new AttributeImpl(Metacard.DERIVED, context.getParentMetacard().get().getId()));
-    }
   }
 
   private CreateResponse submitStorageCreateRequest(CreateStorageRequest createRequest)

--- a/catalog/video/video-mpegts-stream/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/video/video-mpegts-stream/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -191,6 +191,7 @@
                         <bean class="org.codice.alliance.video.stream.mpegts.metacard.SecurityDisseminationControlsMetacardUpdater"/>
                         <bean class="org.codice.alliance.video.stream.mpegts.metacard.SecurityClassificationSystemMetacardUpdater"/>
                         <bean class="org.codice.alliance.video.stream.mpegts.metacard.SecurityReleasabilityMetacardUpdater"/>
+                        <bean class="org.codice.alliance.video.stream.mpegts.metacard.DerivedAssociationMetacardUpdater" />
                     </list>
                 </argument>
             </bean>

--- a/catalog/video/video-mpegts-stream/src/test/java/org/codice/alliance/video/stream/mpegts/metacard/DerivedAssociationMetacardUpdaterTest.java
+++ b/catalog/video/video-mpegts-stream/src/test/java/org/codice/alliance/video/stream/mpegts/metacard/DerivedAssociationMetacardUpdaterTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.video.stream.mpegts.metacard;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.data.types.Associations;
+import java.util.Arrays;
+import java.util.UUID;
+import org.junit.Test;
+
+public class DerivedAssociationMetacardUpdaterTest {
+
+  private final DerivedAssociationMetacardUpdater updater = new DerivedAssociationMetacardUpdater();
+
+  @Test
+  public void firstChild() {
+    final Metacard parent = new MetacardImpl();
+    final MetacardImpl child = new MetacardImpl();
+    child.setId(UUID.randomUUID().toString());
+
+    updater.update(parent, child, null);
+
+    final Attribute derivedAssociation = parent.getAttribute(Associations.DERIVED);
+    assertThat(derivedAssociation, is(notNullValue()));
+    assertThat(derivedAssociation.getValues(), contains(child.getId()));
+  }
+
+  @Test
+  public void multipleChildren() {
+    final Metacard parent = new MetacardImpl();
+    parent.setAttribute(new AttributeImpl(Associations.DERIVED, Arrays.asList("first", "second")));
+    final MetacardImpl child = new MetacardImpl();
+    child.setId("third");
+
+    updater.update(parent, child, null);
+
+    final Attribute derivedAssociation = parent.getAttribute(Associations.DERIVED);
+    assertThat(derivedAssociation, is(notNullValue()));
+    assertThat(derivedAssociation.getValues(), containsInAnyOrder("first", "second", "third"));
+  }
+}

--- a/catalog/video/video-mpegts-stream/src/test/java/org/codice/alliance/video/stream/mpegts/rollover/CatalogRolloverActionTest.java
+++ b/catalog/video/video-mpegts-stream/src/test/java/org/codice/alliance/video/stream/mpegts/rollover/CatalogRolloverActionTest.java
@@ -201,7 +201,7 @@ public class CatalogRolloverActionTest {
 
     ArgumentCaptor<UpdateRequest> argumentCaptor = ArgumentCaptor.forClass(UpdateRequest.class);
 
-    verify(catalogFramework, times(3)).update(argumentCaptor.capture());
+    verify(catalogFramework, times(2)).update(argumentCaptor.capture());
 
     ArgumentCaptor<Attribute> attributeCaptor = ArgumentCaptor.forClass(Attribute.class);
     verify(createdParentMetacard, atLeastOnce()).setAttribute(attributeCaptor.capture());
@@ -223,7 +223,7 @@ public class CatalogRolloverActionTest {
 
     ArgumentCaptor<UpdateRequest> argumentCaptor = ArgumentCaptor.forClass(UpdateRequest.class);
 
-    verify(catalogFramework, times(2)).update(argumentCaptor.capture());
+    verify(catalogFramework).update(argumentCaptor.capture());
 
     ArgumentCaptor<Attribute> attributeCaptor = ArgumentCaptor.forClass(Attribute.class);
     verify(createdParentMetacard, atLeastOnce()).setAttribute(attributeCaptor.capture());
@@ -245,7 +245,7 @@ public class CatalogRolloverActionTest {
 
     ArgumentCaptor<UpdateRequest> argumentCaptor = ArgumentCaptor.forClass(UpdateRequest.class);
 
-    verify(catalogFramework, times(2)).update(argumentCaptor.capture());
+    verify(catalogFramework).update(argumentCaptor.capture());
 
     ArgumentCaptor<Attribute> attributeCaptor = ArgumentCaptor.forClass(Attribute.class);
     verify(createdParentMetacard, atLeastOnce()).setAttribute(attributeCaptor.capture());


### PR DESCRIPTION
### Forward port of https://github.com/codice/alliance/pull/854

#### What does this PR do?
For video streams, the parent metacard (representing the entire stream) now points to its children (the chunk metacards) using the `metacard.associations.derived` attribute, instead of the children pointing to the parent via the same attribute. The DDF documentation states that this attribute is the 'ID of one or more metacards derived from this metacard'.

#### Who is reviewing it? 
@peterhuffer 
@aj-brooks 
@glenhein 

#### Choose 2 committers to review/merge the PR.
@jlcsmith
@clockard  

#### How should this be tested?
1. Install Alliance with the video app.
2. Configure a video stream in the Admin UI. The default settings will work fine, but you can change the title or filename template if you want.
3. Stream an MPEG-TS video to the address specified in the stream configuration from the previous step (the default is `127.0.0.1:50000`). Two sample videos are available here: https://samples.ffmpeg.org/MPEG2/mpegts-klv/
a. Using [FFmpeg](https://ffmpeg.org/): `ffmpeg -re -i Night_Flight_IR.mpg -map 0 -c copy -f mpegts udp://127.0.0.1:50000`
b. Using [TSduck](https://tsduck.io/): `tsp -I file Night_Flight_IR.mpg -P regulate -O ip 127.0.0.1:50000`
4. Wait for the video to finish streaming.
5. Open Intrigue and search for the stream title (for the parent metacard) and the filename template (for the chunks). Verify the `metacard.associations.derived` attribute of the parent metacard contains the IDs of all the chunk metacards.

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [x] Update / Add Integration Tests