### PR TITLE
Update docs about chunk frames when streaming video

### DIFF
--- a/catalog/video/video-mpegts-stream/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/video/video-mpegts-stream/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -33,12 +33,12 @@
                 type="String" default="" />
 
         <AD
-                description="Maximum file size (megabytes) before rollover. Must be >=1 and integer."
+                description="Maximum file size (megabytes) before rollover. Must be >=1 and integer. The current chunk must contain an I-frame for a rollover to occur, so it is possible for the chunk size to be greater than this number of bytes if additional frames had to be processed to find one."
                 name="Max File Size" id="megabyteCountRolloverCondition" required="false"
                 type="Integer" default="10"/>
 
         <AD
-                description="Maximum elapsed time in milliseconds before rollover. Must be >=1."
+                description="Maximum elapsed time in milliseconds before rollover. Must be >=1. The current chunk must contain an I-frame for a rollover to occur, so it is possible the rollover could be delayed beyond this time limit if additional frames had to be processed to find one."
                 name="Max Elapsed Time" id="elapsedTimeRolloverCondition" required="false"
                 type="Long" default="60000"/>
 

--- a/distribution/docs/src/main/resources/content/_reference/_tables/UdpStreamMonitor.adoc
+++ b/distribution/docs/src/main/resources/content/_reference/_tables/UdpStreamMonitor.adoc
@@ -33,14 +33,14 @@
 |Max File Size
 |byteCountRolloverCondition
 |Integer
-|Maximum file size (bytes) before rollover. Must be >=1.
+|Maximum file size (bytes) before rollover. Must be >=1. The current chunk must contain an I-frame for a rollover to occur, so it is possible for the chunk size to be greater than this number of bytes if additional frames had to be processed to find one.
 |10000000
 |false
 
 |Max Elapsed Time
 |elapsedTimeRolloverCondition
 |Long
-|Maximum elapsed time in milliseconds before rollover. Must be >=1.
+|Maximum elapsed time in milliseconds before rollover. Must be >=1. The current chunk must contain an I-frame for a rollover to occur, so it is possible the rollover could be delayed beyond this time limit if additional frames had to be processed to find one.
 |60000
 |false
 


### PR DESCRIPTION
#### What does this PR do?
Updates documentation about video chunk size and limit are not respected when streaming. Certain frame types are looked for when determining when to finish a chunk but some videos (more specifically in this scenario, streaming videos) have very few of these frames causing larger chunks which also causes it to take more time to process. 

#### Who is reviewing it? 
@kcover 
@josephthweatt 
@jrnorth 

#### Choose 2 committers to review/merge the PR.
@clockard
@ricklarsen 


#### Checklist:
- [X] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
