### PR TITLE
Skip itests and docs when doing OWASP scans, scan distro during nightly builds, and archive OWASP reports

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
     }
     environment {
         DOCS = 'distribution/docs'
-        ITESTS = 'distribution/test/itests/test-itests-alliance'
+        ITESTS = 'distribution/test/itests'
         LARGE_MVN_OPTS = '-Xmx8192M -Xss128M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC '
         DISABLE_DOWNLOAD_PROGRESS_OPTS = '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn '
         LINUX_MVN_RANDOM = '-Djava.security.egd=file:/dev/./urandom'
@@ -71,23 +71,23 @@ pipeline {
                         unset JAVA_TOOL_OPTIONS
                         mvn install -B -DskipStatic=true -DskipTests=true $DISABLE_DOWNLOAD_PROGRESS_OPTS
                     '''
-                    
+
                     sh '''
                         unset JAVA_TOOL_OPTIONS
-                        mvn clean install -B -pl !$ITESTS -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/$CHANGE_TARGET $DISABLE_DOWNLOAD_PROGRESS_OPTS
+                        mvn clean install -B -P !itests -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/$CHANGE_TARGET $DISABLE_DOWNLOAD_PROGRESS_OPTS
                     '''
-                    
+
                     sh '''
                         unset JAVA_TOOL_OPTIONS
-                        mvn install -B -pl $ITESTS -nsu $DISABLE_DOWNLOAD_PROGRESS_OPTS
+                        mvn install -B -pl $ITESTS -amd -nsu $DISABLE_DOWNLOAD_PROGRESS_OPTS
                     '''
                 }
             }
         }
         // The full build will be run against all regular branches
         stage('Full Build') {
-            when { 
-                expression { env.CHANGE_ID == null } 
+            when {
+                expression { env.CHANGE_ID == null }
             }
             options {
                 timeout(time: 1, unit: 'HOURS')
@@ -97,12 +97,12 @@ pipeline {
                 withMaven(maven: 'maven-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}') {
                     sh '''
                         unset JAVA_TOOL_OPTIONS
-                        mvn clean install -B -pl !$ITESTS $DISABLE_DOWNLOAD_PROGRESS_OPTS
+                        mvn clean install -B -P !itests $DISABLE_DOWNLOAD_PROGRESS_OPTS
                     '''
-                    
+
                     sh '''
                         unset JAVA_TOOL_OPTIONS
-                        mvn install -B -pl $ITESTS -nsu $DISABLE_DOWNLOAD_PROGRESS_OPTS
+                        mvn install -B -pl $ITESTS -amd -nsu $DISABLE_DOWNLOAD_PROGRESS_OPTS
                     '''
                 }
             }
@@ -124,13 +124,18 @@ pipeline {
             steps {
                 withMaven(maven: 'maven-latest', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}') {
                     script {
-                        // If this build is not a pull request, run full owasp scan. Otherwise run incremental scan
+                        // If this build is not a pull request, run owasp scan on the distribution
                         if (env.CHANGE_ID == null) {
-                            sh 'mvn org.commonjava.maven.plugins:directory-maven-plugin:highest-basedir@directories dependency-check:check dependency-check:aggregate -q -B -Powasp -DskipTests=true -DskipStatic=true -pl !$DOCS $DISABLE_DOWNLOAD_PROGRESS_OPTS'
+                            sh 'mvn dependency-check:check dependency-check:aggregate -q -B -Powasp-dist -pl !$DOCS -P !itests $DISABLE_DOWNLOAD_PROGRESS_OPTS'
                         } else {
-                            sh 'mvn org.commonjava.maven.plugins:directory-maven-plugin:highest-basedir@directories dependency-check:check -q -B -Powasp -DskipTests=true -DskipStatic=true -pl !$DOCS -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/$CHANGE_TARGET $DISABLE_DOWNLOAD_PROGRESS_OPTS'
+                            sh 'mvn dependency-check:check -q -B -pl !$DOCS -P !itests $DISABLE_DOWNLOAD_PROGRESS_OPTS'
                         }
                     }
+                }
+            }
+            post {
+                success {
+                    archiveArtifacts artifacts: 'target/dependency-check-report.html'
                 }
             }
         }
@@ -150,7 +155,7 @@ pipeline {
                 }
             }
         }
-        
+
         /*
           Deploy stage will only be executed for deployable branches. These include master and any patch branch matching M.m.x format (i.e. 2.10.x, 2.9.x, etc...).
           It will also only deploy in the presence of an environment variable JENKINS_ENV = 'prod'. This can be passed in globally from the jenkins master node settings.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -126,9 +126,9 @@ pipeline {
                     script {
                         // If this build is not a pull request, run owasp scan on the distribution
                         if (env.CHANGE_ID == null) {
-                            sh 'mvn dependency-check:check dependency-check:aggregate -q -B -Powasp-dist -pl !$DOCS -P !itests $DISABLE_DOWNLOAD_PROGRESS_OPTS'
+                            sh 'mvn dependency-check:aggregate -q -B -Powasp-dist -pl !$DOCS -P !itests $DISABLE_DOWNLOAD_PROGRESS_OPTS'
                         } else {
-                            sh 'mvn dependency-check:check -q -B -pl !$DOCS -P !itests $DISABLE_DOWNLOAD_PROGRESS_OPTS'
+                            sh 'mvn dependency-check:aggregate -q -B -pl !$DOCS -P !itests $DISABLE_DOWNLOAD_PROGRESS_OPTS'
                         }
                     }
                 }

--- a/dependency-check-maven-config.xml
+++ b/dependency-check-maven-config.xml
@@ -1,4 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://www.owasp.org/index.php/OWASP_Dependency_Check_Suppression">
 
+  <suppress>
+    <notes>
+      Ignore all vulnerabilities reported against Alliance artifacts. These are false positives.
+      Note: CVEs with a score of exactly 10.0 will need to be suppressed separately.
+    </notes>
+    <gav regex="true">org.codice.alliance.*:.*</gav>
+    <cvssBelow>10</cvssBelow>
+  </suppress>
+
 </suppressions>

--- a/distribution/docs/pom.xml
+++ b/distribution/docs/pom.xml
@@ -26,11 +26,13 @@
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctorj-diagram</artifactId>
             <version>${asciidoctorj.diagram.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctorj</artifactId>
             <version>${asciidoctorj.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>

--- a/distribution/test/pom.xml
+++ b/distribution/test/pom.xml
@@ -23,7 +23,20 @@
     <artifactId>test</artifactId>
     <packaging>pom</packaging>
     <name>Alliance :: Test</name>
-    <modules>
-        <module>itests</module>
-    </modules>
+
+    <profiles>
+        <profile>
+            <!-- The itests profile is here so we can selectively skip the itest modules. We need a
+                 way to skip them because OWASP scans will report CVEs for itest dependencies if the
+                 itest modules are run. These CVEs add a bunch of noise to the OWASP reports. -->
+            <id>itests</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>itests</module>
+            </modules>
+        </profile>
+    </profiles>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -506,6 +506,52 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>org.owasp</groupId>
+                    <artifactId>dependency-check-maven</artifactId>
+                    <version>${dependency-check-maven.version}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>ddf.support</groupId>
+                            <artifactId>support-owasp</artifactId>
+                            <version>${ddf.support.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.mariadb.jdbc</groupId>
+                            <artifactId>mariadb-java-client</artifactId>
+                            <version>${mariadb.version}</version>
+                        </dependency>
+                    </dependencies>
+                    <configuration>
+                        <!-- The following properties enable using a centralized nvd server -->
+                        <autoUpdate>${owasp.autoUpdate}</autoUpdate>
+                        <databaseDriverName>${owasp.database.driverName}</databaseDriverName>
+                        <connectionString>${owasp.database.url}</connectionString>
+                        <serverId>${owasp.serverId}</serverId>
+                        <!-- End Centralized NVD Server Configuration -->
+                        <failOnError>false</failOnError>
+                        <skipTestScope>true</skipTestScope>
+                        <!--Disable by plugin maintainer recommendation on https://github.com/jeremylong/DependencyCheck/issues/978#issuecomment-349620687-->
+                        <centralAnalyzerEnabled>false</centralAnalyzerEnabled>
+                        <!--Disable .NET analyzers-->
+                        <nuspecAnalyzerEnabled>false</nuspecAnalyzerEnabled>
+                        <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+                        <!--Analyzes Ruby Gemfile.lock files, not OSGi bundles-->
+                        <bundleAuditAnalyzerEnabled>false</bundleAuditAnalyzerEnabled>
+                        <!--We don't use CMake, CocoaPods, AutoConf, or Ruby-->
+                        <cmakeAnalyzerEnabled>false</cmakeAnalyzerEnabled>
+                        <cocoapodsAnalyzerEnabled>false</cocoapodsAnalyzerEnabled>
+                        <autoconfAnalyzerEnabled>false</autoconfAnalyzerEnabled>
+                        <rubygemsAnalyzerEnabled>false</rubygemsAnalyzerEnabled>
+                        <suppressionFiles>
+                            <suppressionFile>https://raw.githubusercontent.com/codice/ddf/master/dependency-check-maven-config.xml</suppressionFile>
+                            <suppressionFile>https://raw.githubusercontent.com/codice/ddf-support/master/support-owasp/src/main/resources/dependency-check-maven-config.xml</suppressionFile>
+                            <suppressionFile>dependency-check-maven-config.xml</suppressionFile>
+                        </suppressionFiles>
+                        <!-- This prevents a build failure on jdk tools jar -->
+                        <skipSystemScope>true</skipSystemScope>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -543,6 +589,17 @@
                 <configuration>
                     <skip>true</skip>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>aggregate</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
             </plugin>
         </plugins>
     </reporting>
@@ -782,8 +839,11 @@
                 </plugins>
             </build>
         </profile>
+        <!-- Adds all zip build artifacts to the OWASP scan. This includes the kernel, the DDF
+             distro, etc. Those may include artifacts which aren't actually dependencies of any
+             DDF modules, so won't appear in a normal scan. -->
         <profile>
-            <id>owasp</id>
+            <id>owasp-dist</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
@@ -792,80 +852,19 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>${dependency-check-maven.version}</version>
-                        <dependencies>
-                            <dependency>
-                                <groupId>ddf.support</groupId>
-                                <artifactId>support-owasp</artifactId>
-                                <version>${ddf.support.version}</version>
-                            </dependency>
-                            <dependency>
-                                <groupId>org.mariadb.jdbc</groupId>
-                                <artifactId>mariadb-java-client</artifactId>
-                                <version>${mariadb.version}</version>
-                            </dependency>
-                        </dependencies>
                         <configuration>
-                            <!-- The following properties enable using a centralized nvd server -->
-                            <autoUpdate>${owasp.autoUpdate}</autoUpdate>
-                            <databaseDriverName>${owasp.database.driverName}</databaseDriverName>
-                            <connectionString>${owasp.database.url}</connectionString>
-                            <serverId>${owasp.serverId}</serverId>
-                            <!-- End Centralized NVD Server Configuration -->
-                            <failOnError>false</failOnError>
-                            <skipTestScope>true</skipTestScope>
-                            <!--Disable by plugin maintainer recommendation on https://github.com/jeremylong/DependencyCheck/issues/978#issuecomment-349620687-->
-                            <centralAnalyzerEnabled>false</centralAnalyzerEnabled>
-                            <!--Disable .NET analyzers-->
-                            <nuspecAnalyzerEnabled>false</nuspecAnalyzerEnabled>
-                            <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
-                            <!--Analyzes Ruby Gemfile.lock files, not OSGi bundles-->
-                            <bundleAuditAnalyzerEnabled>false</bundleAuditAnalyzerEnabled>
-                            <!--We don't use CMake, CocoaPods, AutoConf, or Ruby-->
-                            <cmakeAnalyzerEnabled>false</cmakeAnalyzerEnabled>
-                            <cocoapodsAnalyzerEnabled>false</cocoapodsAnalyzerEnabled>
-                            <autoconfAnalyzerEnabled>false</autoconfAnalyzerEnabled>
-                            <rubygemsAnalyzerEnabled>false</rubygemsAnalyzerEnabled>
-                            <suppressionFiles>
-                                <suppressionFile>https://raw.githubusercontent.com/codice/ddf/master/dependency-check-maven-config.xml</suppressionFile>
-                                <suppressionFile>dependency-check-maven-config.xml</suppressionFile>
-                            </suppressionFiles>
-                            <!-- This prevents a build failure on jdk tools jar -->
-                            <skipSystemScope>true</skipSystemScope>
+                            <scanSet>
+                                <fileSet>
+                                    <directory>target</directory>
+                                    <includes>
+                                        <include>*.zip</include>
+                                    </includes>
+                                </fileSet>
+                            </scanSet>
                         </configuration>
-                        <executions>
-                            <execution>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>check</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                     </plugin>
                 </plugins>
             </build>
-            <reporting>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-checkstyle-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.owasp</groupId>
-                        <artifactId>dependency-check-maven</artifactId>
-                        <version>${dependency-check-maven.version}</version>
-                        <reportSets>
-                            <reportSet>
-                                <reports>
-                                    <report>aggregate</report>
-                                </reports>
-                            </reportSet>
-                        </reportSets>
-                    </plugin>
-                </plugins>
-            </reporting>
         </profile>
     </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -545,7 +545,6 @@
                         <rubygemsAnalyzerEnabled>false</rubygemsAnalyzerEnabled>
                         <suppressionFiles>
                             <suppressionFile>https://raw.githubusercontent.com/codice/ddf/master/dependency-check-maven-config.xml</suppressionFile>
-                            <suppressionFile>https://raw.githubusercontent.com/codice/ddf-support/master/support-owasp/src/main/resources/dependency-check-maven-config.xml</suppressionFile>
                             <suppressionFile>dependency-check-maven-config.xml</suppressionFile>
                         </suppressionFiles>
                         <!-- This prevents a build failure on jdk tools jar -->

--- a/pom.xml
+++ b/pom.xml
@@ -838,9 +838,9 @@
                 </plugins>
             </build>
         </profile>
-        <!-- Adds all zip build artifacts to the OWASP scan. This includes the kernel, the DDF
-             distro, etc. Those may include artifacts which aren't actually dependencies of any
-             DDF modules, so won't appear in a normal scan. -->
+        <!-- Adds all zip build artifacts to the OWASP scan, including the Alliance distribution.
+             This may discover artifacts which aren't actually dependencies of any DDF modules,
+             so won't appear in a normal scan. -->
         <profile>
             <id>owasp-dist</id>
             <activation>


### PR DESCRIPTION
### What does this PR do?
A few things:
* Skips docs and itest modules when running OWASP scans. Don't care about those CVEs as they don't matter at runtime.
* Changes the CI scans to analyze the distribution zip when doing nightly builds, which takes longer but may catch some dependencies that the normal scans won't
* Makes the OWASP reports available in Jenkins

The changes are similar to https://github.com/codice/ddf/pull/6347

#### Who is reviewing it? 
@codice/build 
@codice/continuous-integration 
@codice/security 

#### How should this be tested?
Verify that:
* CI passes
* The OWASP reports are available
* itest and docs CVEs don't show up in the reports (look for asciidoctor, jruby, groovy)

#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-xxx](https://codice.atlassian.net/browse/CAL-xxx)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
