### PR TITLE
Create video-core feature

### DIFF
--- a/catalog/video/video-app/pom.xml
+++ b/catalog/video/video-app/pom.xml
@@ -83,6 +83,13 @@
             <artifactId>klv</artifactId>
             <version>${ddf.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.codice.alliance.security</groupId>
+            <artifactId>security-app</artifactId>
+            <version>${project.version}</version>
+            <type>xml</type>
+            <classifier>features</classifier>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/catalog/video/video-app/src/main/resources/features.xml
+++ b/catalog/video/video-app/src/main/resources/features.xml
@@ -18,19 +18,16 @@
 
     <feature name="mpegts-stream" version="${project.version}"
              description="Consume UDP MPEG-TS Stream">
-        <feature>video-app</feature>
         <feature>security-classification-service</feature>
         <feature>catalog-core-impl</feature>
-        <bundle>mvn:org.codice.alliance.video/video-mpegts-transformer/${project.version}
-        </bundle>
+        <feature>mpegts-input-transformer</feature>
         <bundle>mvn:org.codice.alliance.video/video-mpegts-stream/${project.version}</bundle>
-        <bundle>mvn:org.codice.alliance.video/video-admin-plugin/${project.version}</bundle>
     </feature>
 
     <feature name="mpegts-input-transformer" version="${project.version}"
              description="Transform MPEG-TS Files">
-        <feature>video-app</feature>
         <feature>security-classification-service</feature>
+        <feature>catalog-transformer-tika</feature>
         <bundle>mvn:org.codice.alliance.video/video-mpegts-transformer/${project.version}
         </bundle>
         <configfile finalname="/etc/DDF_Custom_Mime_Type_Resolver-mpegts.config">
@@ -38,9 +35,10 @@
         </configfile>
     </feature>
 
-    <feature name="video-app" version="${project.version}"
-             description="The Video Application provides support for ingesting and searching for MPEG-TS products.::Video">
-        <feature>catalog-app</feature>
+
+    <feature name="video-core" version="${project.version}"
+             description="Provides core requirements for ingesting and searching for MPEG-TS products. Excludes UI components.">
+        <feature>catalog-core</feature>
         <feature>catalog-core-validator</feature>
         <feature>catalog-core-definitionparser</feature>
         <feature>security-classification-service</feature>
@@ -54,7 +52,13 @@
         <bundle>mvn:org.codice.alliance/klv/${project.version}</bundle>
         <bundle>mvn:org.codice.alliance.video/video-security/${project.version}</bundle>
         <feature>mpegts-stream</feature>
-        <feature>mpegts-input-transformer</feature>
     </feature>
 
+    <feature name="video-app" version="${project.version}"
+             description="The Video Application provides support for ingesting and searching for MPEG-TS products.::Video">
+        <feature>catalog-app</feature>
+        <feature>video-core</feature>
+        <!-- mpegts-stream admin UI plugin -->
+        <bundle>mvn:org.codice.alliance.video/video-admin-plugin/${project.version}</bundle>
+    </feature>
 </features>

--- a/catalog/video/video-app/src/main/resources/features.xml
+++ b/catalog/video/video-app/src/main/resources/features.xml
@@ -16,6 +16,8 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
 
+    <repository>mvn:org.codice.alliance.security/security-app/${project.version}/xml/features</repository>
+
     <feature name="mpegts-stream" version="${project.version}"
              description="Consume UDP MPEG-TS Stream">
         <feature>security-classification-service</feature>


### PR DESCRIPTION
#### What does this PR do?
Creates a feature that will start just the core bundles needed for
streaming and ingesting video, excluding any UI components.

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)
@jrnorth 
@aj-brooks 

#### Choose 2 committers to review/merge the PR.
(please choose ONLY two committers from below, delete the rest)
@clockard
@pklinef

#### How should this be tested?
Start with a DDF-catalog distribution, install the video-core feature, create a video stream by placing a config file in `/etc` (e.g. 
[video1.config.txt](https://github.com/codice/alliance/files/5518320/org.codice.alliance.video.stream.mpegts.UdpStreamMonitor-video1.config.txt), minus the `.txt` extension), ingest a video using something like TSDuck. Contact me if you're not familiar with TSDuck.
[The Itests](https://github.com/codice/alliance/blob/master/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/VideoTest.java) will confirm the video-app feature is still in working order. 

#### Any background context you want to provide?
This change was made to help the product team create a ddf-distribution, with video streaming capability, that is as small as possible. 