### PR TITLE
Remove mvn install from sonar stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -146,7 +146,7 @@ pipeline {
             }
             steps {
                 withMaven(maven: 'maven-latest', jdk: 'jdk11', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}') {
-                            sh 'mvn -q -B -Dcheckstyle.skip=true org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN  -Dsonar.organization=codice -Dsonar.projectKey=org.codice:alliance -Dsonar.exclusions=${COVERAGE_EXCLUSIONS} -pl !$DOCS,!$ITESTS $DISABLE_DOWNLOAD_PROGRESS_OPTS'
+                            sh 'mvn -q -B -Dcheckstyle.skip=true org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN  -Dsonar.organization=codice -Dsonar.projectKey=org.codice:alliance -Dsonar.exclusions=${COVERAGE_EXCLUSIONS} -pl !$DOCS,!$ITESTS $DISABLE_DOWNLOAD_PROGRESS_OPTS'
                 }
             }
         }


### PR DESCRIPTION
#### What does this PR do?
This removes the `mvn install` command from the sonar stage. This currently will fail now that the sonar stage requires jdk 11 to be accepted. 
#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)
@codice/build 
@codice/continuous-integration 
@TonyMorrison 
@LinkMJB 

#### Choose 2 committers to review/merge the PR.
(please choose ONLY two committers from below, delete the rest)
@Lambeaux 
@mojogitoverhere 

#### How should this be tested?
Jenkins build

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/codice/alliance/882)
<!-- Reviewable:end -->
