### PR TITLE
Skip distribution/alliance module sonar

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -149,7 +149,7 @@ pipeline {
             }
             steps {
                 withMaven(maven: 'maven-latest', jdk: 'jdk11', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}') {
-                            sh 'mvn -q -B -Dcheckstyle.skip=true org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN  -Dsonar.organization=codice -Dsonar.projectKey=org.codice:alliance -Dsonar.exclusions=${COVERAGE_EXCLUSIONS} -pl !distribution/alliance !$DOCS,!$ITESTS $DISABLE_DOWNLOAD_PROGRESS_OPTS'
+                            sh 'mvn -q -B -Dcheckstyle.skip=true org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN  -Dsonar.organization=codice -Dsonar.projectKey=org.codice:alliance -Dsonar.exclusions=${COVERAGE_EXCLUSIONS} -pl !distribution/alliance,!$DOCS,!$ITESTS $DISABLE_DOWNLOAD_PROGRESS_OPTS'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -134,7 +134,10 @@ pipeline {
                 }
             }
         }
-
+        /*
+          SonarCloud requires JDK 11 for sonar analysis. ACDebugger required Java 8 currently and so we need to skip the distribution/alliance module
+          to prevent the build failure when running the sonar analysis. This is fine since Sonar analysis primarily looks at Java code.
+        */
         stage ('SonarCloud') {
             when {
                 // Currently Sonar is not run for pull requests
@@ -146,7 +149,7 @@ pipeline {
             }
             steps {
                 withMaven(maven: 'maven-latest', jdk: 'jdk11', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}') {
-                            sh 'mvn -q -B -Dcheckstyle.skip=true org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN  -Dsonar.organization=codice -Dsonar.projectKey=org.codice:alliance -Dsonar.exclusions=${COVERAGE_EXCLUSIONS} -pl !$DOCS,!$ITESTS $DISABLE_DOWNLOAD_PROGRESS_OPTS'
+                            sh 'mvn -q -B -Dcheckstyle.skip=true org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN  -Dsonar.organization=codice -Dsonar.projectKey=org.codice:alliance -Dsonar.exclusions=${COVERAGE_EXCLUSIONS} -pl !distribution/alliance !$DOCS,!$ITESTS $DISABLE_DOWNLOAD_PROGRESS_OPTS'
                 }
             }
         }


### PR DESCRIPTION
#### What does this PR do?
Skips the distribution/alliance module when running the Sonar analysis. There is still a dependency on ACDebugger, which requires JDK8 (specifically tools.jar which has been removed in Java 9). Even running the sonar command on this module will cause a build failure as tools.jar will not be resolved. The workaround here is to skip the module on this stage since sonar primarily does Java analysis which the distribution/alliance module does not include.

#### Who is reviewing it? 
(please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)
@TonyMorrison 
@codice/build 
@codice/continuous-integration 
@stustison 
@LinkMJB 

#### Choose 2 committers to review/merge the PR.
(please choose ONLY two committers from below, delete the rest)
@Lambeaux 
@mojogitoverhere 

#### How should this be tested?
Build. I tested this with a replay on the master build and it was successful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/codice/alliance/883)
<!-- Reviewable:end -->
