### PR TITLE
BR-154 Add Docker Credentials to prevent exceeding the Docker call limits

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,17 +71,17 @@ pipeline {
                 withMaven(maven: 'maven-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}', options: [artifactsPublisher(disabled: true), dependenciesFingerprintPublisher(disabled: true, includeScopeCompile: false, includeScopeProvided: false, includeScopeRuntime: false, includeSnapshotVersions: false)]) {
                     sh '''
                         unset JAVA_TOOL_OPTIONS
-                        mvn install -B -DskipStatic=true -DskipTests=true $DISABLE_DOWNLOAD_PROGRESS_OPTS
+                        mvn install -B -DskipStatic=true -DskipTests=true $DISABLE_DOWNLOAD_PROGRESS_OPTS -Ddocker.username=$DOCKERHUB_CREDS_USR -Ddocker.password=$DOCKERHUB_CREDS_PSW
                     '''
                     
                     sh '''
                         unset JAVA_TOOL_OPTIONS
-                        mvn clean install -B -pl !$ITESTS -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/$CHANGE_TARGET $DISABLE_DOWNLOAD_PROGRESS_OPTS
+                        mvn clean install -B -pl !$ITESTS -Dgib.enabled=true -Dgib.referenceBranch=/refs/remotes/origin/$CHANGE_TARGET $DISABLE_DOWNLOAD_PROGRESS_OPTS -Ddocker.username=$DOCKERHUB_CREDS_USR -Ddocker.password=$DOCKERHUB_CREDS_PSW
                     '''
                     
                     sh '''
                         unset JAVA_TOOL_OPTIONS
-                        mvn install -B -pl $ITESTS -nsu $DISABLE_DOWNLOAD_PROGRESS_OPTS
+                        mvn install -B -pl $ITESTS -nsu $DISABLE_DOWNLOAD_PROGRESS_OPTS -Ddocker.username=$DOCKERHUB_CREDS_USR -Ddocker.password=$DOCKERHUB_CREDS_PSW
                     '''
                 }
             }
@@ -169,7 +169,7 @@ pipeline {
             }
             steps {
                 withMaven(maven: 'maven-latest', jdk: 'jdk8-latest', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LINUX_MVN_RANDOM}') {
-                    sh 'mvn deploy -B -DskipStatic=true -DskipTests=true -DretryFailedDeploymentCount=10 $DISABLE_DOWNLOAD_PROGRESS_OPTS -Ddocker.username=$DOCKERHUB_CREDS_USR -Ddocker.password=$DOCKERHUB_CREDS_PSW'
+                    sh 'mvn deploy -B -DskipStatic=true -DskipTests=true -DretryFailedDeploymentCount=10 $DISABLE_DOWNLOAD_PROGRESS_OPTS'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,6 @@ pipeline {
     environment {
         DOCS = 'distribution/docs'
         ITESTS = 'distribution/test/itests/test-itests-alliance'
-        DOCKER = 'distribution/docker/alliance'
         LARGE_MVN_OPTS = '-Xmx8192M -Xss128M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC '
         DISABLE_DOWNLOAD_PROGRESS_OPTS = '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn '
         LINUX_MVN_RANDOM = '-Djava.security.egd=file:/dev/./urandom'

--- a/distribution/docker/alliance/pom.xml
+++ b/distribution/docker/alliance/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice.alliance.distribution</groupId>
         <artifactId>docker</artifactId>
-        <version>1.15.0-SNAPSHOT</version>
+        <version>1.16.0-SNAPSHOT</version>
     </parent>
     <artifactId>alliance</artifactId>
     <groupId>org.codice.alliance.distribution.docker</groupId>

--- a/distribution/docker/pom.xml
+++ b/distribution/docker/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.codice.alliance</groupId>
         <artifactId>distribution</artifactId>
-        <version>1.15.0-SNAPSHOT</version>
+        <version>1.16.0-SNAPSHOT</version>
     </parent>
     <artifactId>docker</artifactId>
     <groupId>org.codice.alliance.distribution</groupId>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -38,7 +38,7 @@
         <module>install-profiles</module>
         <module>docs</module>
         <module>alliance</module>
-        <!--module>docker</module-->
+        <module>docker</module>
         <module>test</module>
     </modules>
 


### PR DESCRIPTION
#### What does this PR do?
Added Docker credentials to maven steps that do anonymous calls to Docker Hub to prevent exceeding the Docker call limits.
Docker recently instituted new limits for anonymous pulls from the Docker Hub registry, and by using the bot with the credential to access, we effectively double the number of calls we can make vs the anonymous calls

#### Who is reviewing it? 
@jlcsmith 
@LinkMJB 

#### Choose 2 committers to review/merge the PR.
(please choose ONLY two committers from below, delete the rest)

@jlcsmith
@shaundmorris

#### How should this be tested?
#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-xxx](https://codice.atlassian.net/browse/CAL-xxx)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
