### PR TITLE
Skipping more modules on sonar analysis

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -154,7 +154,7 @@ pipeline {
             }
             steps {
                 withMaven(maven: 'maven-latest', jdk: 'jdk11', globalMavenSettingsConfig: 'default-global-settings', mavenSettingsConfig: 'codice-maven-settings', mavenOpts: '${LARGE_MVN_OPTS} ${LINUX_MVN_RANDOM}') {
-                            sh 'mvn -q -B -Dcheckstyle.skip=true org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN  -Dsonar.organization=codice -Dsonar.projectKey=org.codice:alliance -Dsonar.exclusions=${COVERAGE_EXCLUSIONS} -pl !distribution/alliance,!$DOCS,!$ITESTS $DISABLE_DOWNLOAD_PROGRESS_OPTS'
+                            sh 'mvn -P !itests -q -B -Dcheckstyle.skip=true org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN  -Dsonar.organization=codice -Dsonar.projectKey=org.codice:alliance -Dsonar.exclusions=${COVERAGE_EXCLUSIONS} -pl !distribution/alliance,!$DOCS $DISABLE_DOWNLOAD_PROGRESS_OPTS'
                 }
             }
         }


### PR DESCRIPTION
#### What does this PR do?
Skips more modules on Sonar Analysis. For some reason there are JDK failures on these modules. I'm also open to more elegant solutions but this is currently failing on the build. This change passed on this build: https://jenkins.phx.connexta.com/service/jenkins/job/Alliance/job/master/809/

#### Who is reviewing it? 
@TonyMorrison 
@LinkMJB 
@SmithJosh 
@codice/continuous-integration 
@codice/build

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/codice/alliance/886)
<!-- Reviewable:end -->
