### PR TITLE
Only run Sonar analysis on master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -139,8 +139,8 @@ pipeline {
 
         stage ('SonarCloud') {
             when {
-                // Currently Sonar is not run for pull requests
-                expression { env.CHANGE_ID == null }
+                // Sonar Cloud only supports a single branch in the free/OSS tier
+                expression { env.BRANCH_NAME == 'master'}
             }
             environment {
                 SONARQUBE_GITHUB_TOKEN = credentials('SonarQubeGithubToken')


### PR DESCRIPTION
#### What does this PR do?
Stops running Sonar Analysis on the 1.6.x branch since we can only use one branch at a time. Currently this stage is failing since Sonar requires JDK 11 analysis.
#### Who is reviewing it? 
@TonyMorrison 
@mojogitoverhere 
@Lambeaux 
@andrewzimmer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/codice/alliance/887)
<!-- Reviewable:end -->
