### PR TITLE
[1.6.x] Support concealed FGI

### DIFF
--- a/catalog/nsili/catalog-nsili-endpoint/pom.xml
+++ b/catalog/nsili/catalog-nsili-endpoint/pom.xml
@@ -172,6 +172,11 @@
             <artifactId>log4j-api</artifactId>
             <version>${log4j.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/catalog/security/banner-marking/src/main/java/org/codice/alliance/security/banner/marking/BannerMarkings.java
+++ b/catalog/security/banner-marking/src/main/java/org/codice/alliance/security/banner/marking/BannerMarkings.java
@@ -50,6 +50,8 @@ public class BannerMarkings implements Serializable {
 
   protected List<String> jointAuthorities;
 
+  protected boolean hasConcealedFgi;
+
   protected List<String> usFgiCountryCodes;
 
   protected List<SciControl> sciControls;
@@ -192,6 +194,10 @@ public class BannerMarkings implements Serializable {
 
   public List<String> getJointAuthorities() {
     return jointAuthorities;
+  }
+
+  public boolean hasConcealedFgi() {
+    return hasConcealedFgi;
   }
 
   public List<String> getUsFgiCountryCodes() {
@@ -341,13 +347,13 @@ public class BannerMarkings implements Serializable {
     String suffix = null;
     if (segment.startsWith("FGI")) {
       suffix = segment.substring("FGI".length()).trim();
-
     } else if (segment.startsWith("FOREIGN GOVERNMENT INFORMATION")) {
       suffix = segment.substring("FOREIGN GOVERNMENT INFORMATION".length()).trim();
     }
 
     if (suffix == null || suffix.isEmpty()) {
       usFgiCountryCodes = ImmutableList.of();
+      hasConcealedFgi = true;
     } else {
       usFgiCountryCodes =
           ImmutableList.copyOf(SPACE_PATTERN.splitAsStream(suffix).collect(Collectors.toList()));

--- a/catalog/security/banner-marking/src/test/groovy/org/codice/alliance/security/banner/marking/BannerMarkingsSpec.groovy
+++ b/catalog/security/banner-marking/src/test/groovy/org/codice/alliance/security/banner/marking/BannerMarkingsSpec.groovy
@@ -220,12 +220,13 @@ class BannerMarkingsSpec extends Specification {
         bannerMarkings.usFgiCountryCodes != null
         bannerMarkings.usFgiCountryCodes.size() == countryCodes.size()
         bannerMarkings.usFgiCountryCodes.containsAll(countryCodes)
+        bannerMarkings.hasConcealedFgi() == hasConcealedFgi
 
         where:
-        markings                       | countryCodes
-        'TOP SECRET//FGI DEU GBR'      | ['DEU', 'GBR']
-        'TOP SECRET//FGI DEU GBR NATO' | ['DEU', 'GBR', 'NATO']
-        'SECRET//TK//FGI//RELIDO'      | []
+        markings                       | countryCodes           | hasConcealedFgi
+        'TOP SECRET//FGI DEU GBR'      | ['DEU', 'GBR']         | false
+        'TOP SECRET//FGI DEU GBR NATO' | ['DEU', 'GBR', 'NATO'] | false
+        'SECRET//TK//FGI//RELIDO'      | []                     | true
     }
 
     def 'test dissemination markings'() {

--- a/catalog/security/banner-marking/src/test/groovy/org/codice/alliance/security/banner/marking/PortionMarkingsSpec.groovy
+++ b/catalog/security/banner-marking/src/test/groovy/org/codice/alliance/security/banner/marking/PortionMarkingsSpec.groovy
@@ -238,12 +238,13 @@ class PortionMarkingsSpec extends Specification {
         portionMarkings.usFgiCountryCodes != null
         portionMarkings.usFgiCountryCodes.size() == countryCodes.size()
         portionMarkings.usFgiCountryCodes.containsAll(countryCodes)
+        portionMarkings.hasConcealedFgi() == hasConcealedFgi
 
         where:
-        markings                       | countryCodes
-        'TS//FGI DEU GBR'              | ['DEU', 'GBR']
-        'TS//FGI DEU GBR NATO'         | ['DEU', 'GBR', 'NATO']
-        'S//TK//FGI//RELIDO'           | []
+        markings                       | countryCodes           | hasConcealedFgi
+        'TS//FGI DEU GBR'              | ['DEU', 'GBR']         | false
+        'TS//FGI DEU GBR NATO'         | ['DEU', 'GBR', 'NATO'] | false
+        'S//TK//FGI//RELIDO'           | []                     | true
     }
 
     def 'test dissemination markings'() {


### PR DESCRIPTION
#### What does this PR do?
Adds a field to `BannerMarkings` to indicate whether the banner marking contains concealed FGI.
#### Who is reviewing it? 
@kcwire
@millerw8
@shaundmorris 
#### How should this be tested?
Check out the unit tests.
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
