### PR TITLE
added import of ddf-ui documentation to docs module

### DIFF
--- a/distribution/docs/pom.xml
+++ b/distribution/docs/pom.xml
@@ -47,6 +47,9 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <properties>
+        <ddf-ui.version>5.0.8-SNAPSHOT</ddf-ui.version>
+    </properties>
     <profiles>
         <profile>
             <id>release</id>
@@ -162,6 +165,26 @@
                                     <type>zip</type>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/pre-build-${project.version}/upstream-templates-${project.version}</outputDirectory>
+                                    <includes>**</includes>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.codice.ddf.search</groupId>
+                                    <version>${ddf-ui.version}</version>
+                                    <artifactId>docs</artifactId>
+                                    <classifier>adoc-files</classifier>
+                                    <type>zip</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}/pre-build-${project.version}/upstream-adoc-${project.version}/_ddf-ui</outputDirectory>
+                                    <includes>**</includes>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.codice.ddf.search</groupId>
+                                    <version>${ddf-ui.version}</version>
+                                    <artifactId>docs</artifactId>
+                                    <classifier>images</classifier>
+                                    <type>zip</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}/images</outputDirectory>
                                     <includes>**</includes>
                                 </artifactItem>
                             </artifactItems>
@@ -313,6 +336,13 @@
                                 </resource>
                                 <resource>
                                     <directory>${project.build.directory}/images/docs-${ddf.version}</directory>
+                                    <filtering>false</filtering>
+                                    <includes>
+                                        <include>*</include>
+                                    </includes>
+                                </resource>
+                                <resource>
+                                    <directory>${project.build.directory}/images/docs-${ddf-ui.version}</directory>
                                     <filtering>false</filtering>
                                     <includes>
                                         <include>*</include>

--- a/distribution/docs/src/main/resources/content/config.adoc
+++ b/distribution/docs/src/main/resources/content/config.adoc
@@ -19,6 +19,7 @@ Version: ${project.version}. Copyright (c) Codice Foundation
 :adoc-include-cal: ${project.build.directory}/doc-contents/_contents
 :download-url: https://github.com/codice/alliance/releases
 :release-notes-url: https://codice.atlassian.net/wiki/spaces/CAL/pages/71276940/Release+Notes
+:catalog-ui: Intrigue
 :last-update-label: Copyright (c) Codice Foundation. +
 This work is licensed under a Creative Commons Attribution 4.0 International License (http://creativecommons.org/licenses/by/4.0). +
 This page last updated:


### PR DESCRIPTION
#### What does this PR do?

imports Intrigue documentation content from ddf-ui repository. 

#### Who is reviewing it? 


#### Choose 2 committers to review/merge the PR.

@jaymcnallie
@shaundmorris

#### How should this be ### tested?
content is included correctly in html and pdf versions

#### Screenshots (if appropriate)

[using.pdf](https://github.com/codice/alliance/files/7010067/using.pdf)

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
