### PR TITLE
added import of ddf-ui documentation to docs module

### DIFF
--- a/distribution/docs/pom.xml
+++ b/distribution/docs/pom.xml
@@ -48,6 +48,7 @@
     <properties>
         <timestamp>${maven.build.timestamp}</timestamp>
         <maven.build.timestamp.format>MM-dd-yyyy</maven.build.timestamp.format>
+        <ddf-ui.version>5.0.8</ddf-ui.version>
     </properties>
     <profiles>
         <profile>
@@ -164,6 +165,26 @@
                                     <type>zip</type>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/pre-build-${project.version}/upstream-templates-${project.version}</outputDirectory>
+                                    <includes>**</includes>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.codice.ddf.search</groupId>
+                                    <version>${ddf-ui.version}</version>
+                                    <artifactId>docs</artifactId>
+                                    <classifier>adoc-files</classifier>
+                                    <type>zip</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}/pre-build-${project.version}/upstream-adoc-${project.version}/_ddf-ui</outputDirectory>
+                                    <includes>**</includes>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.codice.ddf.search</groupId>
+                                    <version>${ddf-ui.version}</version>
+                                    <artifactId>docs</artifactId>
+                                    <classifier>images</classifier>
+                                    <type>zip</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}/images</outputDirectory>
                                     <includes>**</includes>
                                 </artifactItem>
                             </artifactItems>
@@ -315,6 +336,13 @@
                                 </resource>
                                 <resource>
                                     <directory>${project.build.directory}/images/docs-${ddf.version}</directory>
+                                    <filtering>false</filtering>
+                                    <includes>
+                                        <include>*</include>
+                                    </includes>
+                                </resource>
+                                <resource>
+                                    <directory>${project.build.directory}/images/docs-${ddf-ui.version}</directory>
                                     <filtering>false</filtering>
                                     <includes>
                                         <include>*</include>

--- a/distribution/docs/src/main/resources/content/config.adoc
+++ b/distribution/docs/src/main/resources/content/config.adoc
@@ -20,6 +20,7 @@ ${timestamp}
 :adoc-include-cal: ${project.build.directory}/doc-contents/_contents
 :download-url: https://github.com/codice/alliance/releases
 :release-notes-url: https://codice.atlassian.net/wiki/spaces/CAL/pages/71276940/Release+Notes
+:catalog-ui: Intrigue
 :last-update-label: Copyright (c) Codice Foundation. +
 This work is licensed under a Creative Commons Attribution 4.0 International License (http://creativecommons.org/licenses/by/4.0). +
 This page last updated:


### PR DESCRIPTION
#### What does this PR do?

adds content for ddf-ui repo into the 1.15.x documentation module.

#### How should this be tested?

verify content is included in html and pdf versions of documentation.

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
