### PR TITLE
edits to docs to remove latin abbreviations (#916)

### DIFF
--- a/distribution/docs/src/main/resources/content/_metadataReference/isr-attributes-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataReference/isr-attributes-table.adoc
@@ -300,7 +300,7 @@ ALPHA4='C'
 |
 
 |[[_isr.tdl-track-number]]isr.tdl-track-number
-|Link 16 J Series track number for the track found in the product. The track number shall be in the decoded 5-character format (e.g. EK627).
+|Link 16 J Series track number for the track found in the product. The track number shall be in the decoded 5-character format (for example, `EK627`).
 |String
 |<= 10 characters
 |

--- a/distribution/docs/src/main/resources/content/_reference/_tables/UdpStreamMonitor.adoc
+++ b/distribution/docs/src/main/resources/content/_reference/_tables/UdpStreamMonitor.adoc
@@ -26,7 +26,7 @@
 |Network Address
 |monitoredAddress
 |String
-|Specifies the network address (e.g. udp://localhost:50000) to be monitored. The address must be resolvable.
+|Specifies the network address (such as udp://localhost:50000) to be monitored. The address must be resolvable.
 |udp://127.0.0.1:50000
 |true
 


### PR DESCRIPTION
**FORWARD PORT to MASTER of #916**

#### What does this PR do?

Simplifies docs content to remove latin abbreviations to match Google Developer documentation style guide: https://developers.google.com/style/abbreviations?hl=en#dont-use

#### Who is reviewing it? 

@jaymcnallie 
@shaundmorris 
@sgalla 
@rececoffin 

#### Relevant component teams: 

@codice/docs 

#### How should this be tested?
review content

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
