### PR TITLE
removed future tense from docs content #921

### DIFF
--- a/distribution/docs/src/main/resources/content/_architecture/_plugins/default-attribute-plugin.adoc
+++ b/distribution/docs/src/main/resources/content/_architecture/_plugins/default-attribute-plugin.adoc
@@ -8,7 +8,7 @@
 The ((Default Security Attribute Plugin)) maps system high user attribute names to metacard attribute names.
 If a metacard has no security policy, the plugin applies standard security attributes according to the mapping.
 
-These metacards will be flagged for administrator review with default markings.
+These metacards are flagged for administrator review with default markings.
 
 * The attributes are not enforced unless a policy is added.
 

--- a/distribution/docs/src/main/resources/content/_managing/_configuring/banner-markings-content-extractor.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_configuring/banner-markings-content-extractor.adoc
@@ -17,9 +17,9 @@ classified documents that include security mark-up in the text.
 The Banner Markings Extractor parses a banner marking and populates the values of security
 attributes on the metacard of the ingested document. The extractor looks at the first non-blank
 line of text in the document and tries to interpret it as a banner marking.
-The interpretation of a banner marking is guided by ((DoD Instruction 5200.01))
-and the ${branding} catalog taxonomy. The marking extractors
-will attempt to get as much information from the banner marking as possible.
+The interpretation of a banner marking is guided by ((DoD Instruction 5200.01))and the ${branding} catalog taxonomy.
+The marking extractors attempt to get as much information from the banner marking as possible.
+
 The attributes they attempt to extract are:
 
 * Classification
@@ -40,7 +40,7 @@ The attributes they attempt to extract are:
 ====
 If other transformers or extractors have already assigned values to the metacard's
 security attributes, and the markings extracted by Banner Markings Extractor
-do not match them, the ingest will fail. This is done to prevent a data spill because
+do not match them, the ingest fails. This is done to prevent a data spill because
 the correct markings cannot be determined by ${branding}.
 ====
 
@@ -101,7 +101,7 @@ the security policies would not work as expected.
 [WARNING]
 ====
 The Banner Markings Extractor transfers values from a banner marking to a
-metacards. This does NOT imply that the ${branding} will make correct policy decisions based
+metacard. This does NOT imply that the ${branding} makes correct policy decisions based
 on those values. Changes to the <<{managing-prefix}configuring_catalog_filtering_policies,XACML policy file>> or
  <<{architecture-prefix}security_pdp,PDP configuration>> are typically necessary and
  are based on organizational needs.

--- a/distribution/docs/src/main/resources/content/_managing/_installing/cal-setup-types.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/_installing/cal-setup-types.adoc
@@ -9,7 +9,7 @@
 ****
 ${branding} is pre-configured with several installation profiles.
 
-* Standard Installation: This will install DDF with Alliance applications:
+* Standard Installation: This installs DDF with Alliance applications:
 ** <<{reference-prefix}admin_application_reference,${ddf-admin}>>
 ** <<{reference-prefix}catalog_application_reference,${ddf-catalog}>>
 ** <<{reference-prefix}platform_application_reference,${ddf-platform}>>
@@ -20,5 +20,5 @@ ${branding} is pre-configured with several installation profiles.
 ** <<{reference-prefix}imaging_application_reference,${alliance-imaging}>>
 ** <<{reference-prefix}ic_security_application_reference,${alliance-security}>>
 
-* Experimental: This will install experimental applications along with the standard Alliance applications.
+* Experimental: This installs experimental applications along with the standard Alliance applications.
 ****

--- a/distribution/docs/src/main/resources/content/_managing/attributes-added-by-pre-ingest-plugins.adoc
+++ b/distribution/docs/src/main/resources/content/_managing/attributes-added-by-pre-ingest-plugins.adoc
@@ -9,4 +9,4 @@
 "((System high user attributes))" refers to the attributes on the ${branding}'s https://en.wikipedia.org/wiki/Second-level_domain[Second-Level Domain] {external-link} user, who is defined in the `etc/users.attributes` file.
 For example, if `https://localhost:8993` is the ${branding}'s domain name, then the `localhost` user has the system high user attributes.
 See <<{architecture-prefix}configuring_the_default_security_attribute_plugin,Configuring the Default Security Attribute Plugin>> for configuration details.
-Note that if security markings have already been applied to the metacard, the values will not be overridden by this plugin.
+Note that if security markings have already been applied to the metacard, the values are not overridden by this plugin.

--- a/distribution/docs/src/main/resources/content/_metadataReference/isr-attributes-table.adoc
+++ b/distribution/docs/src/main/resources/content/_metadataReference/isr-attributes-table.adoc
@@ -60,7 +60,7 @@
 |[[_isr.niirs]]isr.niirs
 |The quality or detail level of an image. (National Imagery Interpretability Rating Scale)
 |Float
-|\#.# where # is a value between 0-9
+|\#.# where # is a value 0-9
 |
 
 |[[_isr.nato-reporting-code]]isr.nato-reporting-code

--- a/distribution/docs/src/main/resources/content/_reference/_tables/MpegTsInputTransformer.adoc
+++ b/distribution/docs/src/main/resources/content/_reference/_tables/MpegTsInputTransformer.adoc
@@ -26,7 +26,7 @@
 |Distance Tolerance
 |distanceTolerance
 |Double
-|Distance tolerance used to simplify WKT data. All vertices in the simplified geometry will be within this distance of the original geometry. The tolerance value must be non-negative.
+|Distance tolerance used to simplify WKT data. All vertices in the simplified geometry are within this distance of the original geometry. The tolerance value must be non-negative.
 |0.0001
 |false
 

--- a/distribution/docs/src/main/resources/content/_reference/_tables/NITF_Post_Process_Plugin.adoc
+++ b/distribution/docs/src/main/resources/content/_reference/_tables/NITF_Post_Process_Plugin.adoc
@@ -19,7 +19,7 @@
 |Overview image maximum side length (pixels)
 |maxSideLength
 |Integer
-|Maximum length of longest side of NITF overview image in pixels. The input transformer will resize the image as needed so that the overview retains the same aspect ratio as the original.
+|Maximum length of longest side of NITF overview image in pixels. The input transformer resizes the image as needed so that the overview retains the same aspect ratio as the original.
 |1024
 |true
 

--- a/distribution/docs/src/main/resources/content/_reference/_tables/NITF_Render_Plugin.adoc
+++ b/distribution/docs/src/main/resources/content/_reference/_tables/NITF_Render_Plugin.adoc
@@ -19,7 +19,7 @@
 |Overview image maximum side length (pixels)
 |maxSideLength
 |Integer
-|Maximum length of longest side of NITF overview image in pixels. The input transformer will calculate the size of the shorter side so that the overview will have the same aspect ratio as the original.
+|Maximum length of longest side of NITF overview image in pixels. The input transformer calculates the size of the shorter side so that the overview has the same aspect ratio as the original.
 |1024
 |true
 


### PR DESCRIPTION
**PORT to MASTER of #921**

#### What does this PR do?

edits to documentation to standardize present tense usage over future tense. 
This aligns with the Google Developer Documentation Style Guide guidance: https://developers.google.com/style/tense?hl=en

#### Who is reviewing it? 
@shaundmorris 
@jaymcnallie 
@rececoffin 
@sgalla 
@ahoffer 

#### Select relevant component teams: 
@codice/docs 

#### How should this be tested?
review content.

#### Checklist:
- [x] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

#### Notes on Review Process
Please see [Notes on Review Process](https://codice.atlassian.net/wiki/spaces/DDF/pages/71946981/Pull+Request+Guidelines) for further guidance on requirements for merging and abbreviated reviews. 

#### Review Comment Legend:
- ✏️ (Pencil) This comment is a nitpick or style suggestion, no action required for approval. This comment should provide a suggestion either as an in line code snippet or a gist. 
- ❓ (Question Mark) This comment is to gain a clearer understanding of design or code choices, clarification is required but action may not be necessary for approval.
- ❗ (Exclamation Mark) This comment is critical and requires clarification or action before approval.
