### PR TITLE
Set the fabric io version to 0.40.3 to fix build issue

### DIFF
--- a/distribution/docker/alliance/pom.xml
+++ b/distribution/docker/alliance/pom.xml
@@ -57,6 +57,7 @@
                     <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
+                        <version>0.40.3</version>
                         <configuration>
                             <images>
                                 <image>


### PR DESCRIPTION
#### What does this PR do?
Fixes issue with docker build by specifying the fabric version

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
