### PR TITLE
Add missing nitf metacard types

### DIFF
--- a/catalog/imaging/imaging-transformer-nitf/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/imaging/imaging-transformer-nitf/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -17,9 +17,28 @@
            xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0
            http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
 
+    <bean id="imageMetacardType"
+          class="org.codice.alliance.transformer.nitf.image.ImageMetacardType">
+    </bean>
+
+    <bean id="gmtiMetacardType" class="org.codice.alliance.transformer.nitf.gmti.GmtiMetacardType">
+    </bean>
+
     <bean id="transformer"
           class="org.codice.alliance.transformer.nitf.NitfTransformer">
     </bean>
+
+    <service ref="imageMetacardType" interface="ddf.catalog.data.MetacardType">
+        <service-properties>
+            <entry key="name" value="isr.image"/>
+        </service-properties>
+    </service>
+
+    <service ref="gmtiMetacardType" interface="ddf.catalog.data.MetacardType">
+        <service-properties>
+            <entry key="name" value="isr.gmti"/>
+        </service-properties>
+    </service>
 
     <service ref="transformer" interface="ddf.catalog.transform.InputTransformer">
         <service-properties>


### PR DESCRIPTION
#### What does this PR do?
Adds back in the nitf metacard types that were removed when the nitf transformer was refactored. 
#### Who is reviewing it? 
@lavoywj 
#### Choose 2 committers to review/merge the PR.

@vinamartin

