### PR TITLE
Upgrades DDF to 2.29.17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.idea
 *.checkstyle
 *.DS_Store
+*.vscode
 node_modules/
 node/
 atlassian-ide-plugin.xml

--- a/catalog/imaging/imaging-actionprovider-chip/pom.xml
+++ b/catalog/imaging/imaging-actionprovider-chip/pom.xml
@@ -173,7 +173,10 @@
                 <configuration>
                     <instructions>
                         <Web-ContextPath>/chipping</Web-ContextPath>
-                        <_wab>src/main/webapp,${project.build.directory}/webapp,${project.build.directory}/META-INF/resources/webjars</_wab>
+                        <!-- DDF-2.29.15+ upgrade: This was previously a wab (web bundle),
+                        which has been naïvely converted to a war, this makes the UI start and
+                        come up properly but lacks the correct styling. -->
+                        <_war>src/main/webapp,${project.build.directory}/webapp,${project.build.directory}/META-INF/resources/webjars</_war>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Embed-Dependency>
                             commons-lang3,

--- a/distribution/alliance/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
+++ b/distribution/alliance/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
@@ -53,10 +53,9 @@ featuresRepositories= \
 #
 # TODO DDF-3072 Investigate improvements of this configuration.
 featuresBoot= \
- (ddf-boot-features, \
- ui, \
- admin-modules-installer, \
- alliance-branding)
+ (ddf-boot-features ), ( ui, \
+    admin-modules-installer, \
+    alliance-branding)
 
 #
 # Defines if the boot features are started in asynchronous mode (in a dedicated thread)

--- a/distribution/alliance/src/main/filtered-resources/etc/org.apache.karaf.features.xml
+++ b/distribution/alliance/src/main/filtered-resources/etc/org.apache.karaf.features.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<!--
+    This file was manually created for right now.
+-->
+<featuresProcessing xmlns="http://karaf.apache.org/xmlns/features-processing/v1.0.0"
+                    xmlns:f="http://karaf.apache.org/xmlns/features/v1.5.0">
+
+    <!-- A list of blacklisted features XML repository URIs - they can't be added later -->
+    <blacklistedRepositories/>
+
+    <!-- A list of blacklisted feature identifiers that can't be installed in Karaf and are not part of the distribution -->
+    <blacklistedFeatures>
+        <feature>pax-web-jetty-http2</feature>
+        <feature>decanter-appender-cassandra</feature>
+        <feature>decanter-appender-cassandra-core</feature>
+        <feature>cxf-http-undertow</feature>
+        <feature>cxf-rs-description-openapi-v3</feature>
+    </blacklistedFeatures>
+
+    <!-- A list of blacklisted bundle URIs that are not installed even if they are part of some features -->
+    <blacklistedBundles>
+        <bundle>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.saaj-api-1.3</bundle>
+        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xalan/2.7.3_1</bundle>
+    </blacklistedBundles>
+
+    <!-- A list of repository URIs, feature identifiers and bundle URIs to override "dependency" flag -->
+    <overrideBundleDependency/>
+
+    <!-- A list of bundle URI replacements that allows changing external feature definitions -->
+    <bundleReplacements/>
+
+    <!-- A list of feature replacements that allows changing external feature definitions -->
+    <featureReplacements/>
+
+</featuresProcessing>

--- a/distribution/common/src/main/resources/common-bin.xml
+++ b/distribution/common/src/main/resources/common-bin.xml
@@ -24,6 +24,7 @@
                 <exclude>**/demos/**</exclude>
                 <exclude>bin/**</exclude>
                 <exclude>etc/org.apache.karaf.features.cfg</exclude>
+                <exclude>etc/org.apache.karaf.features.xml</exclude>
                 <exclude>etc/profiles/ha.json</exclude>
                 <!-- Karaf comes with a README in deploy folder which throws warnings in log -->
                 <exclude>deploy/*</exclude>

--- a/distribution/docs/pom.xml
+++ b/distribution/docs/pom.xml
@@ -366,7 +366,7 @@
             <plugin>
                 <groupId>org.jbake</groupId>
                 <artifactId>jbake-maven-plugin</artifactId>
-                <version>0.3.3</version>
+                <version>2.7.0-rc.7</version>
                 <executions>
                     <execution>
                         <phase>generate-resources</phase>
@@ -381,19 +381,9 @@
                 </configuration>
                 <dependencies>
                     <dependency>
-                        <groupId>org.freemarker</groupId>
-                        <artifactId>freemarker</artifactId>
-                        <version>2.3.30</version>
-                    </dependency>
-                    <dependency>
                         <groupId>org.asciidoctor</groupId>
-                        <artifactId>asciidoctor-maven-plugin</artifactId>
-                        <version>${asciidoctor.maven.plugin.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.pegdown</groupId>
-                        <artifactId>pegdown</artifactId>
-                        <version>1.6.0</version>
+                        <artifactId>asciidoctorj</artifactId>
+                        <version>2.5.13</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/distribution/test/itests/test-itests-alliance/pom.xml
+++ b/distribution/test/itests/test-itests-alliance/pom.xml
@@ -141,6 +141,24 @@
             <version>${ddf.version}</version>
             <classifier>assembly</classifier>
             <type>zip</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-handler</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-common</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport-native-epoll</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>ddf.platform.security</groupId>

--- a/distribution/test/itests/test-itests-alliance/pom.xml
+++ b/distribution/test/itests/test-itests-alliance/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
-            <version>3.3.0</version>
+            <version>${restassured.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -331,7 +331,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.5.2</version>
                 <configuration>
                     <includes>
                         <include>**/*Suite.java</include>

--- a/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/ImagingTest.java
+++ b/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/ImagingTest.java
@@ -43,6 +43,7 @@ import org.codice.imaging.nitf.core.image.ImageSegment;
 import org.codice.imaging.nitf.fluent.NitfSegmentsFlow;
 import org.codice.imaging.nitf.fluent.impl.NitfParserInputFlowImpl;
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
@@ -148,6 +149,7 @@ public class ImagingTest extends AbstractAllianceIntegrationTest {
     configureNitfRenderPlugin(120, true, true);
   }
 
+  @Ignore // TODO: Chipping WAB does not start, gives 404
   @Test
   public void testImageNitfChipCreationJpeg() throws Exception {
     String id = ingestNitfFile(TEST_IMAGE_NITF);
@@ -182,6 +184,7 @@ public class ImagingTest extends AbstractAllianceIntegrationTest {
     assertThat(chippedImage.getHeight(), is(height));
   }
 
+  @Ignore // TODO: Chipping WAB does not start, gives 404
   @Test
   public void testImageNitfChipCreationNitf() throws Exception {
     String id = ingestNitfFile(TEST_IMAGE_NITF);

--- a/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/ImagingTest.java
+++ b/distribution/test/itests/test-itests-alliance/src/test/java/org/codice/alliance/test/itests/ImagingTest.java
@@ -43,7 +43,6 @@ import org.codice.imaging.nitf.core.image.ImageSegment;
 import org.codice.imaging.nitf.fluent.NitfSegmentsFlow;
 import org.codice.imaging.nitf.fluent.impl.NitfParserInputFlowImpl;
 import org.junit.After;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
@@ -149,7 +148,6 @@ public class ImagingTest extends AbstractAllianceIntegrationTest {
     configureNitfRenderPlugin(120, true, true);
   }
 
-  @Ignore // TODO: Chipping WAB does not start, gives 404
   @Test
   public void testImageNitfChipCreationJpeg() throws Exception {
     String id = ingestNitfFile(TEST_IMAGE_NITF);
@@ -184,7 +182,6 @@ public class ImagingTest extends AbstractAllianceIntegrationTest {
     assertThat(chippedImage.getHeight(), is(height));
   }
 
-  @Ignore // TODO: Chipping WAB does not start, gives 404
   @Test
   public void testImageNitfChipCreationNitf() throws Exception {
     String id = ingestNitfFile(TEST_IMAGE_NITF);

--- a/distribution/test/itests/test-itests-common/pom.xml
+++ b/distribution/test/itests/test-itests-common/pom.xml
@@ -72,6 +72,7 @@
                         </Bundle-SymbolicName>
                         <Bundle-Name>${project.name}</Bundle-Name>
                         <Import-Package>
+                            io.restassured.*;version=3.3.0,
                             *;resolution:=optional
                         </Import-Package>
                         <Export-Package>

--- a/distribution/test/itests/test-itests-common/src/main/java/org/codice/alliance/test/itests/common/AbstractAllianceIntegrationTest.java
+++ b/distribution/test/itests/test-itests-common/src/main/java/org/codice/alliance/test/itests/common/AbstractAllianceIntegrationTest.java
@@ -16,6 +16,7 @@ package org.codice.alliance.test.itests.common;
 import static io.restassured.RestAssured.when;
 import static org.ops4j.pax.exam.CoreOptions.junitBundles;
 import static org.ops4j.pax.exam.CoreOptions.maven;
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.options;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.features;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
@@ -75,6 +76,8 @@ public abstract class AbstractAllianceIntegrationTest extends AbstractIntegratio
   protected Option[] configureStartScript() {
     // add test dependencies to the test-dependencies-app instead of here
     return options(
+        mavenBundle(
+            "org.apache.servicemix.bundles", "org.apache.servicemix.bundles.xalan", "2.7.2_1"),
         junitBundles(),
         features(
             maven()

--- a/distribution/test/itests/test-itests-dependencies-app/pom.xml
+++ b/distribution/test/itests/test-itests-dependencies-app/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
-            <version>3.3.0</version>
+            <version>${restassured.version}</version>
         </dependency>
         <dependency>
             <groupId>ddf.thirdparty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -84,15 +84,15 @@
         <backbone.modelbinder.version>1.1.0</backbone.modelbinder.version>
         <google-http-client.version>1.22.0</google-http-client.version>
         <html5shiv.version>3.7.2</html5shiv.version>
-        <httpclient.version>4.5.6</httpclient.version>
-        <httpcore.version>4.4.10</httpcore.version>
+        <httpclient.version>4.5.14</httpclient.version>
+        <httpcore.version>4.4.15</httpcore.version>
         <icanhandlebarz.version>0.1</icanhandlebarz.version>
         <iframe-resizer.version>2.6.2</iframe-resizer.version>
         <jquery.version>1.11.0</jquery.version>
         <jquery-ui.version>1.10.4</jquery-ui.version>
         <marionette.version>2.4.5</marionette.version>
         <moment.version>2.20.1</moment.version>
-        <node.version>v10.16.1</node.version>
+        <node.version>v20.18.0</node.version>
         <require-css.version>0.1.10</require-css.version>
         <requirejs-plugins.version>1.0.2</requirejs-plugins.version>
         <underscore.version>1.8.3</underscore.version>
@@ -100,7 +100,7 @@
 
         <!--Maven properties-->
         <error_prone_core.version>2.1.2</error_prone_core.version>
-        <surefire.version>2.22.2</surefire.version>
+        <surefire.version>3.5.2</surefire.version>
 
         <!--Maven plugin properties-->
         <asciidoctor.maven.plugin.version>2.2.1</asciidoctor.maven.plugin.version>
@@ -108,8 +108,8 @@
 
         <!--Test properties-->
         <awaitility.version>3.1.6</awaitility.version>
-        <byte-buddy.version>1.12.19</byte-buddy.version>
-        <groovy.version>3.0.12</groovy.version>
+        <byte-buddy.version>1.14.19</byte-buddy.version>
+        <groovy.version>4.0.23</groovy.version>
         <hamcrest-all.servicemix.version>1.3_1</hamcrest-all.servicemix.version>
         <hamcrest-all.version>1.3</hamcrest-all.version>
         <junit.version>4.13.2</junit.version>
@@ -117,14 +117,16 @@
         <objenesis.version>3.3</objenesis.version>
         <pax.exam.version>4.13.5</pax.exam.version>
         <pax.tinybundles.version>3.0.0</pax.tinybundles.version>
-        <pax.url.version>2.6.12</pax.url.version>
+        <pax.url.version>2.6.14</pax.url.version>
         <powermock.version>2.0.9</powermock.version>
-        <spock.version>2.3-groovy-3.0</spock.version>
+        <restassured.version>5.5.0</restassured.version>
+        <spock.version>2.3-groovy-4.0</spock.version>
         <xmlunit.version>1.4</xmlunit.version>
         <yarn.version>v1.17.3</yarn.version>
+        <restassured.version>5.5.0</restassured.version>
 
         <!--Project properties-->
-        <ddf.version>2.29.1</ddf.version>
+        <ddf.version>2.29.15</ddf.version>
         <ddf-admin-ui.version>2.25.0</ddf-admin-ui.version>
         <ddf.support.version>2.3.16</ddf.support.version>
         <codice-maven.version>0.3</codice-maven.version>
@@ -136,37 +138,37 @@
 
         <!--Documentation properties-->
         <asciidoctor.source.highlighter>coderay</asciidoctor.source.highlighter>
-        <asciidoctor.maven.plugin.version>2.2.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.diagram.version>2.2.1</asciidoctorj.diagram.version>
-        <asciidoctorj.pdf.version>1.6.0</asciidoctorj.pdf.version>
-        <asciidoctorj.version>2.5.2</asciidoctorj.version>
-        <jruby.version>9.2.19.0</jruby.version>
+        <asciidoctor.maven.plugin.version>2.2.6</asciidoctor.maven.plugin.version>
+        <asciidoctorj.diagram.version>2.3.1</asciidoctorj.diagram.version>
+        <asciidoctorj.pdf.version>2.3.19</asciidoctorj.pdf.version>
+        <asciidoctorj.version>2.5.7</asciidoctorj.version>
+        <jruby.version>9.4.12.0</jruby.version>
 
         <camel.version>3.18.8</camel.version>
         <commons-collections4.version>4.1</commons-collections4.version>
         <commons-configuration.version>1.10</commons-configuration.version>
         <commons-exec.version>1.3</commons-exec.version>
-        <commons-io.version>2.11.0</commons-io.version>
+        <commons-io.version>2.15.0</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
-        <commons-lang3.version>3.12.0</commons-lang3.version>
+        <commons-lang3.version>3.17.0</commons-lang3.version>
         <commons-net.version>3.5</commons-net.version>
         <components-font-awesome.version>4.7.0</components-font-awesome.version>
-        <geotools.version>28.3</geotools.version>
-        <guava.version>29.0-jre</guava.version>
+        <geotools.version>28.6</geotools.version>
+        <guava.version>33.4.0-jre</guava.version>
         <jai-imageio-core.version>1.4.0</jai-imageio-core.version>
         <jakarta.mail.version>1.6.6</jakarta.mail.version>
         <javax.inject.version>1</javax.inject.version>
-        <javax.ws.rs.version>2.1</javax.ws.rs.version>
+        <javax.ws.rs.version>2.1.6</javax.ws.rs.version>
         <jcodec.version>0.2.0_1</jcodec.version>
         <dev.failsafe.version>3.2.4</dev.failsafe.version>
-        <joda-time.version>2.10.3</joda-time.version>
+        <joda-time.version>2.10.11</joda-time.version>
         <jpeg2000.version>1.3.1_CODICE_3</jpeg2000.version>
-        <jsoup.version>1.11.3</jsoup.version>
+        <jsoup.version>1.18.3</jsoup.version>
         <jsr305.version>3.0.2</jsr305.version>
         <jts.version>1.17.1</jts.version>
-        <karaf.version>4.3.7</karaf.version>
+        <karaf.version>4.4.5</karaf.version>
         <la4j.version>0.6.0</la4j.version>
-        <log4j.version>2.17.0</log4j.version>
+        <log4j.version>2.17.2</log4j.version>
         <mariadb.version>2.4.1</mariadb.version>
         <mpegts-streamer.version>0.1.0_2</mpegts-streamer.version>
         <netty.version>4.1.46.Final</netty.version>
@@ -175,7 +177,7 @@
         <org.slf4j.version>1.7.29</org.slf4j.version>
         <plexus-compiler-javac-errorprone.version>2.8.2</plexus-compiler-javac-errorprone.version>
         <usng4j.version>0.5</usng4j.version>
-        <xstream.version>1.4.11.1</xstream.version>
+        <xstream.version>1.4.21</xstream.version>
         <!-- Command line argument properties for the maven-surefire-plugin -->
         <surefire.argline.append />
         <surefire.argline>${jacoco.argline} ${surefire.argline.append} -Xmx1024m -Djava.awt.headless=true -noverify -Duser.timezone=UTC -Dddf.version=${ddf.version}</surefire.argline>
@@ -249,7 +251,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <version>${groovy.version}</version>
             <type>pom</type>
@@ -376,7 +378,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.10.1</version>
+                    <version>3.11.0</version>
                     <configuration>
                         <forceJavacCompilerUse>true</forceJavacCompilerUse>
                         <source>17</source>
@@ -626,7 +628,7 @@
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>4.0.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <restassured.version>5.5.0</restassured.version>
 
         <!--Project properties-->
-        <ddf.version>2.29.16</ddf.version>
+        <ddf.version>2.29.17</ddf.version>
         <ddf-admin-ui.version>2.25.0</ddf-admin-ui.version>
         <ddf.support.version>2.3.16</ddf.support.version>
         <codice-maven.version>0.3</codice-maven.version>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <restassured.version>5.5.0</restassured.version>
 
         <!--Project properties-->
-        <ddf.version>2.29.15</ddf.version>
+        <ddf.version>2.29.16</ddf.version>
         <ddf-admin-ui.version>2.25.0</ddf-admin-ui.version>
         <ddf.support.version>2.3.16</ddf.support.version>
         <codice-maven.version>0.3</codice-maven.version>


### PR DESCRIPTION
#### What does this PR do?
Tentatively upgrade DDF to newest 2.29.x release.
I would like to wait for 
- https://github.com/codice/ddf/commit/cf1e79169a8ec9f3f7d33b5c3229de235b329150
- A CXF upgrade to 3.5.12 

in a future 2.29.x release before upgrading, but would be fine with this intermediate step. 

**Caveats:**
- Styling is broken for the Chipping `wab/war`

#### Who is reviewing it? 
@clockard @pklinef @glenhein @ahoffer 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
