### PR TITLE
Upgrade Camel, GeoTools and JTS

### DIFF
--- a/catalog/imaging/imaging-actionprovider-chip/pom.xml
+++ b/catalog/imaging/imaging-actionprovider-chip/pom.xml
@@ -83,10 +83,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.locationtech.jts.io</groupId>
-            <artifactId>jts-io-common</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.webjars.bower</groupId>
             <artifactId>components-bootstrap</artifactId>
             <version>3.1.1</version>

--- a/catalog/imaging/imaging-service-api/pom.xml
+++ b/catalog/imaging/imaging-service-api/pom.xml
@@ -41,10 +41,6 @@
             <artifactId>jts-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.locationtech.jts.io</groupId>
-            <artifactId>jts-io-common</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.codice.imaging.nitf</groupId>
             <artifactId>codice-imaging-nitf-fluent-api</artifactId>
             <version>${nitf-imaging.version}</version>

--- a/catalog/imaging/imaging-transformer-chipping/pom.xml
+++ b/catalog/imaging/imaging-transformer-chipping/pom.xml
@@ -66,20 +66,6 @@
             <version>${ddf.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.locationtech.jts</groupId>
-            <artifactId>jts-core</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>xerces</groupId>
-                    <artifactId>xercesImpl</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.locationtech.jts.io</groupId>
-            <artifactId>jts-io-common</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.codice.alliance.imaging</groupId>
             <artifactId>imaging-service-api</artifactId>
             <version>${project.version}</version>

--- a/catalog/video/video-mpegts-stream/pom.xml
+++ b/catalog/video/video-mpegts-stream/pom.xml
@@ -186,6 +186,11 @@
             <version>1.16.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-api</artifactId>
+            <version>${geotools.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/plugins/FindChildrenStreamEndPlugin.java
+++ b/catalog/video/video-mpegts-stream/src/main/java/org/codice/alliance/video/stream/mpegts/plugins/FindChildrenStreamEndPlugin.java
@@ -37,8 +37,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.codice.alliance.video.stream.mpegts.Context;
-import org.opengis.filter.Filter;
-import org.opengis.filter.sort.SortOrder;
+import org.geotools.api.filter.Filter;
+import org.geotools.api.filter.sort.SortOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/catalog/video/video-mpegts-stream/src/test/java/org/codice/alliance/video/stream/mpegts/plugins/FindChildrenStreamEndPluginTest.java
+++ b/catalog/video/video-mpegts-stream/src/test/java/org/codice/alliance/video/stream/mpegts/plugins/FindChildrenStreamEndPluginTest.java
@@ -40,11 +40,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.IntStream;
 import org.codice.alliance.video.stream.mpegts.Context;
 import org.codice.alliance.video.stream.mpegts.netty.UdpStreamProcessor;
+import org.geotools.api.filter.sort.SortOrder;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
-import org.opengis.filter.sort.SortOrder;
 
 public class FindChildrenStreamEndPluginTest {
 

--- a/catalog/video/video-mpegts-transformer/pom.xml
+++ b/catalog/video/video-mpegts-transformer/pom.xml
@@ -72,16 +72,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.locationtech.jts</groupId>
-            <artifactId>jts-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.locationtech.jts.io</groupId>
-            <artifactId>jts-io-common</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${org.slf4j.version}</version>

--- a/distribution/docker/alliance/pom.xml
+++ b/distribution/docker/alliance/pom.xml
@@ -4,7 +4,7 @@
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
- * version 3 of the License, or any later version. 
+ * version 3 of the License, or any later version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
@@ -57,7 +57,7 @@
                     <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
-                        <version>0.40.3</version>
+                        <version>0.46.0</version>
                         <configuration>
                             <images>
                                 <image>

--- a/libs/klv/pom.xml
+++ b/libs/klv/pom.xml
@@ -78,12 +78,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.locationtech.jts.io</groupId>
-            <artifactId>jts-io-common</artifactId>
-            <version>${jts.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${org.slf4j.version}</version>

--- a/libs/klv/src/main/java/org/codice/alliance/libs/klv/GeometryReducer.java
+++ b/libs/klv/src/main/java/org/codice/alliance/libs/klv/GeometryReducer.java
@@ -21,7 +21,7 @@ import org.locationtech.jts.precision.GeometryPrecisionReducer;
 @ThreadSafe
 public class GeometryReducer implements GeometryOperator {
 
-  private GeometryPrecisionReducer geometryPrecisionReducer =
+  private final GeometryPrecisionReducer geometryPrecisionReducer =
       new GeometryPrecisionReducer(new PrecisionModel(PrecisionModel.FLOATING));
 
   @Override

--- a/libs/klv/src/test/java/org/codice/alliance/libs/klv/GeometryReducerTest.java
+++ b/libs/klv/src/test/java/org/codice/alliance/libs/klv/GeometryReducerTest.java
@@ -13,9 +13,10 @@
  */
 package org.codice.alliance.libs.klv;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import org.junit.Before;
@@ -37,19 +38,17 @@ public class GeometryReducerTest {
   }
 
   @Test
-  public void testNullSubpolygon() throws ParseException {
-
-    Geometry geometry = null;
+  public void testNullSubpolygon() {
 
     GeometryReducer reducer = new GeometryReducer();
 
-    Geometry actual = reducer.apply(geometry, context);
+    Geometry actual = reducer.apply(null, context);
 
     assertThat(actual, nullValue());
   }
 
   @Test
-  public void testEmptySubpolygon() throws ParseException {
+  public void testEmptySubpolygon() {
 
     Geometry geometry = GEOMETRY_FACTORY.createMultiPolygon(null);
 
@@ -71,9 +70,9 @@ public class GeometryReducerTest {
 
     GeometryReducer reducer = new GeometryReducer();
 
-    Geometry actual = reducer.apply(geometry, context);
+    Geometry reduced = reducer.apply(geometry, context);
 
-    assertThat(actual, is(geometry));
+    assertTrue("The reduced geometry was not equivalent.", reduced.equalsNorm(geometry));
   }
 
   @Test
@@ -88,10 +87,8 @@ public class GeometryReducerTest {
 
     GeometryReducer reducer = new GeometryReducer();
 
-    Geometry actual = reducer.apply(geometry, context);
+    Geometry reduced = reducer.apply(geometry, context);
 
-    Geometry expected = wktReader.read(wkt);
-
-    assertThat(actual, is(expected));
+    assertTrue("The reduced geometry was not equivalent.", reduced.equalsNorm(geometry));
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <jquery-ui.version>1.10.4</jquery-ui.version>
         <marionette.version>2.4.5</marionette.version>
         <moment.version>2.20.1</moment.version>
-        <node.version>v20.19.1</node.version>
+        <node.version>v10.16.1</node.version>
         <require-css.version>0.1.10</require-css.version>
         <requirejs-plugins.version>1.0.2</requirejs-plugins.version>
         <underscore.version>1.8.3</underscore.version>
@@ -122,7 +122,7 @@
         <restassured.version>5.5.0</restassured.version>
         <spock.version>2.3-groovy-4.0</spock.version>
         <xmlunit.version>1.4</xmlunit.version>
-        <yarn.version>v1.22.22</yarn.version>
+        <yarn.version>v1.17.3</yarn.version>
         <restassured.version>5.5.0</restassured.version>
 
         <!--Project properties-->

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <restassured.version>5.5.0</restassured.version>
 
         <!--Project properties-->
-        <ddf.version>2.29.24-SNAPSHOT</ddf.version>
+        <ddf.version>2.29.24</ddf.version>
         <ddf-admin-ui.version>2.25.0</ddf-admin-ui.version>
         <ddf.support.version>2.3.16</ddf.support.version>
         <codice-maven.version>0.3</codice-maven.version>

--- a/pom.xml
+++ b/pom.xml
@@ -410,7 +410,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.2</version>
+                    <version>3.1.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -456,7 +456,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>2.5.2</version>
+                    <version>3.1.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <restassured.version>5.5.0</restassured.version>
 
         <!--Project properties-->
-        <ddf.version>2.29.23</ddf.version>
+        <ddf.version>2.29.24-SNAPSHOT</ddf.version>
         <ddf-admin-ui.version>2.25.0</ddf-admin-ui.version>
         <ddf.support.version>2.3.16</ddf.support.version>
         <codice-maven.version>0.3</codice-maven.version>
@@ -144,7 +144,7 @@
         <asciidoctorj.version>2.5.7</asciidoctorj.version>
         <jruby.version>9.4.12.0</jruby.version>
 
-        <camel.version>3.18.8</camel.version>
+        <camel.version>3.22.4</camel.version>
         <commons-collections4.version>4.1</commons-collections4.version>
         <commons-configuration.version>1.10</commons-configuration.version>
         <commons-exec.version>1.3</commons-exec.version>
@@ -167,7 +167,7 @@
         <jsoup.version>1.18.3</jsoup.version>
         <jsr305.version>3.0.2</jsr305.version>
         <jts.version>1.17.1</jts.version>
-        <karaf.version>4.4.5</karaf.version>
+        <karaf.version>4.4.7</karaf.version>
         <la4j.version>0.6.0</la4j.version>
         <log4j.version>2.17.2</log4j.version>
         <mariadb.version>2.4.1</mariadb.version>
@@ -211,6 +211,11 @@
                 <groupId>org.webjars.bower</groupId>
                 <artifactId>jquery</artifactId>
                 <version>${jquery.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
+                <version>2.3.2</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -939,7 +944,7 @@
         <repository>
             <id>maven2-repository.dev.java.net</id>
             <name>Java.net repository</name>
-            <url>http://download.java.net/maven/2</url>
+            <url>https://maven.java.net/content/groups/public/</url>
         </repository>
         <repository>
             <id>codice</id>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <jquery-ui.version>1.10.4</jquery-ui.version>
         <marionette.version>2.4.5</marionette.version>
         <moment.version>2.20.1</moment.version>
-        <node.version>v10.16.1</node.version>
+        <node.version>v20.19.1</node.version>
         <require-css.version>0.1.10</require-css.version>
         <requirejs-plugins.version>1.0.2</requirejs-plugins.version>
         <underscore.version>1.8.3</underscore.version>
@@ -100,7 +100,7 @@
 
         <!--Maven properties-->
         <error_prone_core.version>2.1.2</error_prone_core.version>
-        <surefire.version>3.5.2</surefire.version>
+        <surefire.version>3.5.3</surefire.version>
 
         <!--Maven plugin properties-->
         <asciidoctor.maven.plugin.version>2.2.1</asciidoctor.maven.plugin.version>
@@ -122,7 +122,7 @@
         <restassured.version>5.5.0</restassured.version>
         <spock.version>2.3-groovy-4.0</spock.version>
         <xmlunit.version>1.4</xmlunit.version>
-        <yarn.version>v1.17.3</yarn.version>
+        <yarn.version>v1.22.22</yarn.version>
         <restassured.version>5.5.0</restassured.version>
 
         <!--Project properties-->
@@ -154,7 +154,7 @@
         <commons-net.version>3.5</commons-net.version>
         <components-font-awesome.version>4.7.0</components-font-awesome.version>
         <countrycode.converter.version>0.2.1</countrycode.converter.version>
-        <geotools.version>28.6</geotools.version>
+        <geotools.version>33.1</geotools.version>
         <guava.version>33.4.0-jre</guava.version>
         <jai-imageio-core.version>1.4.0</jai-imageio-core.version>
         <jakarta.mail.version>1.6.7</jakarta.mail.version>
@@ -166,7 +166,7 @@
         <jpeg2000.version>1.3.1_CODICE_3</jpeg2000.version>
         <jsoup.version>1.18.3</jsoup.version>
         <jsr305.version>3.0.2</jsr305.version>
-        <jts.version>1.17.1</jts.version>
+        <jts.version>1.20.0</jts.version>
         <karaf.version>4.4.7</karaf.version>
         <la4j.version>0.6.0</la4j.version>
         <log4j.version>2.17.2</log4j.version>
@@ -370,7 +370,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>5.1.8</version>
+                    <version>5.1.9</version>
                     <extensions>true</extensions>
                     <configuration>
                         <!-- Disabled OBR to increase build speed -->
@@ -384,7 +384,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.11.0</version>
+                    <version>3.14.0</version>
                     <configuration>
                         <forceJavacCompilerUse>true</forceJavacCompilerUse>
                         <source>17</source>
@@ -426,32 +426,32 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.7.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.8.2</version>
+                    <version>3.21.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.8.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.3.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.4.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -491,7 +491,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.6.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jvnet.jaxb2.maven2</groupId>
@@ -501,7 +501,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.11.2</version>
                     <configuration>
                         <failOnError>false</failOnError>
                         <show>protected</show>
@@ -514,7 +514,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.8</version>
+                    <version>0.8.13</version>
                     <dependencies>
                         <dependency>
                             <groupId>org.codice.maven</groupId>


### PR DESCRIPTION
#### What does this PR do?
- Upgrades DDF to the latest 2.29.x version
- Upgrades Camel to the latest 3.x version (3.22.4)
- Upgrades GeoTools to the latest version (33.1)
- Upgrades JTS to the latest version (1.20.0)
- Upgrades most Maven plugins to their latest versions

#### Choose 2 committers to review/merge the PR.
(please choose ONLY two committers from below, delete the rest)
@ahoffer 
@clockard
@derekwilhelm 
@glenhein 

#### Any background context you want to provide?
The primary reason for upgrading these dependencies is to resolve some high and critical CVEs.

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests