### PR TITLE
Replace frontend-maven-plugin Codice fork with upstream 1.12.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -538,7 +538,7 @@
                 <plugin>
                     <groupId>com.github.eirslett</groupId>
                     <artifactId>frontend-maven-plugin</artifactId>
-                    <version>1.6.CODICE</version>
+                    <version>1.12.1</version>
                     <executions>
                         <execution>
                             <id>install node and yarn</id>


### PR DESCRIPTION
## Summary
- Replaces dormant Codice fork (`1.6.CODICE`) with upstream `1.12.1`
- DDF UI repos already use upstream — Alliance was the last consumer of the fork

## Test plan
- [x] Built `video-admin-plugin` and `imaging-actionprovider-chip` locally
- [ ] CI build passes