### PR TITLE
Switch to Nexus (repo.codice.org)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,6 @@ on:
     # Nightly build on master (same as Jenkins: H H(17-19) * * *)
     - cron: '0 18 * * *'
 
-permissions:
-  packages: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -50,15 +47,6 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
-      - name: Configure Maven settings
-        uses: s4u/maven-settings-action@v3.0.0
-        with:
-          servers: |
-            [{
-              "id": "codice",
-              "username": "${{ github.actor }}",
-              "password": "${{ secrets.READ_PACKAGES }}"
-            }]
 
       - name: Quick install (skip tests)
         run: mvn install $MAVEN_CLI_OPTS -DskipStatic=true -DskipTests=true
@@ -93,15 +81,6 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
-      - name: Configure Maven settings
-        uses: s4u/maven-settings-action@v3.0.0
-        with:
-          servers: |
-            [{
-              "id": "codice",
-              "username": "${{ github.actor }}",
-              "password": "${{ secrets.READ_PACKAGES }}"
-            }]
 
       - name: Full build (excluding itests)
         run: mvn clean install $MAVEN_CLI_OPTS -P !itests
@@ -171,15 +150,6 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
-      - name: Configure Maven settings
-        uses: s4u/maven-settings-action@v3.0.0
-        with:
-          servers: |
-            [{
-              "id": "codice",
-              "username": "${{ github.actor }}",
-              "password": "${{ secrets.READ_PACKAGES }}"
-            }]
 
       - name: OWASP Dependency Check
         run: |
@@ -216,8 +186,6 @@ jobs:
       needs.dependency-check.result == 'success'
     runs-on: ubuntu-latest
     environment: production
-    permissions:
-      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -229,15 +197,6 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
-      - name: Configure Maven settings
-        uses: s4u/maven-settings-action@v3.0.0
-        with:
-          servers: |
-            [{
-              "id": "github",
-              "username": "${{ github.actor }}",
-              "password": "${{ secrets.GITHUB_TOKEN }}"
-            }]
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -251,5 +210,5 @@ jobs:
             -DskipStatic=true \
             -DskipTests=true \
             -DretryFailedDeploymentCount=10 \
-            -Dreleases.repository.url=https://maven.pkg.github.com/codice/alliance \
-            -Dsnapshots.repository.url=https://maven.pkg.github.com/codice/alliance
+            -Dreleases.repository.url=https://repo.codice.org/repository/maven-releases/ \
+            -Dsnapshots.repository.url=https://repo.codice.org/repository/maven-snapshots/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ on:
 
 jobs:
   release:
-    uses: codice/release-pipelines/.github/workflows/maven-release.yml@nexus-deploy
+    uses: codice/release-pipelines/.github/workflows/maven-release.yml@main
     with:
       app_name: 'alliance'
       branch: ${{ inputs.branch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,13 +30,9 @@ on:
         description: 'Resume failed deploy from module (e.g. solr). Leave blank for normal release.'
         required: false
 
-permissions:
-  contents: read
-  packages: write
-
 jobs:
   release:
-    uses: codice/release-pipelines/.github/workflows/maven-release.yml@main
+    uses: codice/release-pipelines/.github/workflows/maven-release.yml@nexus-deploy
     with:
       app_name: 'alliance'
       branch: ${{ inputs.branch }}
@@ -52,5 +48,7 @@ jobs:
     secrets:
       app_id: ${{ secrets.RELEASE_APP_ID }}
       app_private_key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+      nexus_username: ${{ secrets.NEXUS_USERNAME }}
+      nexus_password: ${{ secrets.NEXUS_PASSWORD }}
       dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
       dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ on:
 
 jobs:
   release:
-    uses: codice/release-pipelines/.github/workflows/maven-release.yml@main
+    uses: codice/release-pipelines/.github/workflows/maven-release.yml@nexus-deploy
     with:
       app_name: 'alliance'
       branch: ${{ inputs.branch }}

--- a/pom.xml
+++ b/pom.xml
@@ -945,8 +945,8 @@
         </repository>
         <repository>
             <id>codice</id>
-            <name>Codice GitHub Packages</name>
-            <url>https://maven.pkg.github.com/codice/*</url>
+            <name>Codice Repository</name>
+            <url>https://repo.codice.org/repository/maven-public/</url>
         </repository>
         <repository>
             <id>osgeo</id>
@@ -967,7 +967,7 @@
         <pluginRepository>
             <id>codice</id>
             <name>Codice Repository</name>
-            <url>https://maven.pkg.github.com/codice/*</url>
+            <url>https://repo.codice.org/repository/maven-public/</url>
         </pluginRepository>
     </pluginRepositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <yarn.version>v1.17.3</yarn.version>
 
         <!--Project properties-->
-        <ddf.version>2.29.32</ddf.version>
+        <ddf.version>2.29.33-SNAPSHOT</ddf.version>
         <ddf-admin-ui.version>2.25.0</ddf-admin-ui.version>
         <ddf.support.version>2.3.16</ddf.support.version>
         <codice-maven.version>0.3</codice-maven.version>
@@ -938,12 +938,7 @@
             <url>https://repo.maven.apache.org/maven2</url>
             <layout>default</layout>
         </repository>
-        <repository>
-            <id>maven2-repository.dev.java.net</id>
-            <name>Java.net repository</name>
-            <url>https://maven.java.net/content/groups/public/</url>
-        </repository>
-        <repository>
+<repository>
             <id>codice</id>
             <name>Codice Repository</name>
             <url>https://repo.codice.org/repository/maven-public/</url>


### PR DESCRIPTION
Update POM repos, CI deploy, and release workflow to use repo.codice.org. Bump DDF to 2.29.33-SNAPSHOT.