### PR TITLE
Free disk space in deploy job before Docker image build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,13 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          df -h
+
       - name: Checkout
         uses: actions/checkout@v4
 


### PR DESCRIPTION
Adds the same dotnet/android/ghc cleanup step the other jobs use. Without it the deploy runner runs out of space writing the ~1 GB alliance distribution zip into the docker build context (`io.fabric8:docker-maven-plugin`).