### PR TITLE
Pin docker.ddf.base.version to 3.1 (JDK 17) by digest

### DIFF
--- a/distribution/docker/alliance/pom.xml
+++ b/distribution/docker/alliance/pom.xml
@@ -25,7 +25,8 @@
     <name>Alliance :: Distribution :: Docker :: Alliance</name>
 
     <properties>
-        <docker.ddf.base.version>latest</docker.ddf.base.version>
+        <!-- JDK 17 base; pinned by digest for reproducibility. Bump in lockstep with codice/ddf-base releases. -->
+        <docker.ddf.base.version>3.1@sha256:43b423c15c6d6c42a73c387d9de83309ab90ee88888c8595ecf45bbfd8fafe05</docker.ddf.base.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Summary

Replaces `<docker.ddf.base.version>latest</docker.ddf.base.version>` with `3.1@sha256:43b423c15c6d6c42a73c387d9de83309ab90ee88888c8595ecf45bbfd8fafe05`.

`3.1` is the first JDK-pinned tag published from [codice/docker-ddf-base#8](https://github.com/codice/docker-ddf-base/pull/8) — Azul Zulu `17.0.19-17.66`. Alliance follows the DDF `2.30.x` train, which stays on JDK 17.

## Why

Tracking `:latest` is what produced the unbootable `codice/alliance:1.17.4` image (Java 8 image + Java 17 setenv flags = JVM dies on startup, container appears `Up` because entrypoint ends with `tail -f`). Pinning by digest makes every Alliance Docker build bit-for-bit reproducible.

When Alliance is ready to follow DDF master onto JDK 21, this property bumps to `4.0@sha256:...` (separate PR).

## Test plan

- [x] Docker accepts the `tag@sha256:` syntax (verified `FROM codice/ddf-base:3.1@sha256:43b423...` builds cleanly).
- [ ] CI runs the full alliance docker module against the pinned base.